### PR TITLE
AirAccelerate support

### DIFF
--- a/sp/src/game/server/momentum/server_events.cpp
+++ b/sp/src/game/server/momentum/server_events.cpp
@@ -24,8 +24,11 @@ namespace Momentum
     {
         ConVarRef gm("mom_gamemode");
         ConVarRef map("host_map");
+        ConVarRef aa("sv_airaccelerate");
         const char *pMapName = map.GetString();
         // This will only happen if the user didn't use the map selector to start a map
+
+        //set gamemode depending on map name
         if (gm.GetInt() == MOMGM_UNKNOWN)
         {
             if (!Q_strnicmp(pMapName, "surf_", strlen("surf_")))
@@ -41,12 +44,30 @@ namespace Momentum
 
                 //g_Timer.SetGameMode(MOMGM_BHOP);
             }
+            else if (!Q_strnicmp(pMapName, "kz_", strlen("kz_")))
+            {
+               DevLog("SETTING THE GAMEMODE!\n");
+               gm.SetValue(MOMGM_SCROLL);
+            }
             else
             {
                 gm.SetValue(MOMGM_UNKNOWN);
                 //g_Timer.SetGameMode(MOMGM_UNKNOWN);
             }
-        }   
+        }
+        switch (gm.GetInt()) //set aa or other values depending on gamemode 
+        {
+        case MOMGM_BHOP:
+            return aa.SetValue(1000);
+            //MOM_TODO : add other possible gm-dependant values to each
+        case MOMGM_SCROLL:
+            return aa.SetValue(100);
+
+        case MOMGM_SURF:
+        case MOMGM_UNKNOWN:
+        default:
+           return aa.SetValue(150);
+        }
     }
 
     void OnMapStart(const char *pMapName)

--- a/sp/src/game/shared/momentum/mom_player_shared.cpp
+++ b/sp/src/game/shared/momentum/mom_player_shared.cpp
@@ -179,10 +179,6 @@ void CMomentumPlayer::FireBullet(
         if (tr.fraction == 1.0f)
             break; // we didn't hit anything, stop tracing shoot
 
-#ifdef _DEBUG		
-        if (bFirstHit)
-            AddBulletStat(gpGlobals->realtime, VectorLength(vecSrc - tr.endpos), tr.endpos);
-#endif
 
         bFirstHit = false;
 

--- a/sp/src/game/shared/movevars_shared.cpp
+++ b/sp/src/game/shared/movevars_shared.cpp
@@ -34,7 +34,7 @@ ConVar	sv_maxspeed("sv_maxspeed", "260", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR
 
 ConVar	sv_accelerate("sv_accelerate", "5", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY);
 
-ConVar	sv_airaccelerate("sv_airaccelerate", "150", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY);
+ConVar	sv_airaccelerate("sv_airaccelerate", "150", FCVAR_NOTIFY | FCVAR_REPLICATED );
 ConVar	sv_wateraccelerate("sv_wateraccelerate", "10", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY);
 ConVar	sv_waterfriction("sv_waterfriction", "1", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY);
 ConVar	sv_footsteps("sv_footsteps", "1", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "Play footstep sound for players");


### PR DESCRIPTION
AirAccelerate now changes automatically based on MOMGM.
AirAccelerate is no longer a hidden cvar. It will be hidden again during beta (?).
Added preliminary support for kz/scroll game modes.
Removed _DEBUG issues causing crashing and compiler errors if project is compiled on debug.