### PR TITLE
For real this time, fix demo veiw interpolation and timescale cattywampus-ness

### DIFF
--- a/mp/game/momentum/cfg/valve.rc
+++ b/mp/game/momentum/cfg/valve.rc
@@ -14,5 +14,6 @@ exec autoexec.cfg
 stuffcmds
 sv_unlockedchapters 99 //Random background selection
 startupmenu
-//"fix" for demo playback stutter bug. MOM_TODO: fix this for realzies
-demo_interpolateview 0
+
+//FOR REAL FIXEXS DEMO PLAYBACK INTERP ISSUES
+demo_interplimit 9999999

--- a/mp/src/game/client/cdll_client_int.cpp
+++ b/mp/src/game/client/cdll_client_int.cpp
@@ -148,6 +148,7 @@
 #include "fbxsystem/fbxsystem.h"
 #endif
 
+#include "INetChannelInfo.h"
 extern vgui::IInputInternal *g_InputInternal;
 
 //=============================================================================
@@ -2207,6 +2208,18 @@ void OnRenderStart()
 	VPROF( "OnRenderStart" );
 	MDLCACHE_CRITICAL_SECTION();
 	MDLCACHE_COARSE_LOCK();
+    
+    // BenLubar: rescale time in demos during slow motion
+    INetChannelInfo *nci = engine->GetNetChannelInfo();
+    ConVarRef ts("host_timescale");
+    if (nci && nci->IsPlayback() && engine->GetDemoPlaybackTimeScale() != 1)
+    {
+        float flServerTime = engine->GetLastTimeStamp();
+        float flTimeSince = nci->GetTimeSinceLastReceived();
+        float flTimeScale = engine->GetDemoPlaybackTimeScale();
+        gpGlobals->curtime = flServerTime + flTimeSince * flTimeScale * flTimeScale;
+        gpGlobals->frametime *= flTimeScale;
+    }
 
 #ifdef PORTAL
 	g_pPortalRender->UpdatePortalPixelVisibility(); //updating this one or two lines before querying again just isn't cutting it. Update as soon as it's cheap to do so.


### PR DESCRIPTION
Also added in BenLubar's fix for server time during demo timescale, because why not. It doesn't do anything for us other than fix the server time going out of sync, but that might be useful for .... something... ... later....