### PR TITLE
Fix zone trigger filter

### DIFF
--- a/mp/src/game/server/momentum/mapzones_edit.cpp
+++ b/mp/src/game/server/momentum/mapzones_edit.cpp
@@ -309,6 +309,7 @@ void CMomZoneEdit::OnCreate(int zonetype)
         return;
     }
 
+	pEnt->AddSpawnFlags(SF_TRIGGER_ALLOW_CLIENTS);
     pEnt->Spawn();
 
 

--- a/mp/src/game/server/momentum/mapzones_edit.cpp
+++ b/mp/src/game/server/momentum/mapzones_edit.cpp
@@ -309,7 +309,7 @@ void CMomZoneEdit::OnCreate(int zonetype)
         return;
     }
 
-	pEnt->AddSpawnFlags(SF_TRIGGER_ALLOW_CLIENTS);
+    pEnt->AddSpawnFlags(SF_TRIGGER_ALLOW_CLIENTS);
     pEnt->Spawn();
 
 


### PR DESCRIPTION
ATM zones created through zone builder can't be used since clients don't pass the trigger filter and `OnStartTouch` is never called. Just adds the spawn flag to fix this.