### PR TITLE
Small bugfixes

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -194,11 +194,9 @@ void CMomentumGameMovement::WalkMove()
     }
 
     // Set pmove velocity
-    // Commented these 2 out, so we wont be 2 units above the ground
-    // This only happens when the player jumps straight up and lands while standing still
-    //mv->m_vecVelocity[2] = 0;
+    mv->m_vecVelocity[2] = 0;
     Accelerate(wishdir, wishspeed, sv_accelerate.GetFloat());
-    //mv->m_vecVelocity[2] = 0;
+    mv->m_vecVelocity[2] = 0;
 
     // Add in any base velocity to the current velocity.
     VectorAdd(mv->m_vecVelocity, player->GetBaseVelocity(), mv->m_vecVelocity);
@@ -320,7 +318,7 @@ bool CMomentumGameMovement::LadderMove(void)
     TracePlayerBBox(mv->GetAbsOrigin(), end, LadderMask(), COLLISION_GROUP_PLAYER_MOVEMENT, pm);
 
     // no ladder in that direction, return
-    if (pm.fraction == 1.0f || pm.plane.normal.z == 1.0f || !OnLadder(pm))
+    if (CloseEnough(pm.fraction, 1.0f) || CloseEnough(pm.plane.normal.z, 1.0f) || !OnLadder(pm))
     {
         return false;
     }

--- a/mp/src/gameui/OptionsSubAudio.cpp
+++ b/mp/src/gameui/OptionsSubAudio.cpp
@@ -10,6 +10,7 @@
 #include "vgui_controls/ComboBox.h"
 #include "vgui_controls/QueryBox.h"
 #include "vgui_controls/CVarSlider.h"
+#include <vgui_controls/CvarToggleCheckButton.h>
 #include "tier1/KeyValues.h"
 #include "tier1/convar.h"
 #include "vgui/IInput.h"
@@ -63,6 +64,8 @@ COptionsSubAudio::COptionsSubAudio(vgui::Panel *parent) : PropertyPage(parent, N
 
    m_pSpokenLanguageCombo = new ComboBox (this, "AudioSpokenLanguage", 6, false );
 
+   m_pMuteLoseFocus = new CvarToggleCheckButton(this, "snd_mute_losefocus", "#GameUI_SndMuteLoseFocus", "snd_mute_losefocus");
+
 	LoadControlSettings("resource/optionssubaudio.res");
 }
 
@@ -81,7 +84,7 @@ void COptionsSubAudio::OnResetData()
 	m_bRequireRestart = false;
 	m_pSFXSlider->Reset();
 	m_pMusicSlider->Reset();
-
+    m_pMuteLoseFocus->Reset();
 
 	// reset the combo boxes
 
@@ -198,6 +201,7 @@ void COptionsSubAudio::OnApplyChanges()
 {
 	m_pSFXSlider->ApplyChanges();
 	m_pMusicSlider->ApplyChanges();
+    m_pMuteLoseFocus->ApplyChanges();
 
 	// set the cvars appropriately
 	// Tracker 28933:  Note we can't do this because closecaption is marked

--- a/mp/src/gameui/OptionsSubAudio.h
+++ b/mp/src/gameui/OptionsSubAudio.h
@@ -57,6 +57,8 @@ private:
    vgui::DHANDLE<class COptionsSubAudioThirdPartyCreditsDlg> m_OptionsSubAudioThirdPartyCreditsDlg;
    ELanguage         m_nCurrentAudioLanguage;
    static char             *m_pchUpdatedAudioLanguage;
+
+    vgui::CvarToggleCheckButton *m_pMuteLoseFocus;
 };
 
 

--- a/mp/src/vgui2/vgui_controls/Label.cpp
+++ b/mp/src/vgui2/vgui_controls/Label.cpp
@@ -496,7 +496,7 @@ void Label::Paint()
 	ComputeAlignment(tx0, ty0, tx1, ty1);
 
 	// calculate who our associate is if we haven't already
-	if (_associateName)
+	if (!_associateName.IsEmpty())
 	{
 		SetAssociatedControl(FindSiblingByName(_associateName));
         _associateName.Purge();
@@ -988,7 +988,7 @@ void Label::ApplySchemeSettings(IScheme *pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
 
-	if (_fontOverrideName)
+	if (!_fontOverrideName.IsEmpty())
 	{
 		// use the custom specified font since we have one set
 		SetFont(pScheme->GetFont(_fontOverrideName, IsProportional()));
@@ -1201,7 +1201,7 @@ void Label::ApplySettings( KeyValues *inResourceData )
 
 	// the control we are to be associated with may not have been created yet,
 	// so keep a pointer to it's name and calculate it when we can
-    _associateName = inResourceData->GetString("associate", "");
+    _associateName = inResourceData->GetString("associate", nullptr);
 
 	if (inResourceData->GetBool("dulltext", false))
 	{
@@ -1226,7 +1226,7 @@ void Label::ApplySettings( KeyValues *inResourceData )
         _fontOverrideName = overrideFont;
 		SetFont(pScheme->GetFont(_fontOverrideName, IsProportional()));
 	}
-	else if (_fontOverrideName)
+	else if (!_fontOverrideName.IsEmpty())
 	{
         _fontOverrideName.Purge();
 		SetFont(pScheme->GetFont("Default", IsProportional()));

--- a/mp/src/vgui2/vgui_controls/Panel.cpp
+++ b/mp/src/vgui2/vgui_controls/Panel.cpp
@@ -1757,7 +1757,7 @@ void Panel::InternalCursorMoved(int x, int y)
 
 	if (m_pTooltips)
 	{
-		if ( _tooltipText )
+		if ( !_tooltipText.IsEmpty() )
 		{
 			m_pTooltips->SetText( _tooltipText );
 		}
@@ -1784,7 +1784,7 @@ void Panel::InternalCursorEntered()
 	{
 		m_pTooltips->ResetDelay();
 
-		if ( _tooltipText )
+		if ( !_tooltipText.IsEmpty() )
 		{
 			m_pTooltips->SetText( _tooltipText );
 		}
@@ -5893,7 +5893,7 @@ void Panel::SetTooltip( BaseTooltip *pToolTip, const char *pszText )
 //-----------------------------------------------------------------------------
 const char *Panel::GetEffectiveTooltipText() const
 {
-	if ( _tooltipText )
+	if ( !_tooltipText.IsEmpty() )
 	{
 		return _tooltipText;
 	}


### PR DESCRIPTION
 * CUtlStrings should check IsEmpty for null strings, fixes crashes with the menu
 * Re-added "mute audio when game loses focus" to audio settings
 * Fixed sliding along stairs/slight inclines, TBD if this causes any other regressions though