### PR TITLE
Fix boosters

### DIFF
--- a/mp/src/game/server/eventqueue.h
+++ b/mp/src/game/server/eventqueue.h
@@ -18,7 +18,7 @@
 
 struct EventQueuePrioritizedEvent_t
 {
-	float m_flFireTime;
+	int m_iFireTick;
 	string_t m_iTarget;
 	string_t m_iTargetInput;
 	EHANDLE m_pActivator;


### PR DESCRIPTION
Reopened from #85. I previously added a separate tick count inside CEventQueue since gpGlobals->tickcount isn't consistent on CS:S at all, but it seems to be fine here, so I've removed that.

The only change now is a switch from using curtime to tickcount since using curtime suffers from floating-point precision errors.

The only boosters that don't seem to work now are the touch-activated kinds used in bhop_null and bhop_null_fix. There's no neat, general way to fix those in the engine code -- there would need to be branches for specific triggers in those specific maps, which is awkward and seems more appropriately solved by something like a Stripper config or a new map with the changes.