### PR TITLE
Fix osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ obj*/
 !devtools/*.mak
 !utils/smdlexp/smdlexp.mak
 *.a
+*.dylib
+*.plist
 
 # Specific Source build products
 client.so
@@ -83,11 +85,15 @@ game_shader_dx9.so
 game_shader_dx9.so.dbg
 game_shader_dx9_srv.so
 game_shader_dx9_srv.so.dbg
+game_shader_dx9.dylib
+game_shader_dx9.dylib.dYSM/
 gameui2.dll
 gameui2.so
 gameui2.so.dbg
 gameui2_srv.so
 gameui2_srv.so.dbg
+gameui2.dylib
+gameui2.dylib.dYSM/
 mp/game/bin/
 
 # Others

--- a/mp/src/game/gameui2/button_panel.cpp
+++ b/mp/src/game/gameui2/button_panel.cpp
@@ -1,3 +1,8 @@
+
+#include <string>
+#include <functional>
+#include <algorithm>
+
 #include "gameui2_interface.h"
 #include "button_panel.h"
 
@@ -5,9 +10,8 @@
 #include "vgui/ISurface.h"
 #include "vgui/IVGui.h"
 
-#include <string>
-#include <algorithm>
-#include <functional>
+
+
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"

--- a/mp/src/game/gameui2/button_panel.cpp
+++ b/mp/src/game/gameui2/button_panel.cpp
@@ -1,8 +1,3 @@
-
-#include <string>
-#include <functional>
-#include <algorithm>
-
 #include "gameui2_interface.h"
 #include "button_panel.h"
 
@@ -10,7 +5,11 @@
 #include "vgui/ISurface.h"
 #include "vgui/IVGui.h"
 
-
+#undef min
+#undef max
+#include <string>
+#include <functional>
+#include <algorithm>
 
 
 // memdbgon must be the last include file in a .cpp file!!!

--- a/mp/src/game/gameui2/panel_options.cpp
+++ b/mp/src/game/gameui2/panel_options.cpp
@@ -1,3 +1,8 @@
+
+#include <string>
+#include <functional>
+#include <algorithm>
+
 #include "gameui2_interface.h"
 #include "panel_options.h"
 
@@ -6,9 +11,10 @@
 #include "vgui/ISurface.h"
 #include "vgui/IVGui.h"
 
-#include <string>
-#include <algorithm>
-#include <functional>
+
+
+
+
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -139,7 +145,7 @@ void Panel_Options::DrawTitle()
 {
 	std::wstring panel_title = m_PanelTitle;
 	std::transform(panel_title.begin(), panel_title.end(), panel_title.begin(), std::function<int32(int32)>(::toupper));
-	
+	panel_title = towupper(*m_PanelTitle);
 	vgui::surface()->DrawSetTextColor(m_cTitleColor);
 	vgui::surface()->DrawSetTextFont(m_fTitleFont);
 

--- a/mp/src/game/gameui2/panel_options.cpp
+++ b/mp/src/game/gameui2/panel_options.cpp
@@ -145,7 +145,6 @@ void Panel_Options::DrawTitle()
 {
 	std::wstring panel_title = m_PanelTitle;
 	std::transform(panel_title.begin(), panel_title.end(), panel_title.begin(), std::function<int32(int32)>(::toupper));
-	panel_title = towupper(*m_PanelTitle);
 	vgui::surface()->DrawSetTextColor(m_cTitleColor);
 	vgui::surface()->DrawSetTextFont(m_fTitleFont);
 

--- a/mp/src/game/gameui2/panel_options.cpp
+++ b/mp/src/game/gameui2/panel_options.cpp
@@ -1,8 +1,3 @@
-
-#include <string>
-#include <functional>
-#include <algorithm>
-
 #include "gameui2_interface.h"
 #include "panel_options.h"
 
@@ -11,9 +6,11 @@
 #include "vgui/ISurface.h"
 #include "vgui/IVGui.h"
 
-
-
-
+#undef min
+#undef max
+#include <string>
+#include <functional>
+#include <algorithm>
 
 
 // memdbgon must be the last include file in a .cpp file!!!

--- a/mp/src/game/server/momentum/mom_client.cpp
+++ b/mp/src/game/server/momentum/mom_client.cpp
@@ -40,7 +40,7 @@ void ClientPutInServer(edict_t *pEdict, const char *playername)
     pPlayer->SetPlayerName(playername);
     
     //Acquire client module's data recieve function
-    pPlayer->StdDataToPlayer = (DataToPlayerFn)(GetProcAddress( GetModuleHandle(CLIENT_DLL), "StdDataToPlayer"));
+    pPlayer->StdDataToPlayer = (DataToPlayerFn)(GetProcAddress( GetModuleHandle(CLIENT_DLL_NAME), "StdDataToPlayer"));
 }
 
 

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -47,7 +47,7 @@ CMomentumReplayGhostEntity::CMomentumReplayGhostEntity()
     m_bHasJumped(false), m_flLastSyncVelocity(0), m_nStrafeTicks(0), m_nPerfectSyncTicks(0), m_nAccelTicks(0),
     m_nOldReplayButtons(0), m_RunStats(&m_SrvData.m_RunStatsData, g_pMomentumTimer->GetZoneCount())
 {
-    StdDataToReplay = (DataToReplayFn)(GetProcAddress( GetModuleHandle(CLIENT_DLL), "StdDataToReplay"));
+    StdDataToReplay = (DataToReplayFn)(GetProcAddress( GetModuleHandle(CLIENT_DLL_NAME), "StdDataToReplay"));
     
     // Set networked vars here
     m_SrvData.m_nReplayButtons = 0;

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -1,10 +1,8 @@
-#ifndef TICKSET_H
-#define TICKSET_H
+#pragma once
 
 #include "cbase.h"
 #include "momentum/mom_shareddefs.h"
 #include "util/mom_util.h"
-
 
 struct Tickrate
 {
@@ -63,5 +61,3 @@ private:
     static Tickrate m_trCurrent;
     static bool m_bInGameUpdate;
 };
-
-#endif // TICKSET_H

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -59,5 +59,4 @@ private:
 	static float *interval_per_tick;
 
     static Tickrate m_trCurrent;
-    static bool m_bInGameUpdate;
 };

--- a/mp/src/game/shared/momentum/util/os_utils.cpp
+++ b/mp/src/game/shared/momentum/util/os_utils.cpp
@@ -1,5 +1,7 @@
 #include "os_utils.h"
+
 #ifdef POSIX
+
 void *GetModuleHandle(const char *name)
 {
 	void *handle;
@@ -24,4 +26,102 @@ void *GetModuleHandle(const char *name)
 	dlclose(handle);
 	return handle;
 }
-#endif
+//returns 0 if successful
+int GetModuleInformation_LINUX(const char *name, void **base, size_t *length)
+{
+	// this is the only way to do this on linux, lol
+	FILE *f = fopen("/proc/self/maps", "r");
+	if (!f)
+		return 1;
+	
+	char buf[PATH_MAX+100];
+	while (!feof(f))
+	{
+		if (!fgets(buf, sizeof(buf), f))
+			break;
+		
+		char *tmp = strrchr(buf, '\n');
+		if (tmp)
+			*tmp = '\0';
+		
+		char *mapname = strchr(buf, '/');
+		if (!mapname)
+			continue;
+		
+		char perm[5];
+		unsigned long begin, end;
+		sscanf(buf, "%lx-%lx %4s", &begin, &end, perm);
+		
+		if (strcmp(basename(mapname), name) == 0 && perm[0] == 'r' && perm[2] == 'x')
+		{
+			*base = (void*)begin;
+			*length = (size_t)end-begin;
+			fclose(f);
+			return 0;
+		}
+	}
+	
+	fclose(f);
+	return 2;
+}
+
+#ifdef OSX
+//from https://stackoverflow.com/questions/28846503/getting-sizeofimage-and-entrypoint-of-dylib-module
+//returns the total size of the dylib binary, including header, data, ...
+size_t size_of_image(const mach_header *header)
+{
+	size_t sz =sizeof(*header);
+	sz += header->sizeofcmds;
+	load_command *lc = (load_command *)(header + 1);
+	for (uint32_t i = 0; i < header->ncmds; i++)
+	{
+		sz += ((segment_command *)lc)->vmsize;
+	}
+	lc = (load_command*) ((char*) lc + lc->cmdsize);
+	return sz;
+}
+//returns the address of the initilizer function of the dynamic library, or 0 if not found.
+uint32_t mod_init_addr(const mach_header *header)
+{
+	const section *sec;
+	if (sec = getsectbynamefromheader(header, "__DATA", "__mod_init_func"));
+	{
+		return sec->addr;
+	}
+	return 0;
+}
+//please kill me
+//https://blog.lse.epita.fr/articles/82-playing-with-mach-os-and-dyld.html
+int GetModuleInformation_OSX(const char *name, void **base, size_t *length)
+{
+	task_t task;
+	task_dyld_info dlyd_info;
+	mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+	
+	if (task_info(mach_task_self_, TASK_DYLD_INFO, (task_info_t)&dlyd_info, &count) == KERN_SUCCESS) //request info regarding dylibs in this task (hl2_osx)
+	{
+		mach_vm_address_t image_infos = dlyd_info.all_image_info_addr;
+		dyld_all_image_infos *infos = (dyld_all_image_infos*)image_infos;
+		uint32_t image_count = infos->infoArrayCount;
+		const dyld_image_info *image_array =  new dyld_image_info[image_count];
+		image_array = infos->infoArray;
+		
+		for(int i = image_count-1; i >= 0; i--) //iterate through all dylibs backwards (since engine.dylib is likely to have been loaded near the end)
+		{
+			if (V_strstr(image_array[i].imageFilePath, name)) //found it!
+			{
+				printf("Found module %s!\n", name);
+				*base = (void*)mod_init_addr(image_array[i].imageLoadAddress);
+				*length = (size_t)size_of_image(image_array[i].imageLoadAddress);
+				delete[] image_array;
+				return 0; //success!
+			}
+		}
+		delete[] image_array;
+		return 1; //failed to find the given process
+	}
+	return 2; //failed to find task info
+}
+
+#endif //OSX
+#endif // POSIX

--- a/mp/src/game/shared/momentum/util/os_utils.h
+++ b/mp/src/game/shared/momentum/util/os_utils.h
@@ -6,20 +6,28 @@
 //
 #ifdef POSIX
 #include <dlfcn.h>
+#include <libgen.h>
 //#include <unistd.h>
 // Linux doesn't have this function so this emulates its functionality
 extern void *GetModuleHandle(const char *name);
+
+// Moved from tickset.cpp because fuck that
+extern int GetModuleInformation_LINUX(const char *name, void **base, size_t *length);
+extern int GetModuleInformation_OSX(const char *name, void **base, size_t *length);
 
 //GetProcAddress can be flat-out replaced with dlsym
 //So use GetProcAddress on both platforms.
 
 #define GetProcAddress dlsym
 #ifdef OSX
-#define CLIENT_DLL "./momentum/bin/client.dylib" //OSX
+#define CLIENT_DLL_NAME "./momentum/bin/client.dylib" //OSX
+#include <mach-o/getsect.h>
+#include <mach-o/dyld_images.h>
+#include <mach-o/dyld.h>
 #else
-#define CLIENT_DLL "./momentum/bin/client.so" //LINUX
+#define CLIENT_DLL_NAME "./momentum/bin/client.so" //LINUX
 #endif
 
 #else //POSIX
-#define CLIENT_DLL "./momentum/bin/client.dll" //WIN32
+#define CLIENT_DLL_NAME "./momentum/bin/client.dll" //WIN32
 #endif //OS_UTILS_H

--- a/mp/src/game/shared/momentum/util/os_utils.h
+++ b/mp/src/game/shared/momentum/util/os_utils.h
@@ -12,11 +12,14 @@ extern void *GetModuleHandle(const char *name);
 
 //GetProcAddress can be flat-out replaced with dlsym
 //So use GetProcAddress on both platforms.
+
 #define GetProcAddress dlsym
-#define CLIENT_DLL "./momentum/bin/client.so"
+#ifdef OSX
+#define CLIENT_DLL "./momentum/bin/client.dylib" //OSX
+#else
+#define CLIENT_DLL "./momentum/bin/client.so" //LINUX
+#endif
 
-#else //Not POSIX
-
-#define CLIENT_DLL "./momentum/bin/client.dll"
-
+#else //POSIX
+#define CLIENT_DLL "./momentum/bin/client.dll" //WIN32
 #endif //OS_UTILS_H

--- a/mp/src/game/shared/momentum/util/os_utils.h
+++ b/mp/src/game/shared/momentum/util/os_utils.h
@@ -21,7 +21,6 @@ extern int GetModuleInformation_OSX(const char *name, void **base, size_t *lengt
 #define GetProcAddress dlsym
 #ifdef OSX
 #define CLIENT_DLL_NAME "./momentum/bin/client.dylib" //OSX
-#include <mach-o/getsect.h>
 #include <mach-o/dyld_images.h>
 #include <mach-o/dyld.h>
 #else


### PR DESCRIPTION
Mac OSX support! 🎉 

I was going to try to fix the strange twilight zone bug where the "quit" button in VGUI2 menus is being sorted above every other button for some reason, but since Gocnak added HTML GameUI3™ menus, GameUI2 will eventually be deprecated so I'm just marking that as wontfix.

Known bugs remaining: 

- trigger_momentum_limitmovement with BHOP flag doesn't work very well. This also happens on linux so I'm not fixing it on this branch
- vgui HUD looks a little wonky due to font differences (This again also happens on linux, this will be fixed in my overhaul_hud branch that's WIP right now) 

How2Compile:

OSX is kind of terrible for developers who aren't making IOS apps. 
- Install MacOS 10.12 Sierra 
- Install Xcode 8.3.3
- Install command-line tools (lldb, llvm)
- run ./creategameprojects

Changes needed to be made manually for each project settings every time VPC is run (this is VPC's fault and I can't find any settings to change this in the vpc scripts): 
- "BASE SDK" -> MacOS 10.12
- "C++ version" -> libstdc++ (C++11)
- "Target platform" -> MacOS 10.7
- You may also have to delete `libcrypto.a` in the gameui2 project, Xcode 8.3.3 adds this without asking for no reason at all. 
