### PR TITLE
HUD Convar Namespacing

### DIFF
--- a/mp/game/momentum/resource/ui/SettingsPanel_HudSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_HudSettings.res
@@ -68,7 +68,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_speedometer"
+		"cvar_name"		"mom_hud_speedometer"
 		"cvar_value"		"1"
 	}
     "SpeedoShowJump"
@@ -98,7 +98,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_speedometer_showlastjumpvel"
+		"cvar_name"		"mom_hud_speedometer_showlastjumpvel"
 		"cvar_value"		"1"
 	}
     "ShowSpeedoHvel"
@@ -128,7 +128,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_speedometer_hvel"
+		"cvar_name"		"mom_hud_speedometer_hvel"
 		"cvar_value"		"0"
 	}
     "SpeedoUnitsLabel"
@@ -292,7 +292,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_showkeypresses"
+		"cvar_name"		"mom_hud_showkeypresses"
 		"cvar_value"		"1"
 	}
     
@@ -353,7 +353,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_strafesync_draw"
+		"cvar_name"		"mom_hud_strafesync_draw"
 		"cvar_value"		"1"
 	}
 	"SyncShowBar"
@@ -383,7 +383,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_strafesync_drawbar"
+		"cvar_name"		"mom_hud_strafesync_drawbar"
 		"cvar_value"		"1"
 	}
 	"SyncTypeLabel"
@@ -544,7 +544,7 @@
 		"auto_wide_tocontents"		"1"
 		"use_proportional_insets"		"0"
 		"Default"		"0"
-		"cvar_name"		"mom_timer"
+		"cvar_name"		"mom_hud_timer"
 		"cvar_value"		"1"
 	}
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
@@ -22,7 +22,7 @@
 
 using namespace vgui;
 
-static ConVar showkeys("mom_showkeypresses", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_REPLICATED,
+static ConVar showkeys("mom_hud_showkeypresses", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_REPLICATED,
                        "Toggles showing keypresses and strafe/jump counter\n");
 
 class CHudKeyPressDisplay : public CHudElement, public Panel

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapinfo.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapinfo.cpp
@@ -18,13 +18,13 @@
 
 using namespace vgui;
 
-static MAKE_TOGGLE_CONVAR(mom_mapinfo_show_mapname, "1", FLAG_HUD_CVAR,
+static MAKE_TOGGLE_CONVAR(mom_hud_mapinfo_show_mapname, "1", FLAG_HUD_CVAR,
                           "Toggles showing the map name. 0 = OFF, 1 = ON");
 
-static MAKE_TOGGLE_CONVAR(mom_mapinfo_show_author, "0", FLAG_HUD_CVAR,
+static MAKE_TOGGLE_CONVAR(mom_hud_mapinfo_show_author, "0", FLAG_HUD_CVAR,
                           "Toggles showing the map author. 0 = OFF, 1 = ON");
 
-static MAKE_TOGGLE_CONVAR(mom_mapinfo_show_difficulty, "0", FLAG_HUD_CVAR,
+static MAKE_TOGGLE_CONVAR(mom_hud_mapinfo_show_difficulty, "0", FLAG_HUD_CVAR,
                           "Toggles showing the map difficulty. 0 = OFF, 1 = ON");
 
 class C_HudMapInfo : public CHudElement, public Panel
@@ -263,7 +263,7 @@ void C_HudMapInfo::Paint()
     int toIncrement = surface()->GetFontTall(m_hMapInfoFont) + 2;
     surface()->DrawSetTextFont(m_hMapInfoFont);
     IViewPortPanel *pSpecGUI = gViewPortInterface->FindPanelByName(PANEL_SPECGUI);
-    if (mom_mapinfo_show_mapname.GetBool() && pSpecGUI && !pSpecGUI->IsVisible())
+    if (mom_hud_mapinfo_show_mapname.GetBool() && pSpecGUI && !pSpecGUI->IsVisible())
     {
         const char *pMapName = g_pGameRules->MapName();
         if (pMapName)
@@ -278,7 +278,7 @@ void C_HudMapInfo::Paint()
         }
     }
 
-    if (mom_mapinfo_show_author.GetBool())
+    if (mom_hud_mapinfo_show_author.GetBool())
     {
         // MOM_TODO: Map author(s)
 
@@ -288,7 +288,7 @@ void C_HudMapInfo::Paint()
         // surface()->DrawPrintText(mapAuthorUnicode, wcslen(mapAuthorUnicode));
     }
 
-    if (mom_mapinfo_show_difficulty.GetBool())
+    if (mom_hud_mapinfo_show_difficulty.GetBool())
     {
         // MOM_TODO: We need to determine difficulty of a map.
     }

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -24,27 +24,27 @@ using namespace vgui;
 
 #define LASTJUMPVEL_TIMEOUT 3.0f
 
+static MAKE_TOGGLE_CONVAR(mom_hud_speedometer, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
+                          "Toggles displaying the speedometer. 0 = OFF, 1 = ON\n");
+
 static MAKE_TOGGLE_CONVAR(
-    mom_speedometer_hvel, "0", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
+    mom_hud_speedometer_hvel, "0", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
     "Toggles showing only the horizontal component of player speed. 0 = OFF (XYZ), 1 = ON (XY)\n");
 
-static MAKE_CONVAR(mom_speedometer_units, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
+static MAKE_CONVAR(mom_hud_speedometer_units, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
                    "Changes the units of measurement of the speedometer.\n 1 = Units per second\n 2 = "
                    "Kilometers per hour\n 3 = Miles per hour.",
                    1, 3);
 
-static MAKE_TOGGLE_CONVAR(mom_speedometer, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
-                          "Toggles displaying the speedometer. 0 = OFF, 1 = ON\n");
-
-static MAKE_CONVAR(mom_speedometer_colorize, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
+static MAKE_CONVAR(mom_hud_speedometer_colorize, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
                           "Toggles speedometer colorization. 0 = OFF, 1 = ON (Based on acceleration)," 
                           " 2 = ON (Staged by relative velocity to max.)\n", 0, 2);
 
-static MAKE_TOGGLE_CONVAR(mom_speedometer_showlastjumpvel, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
+static MAKE_TOGGLE_CONVAR(mom_hud_speedometer_showlastjumpvel, "1", FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE,
                           "Toggles showing player velocity at last jump (XY only). 0 = OFF, 1 = ON\n");
 
 static MAKE_TOGGLE_CONVAR(
-    mom_speedometer_showenterspeed, "1", FLAG_HUD_CVAR,
+    mom_hud_speedometer_showenterspeed, "1", FLAG_HUD_CVAR,
     "Toggles showing the stage/checkpoint enter speed (and comparison, if existent). 0 = OFF, 1 = ON\n");
 
 class CHudSpeedMeter : public CHudElement, public CHudNumericDisplay
@@ -64,7 +64,7 @@ class CHudSpeedMeter : public CHudElement, public CHudNumericDisplay
     void Reset() OVERRIDE
     {
         // We set the proper LabelText based on mom_speedmeter_units value
-        switch (mom_speedometer_units.GetInt())
+        switch (mom_hud_speedometer_units.GetInt())
         {
         case 2:
             SetLabelText(L"KM/H");
@@ -88,7 +88,7 @@ class CHudSpeedMeter : public CHudElement, public CHudNumericDisplay
     bool ShouldDraw() OVERRIDE
     { 
         IViewPortPanel *pLeaderboards = gViewPortInterface->FindPanelByName(PANEL_TIMES);
-        return mom_speedometer.GetBool() && CHudElement::ShouldDraw() && pLeaderboards && !pLeaderboards->IsVisible(); 
+        return mom_hud_speedometer.GetBool() && CHudElement::ShouldDraw() && pLeaderboards && !pLeaderboards->IsVisible(); 
     }
 
     void ApplySchemeSettings(IScheme *pScheme) OVERRIDE
@@ -101,7 +101,7 @@ class CHudSpeedMeter : public CHudElement, public CHudNumericDisplay
         SetBgColor(_bgColor);
         m_LabelColor = normalColor;
     }
-    bool ShouldColorize() const { return mom_speedometer_colorize.GetInt() >= 1; }
+    bool ShouldColorize() const { return mom_hud_speedometer_colorize.GetInt() >= 1; }
 
     void FireGameEvent(IGameEvent *pEvent) OVERRIDE
     {
@@ -179,7 +179,7 @@ void CHudSpeedMeter::OnThink()
 
         m_bTimerIsRunning = pData->m_bTimerRunning;
 
-        int velType = mom_speedometer_hvel.GetBool(); // 1 is horizontal velocity
+        int velType = mom_hud_speedometer_hvel.GetBool(); // 1 is horizontal velocity
 
         if (gpGlobals->curtime - lastJumpTime > LASTJUMPVEL_TIMEOUT)
         {
@@ -206,7 +206,7 @@ void CHudSpeedMeter::OnThink()
 
         // Conversions based on https://developer.valvesoftware.com/wiki/Dimensions#Map_Grid_Units:_quick_reference
         float vel = static_cast<float>(velocity.Length());
-        switch (mom_speedometer_units.GetInt())
+        switch (mom_hud_speedometer_units.GetInt())
         {
         case 2:
             // 1 unit = 19.05mm -> 0.01905m -> 0.00001905Km(/s) -> 0.06858Km(/h)
@@ -232,7 +232,7 @@ void CHudSpeedMeter::OnThink()
         {
             if (m_flNextColorizeCheck <= gpGlobals->curtime)
             {
-                if (mom_speedometer_colorize.GetInt() == 1)
+                if (mom_hud_speedometer_colorize.GetInt() == 1)
                 {
                     if (m_flLastVelocity != 0)
                     {
@@ -297,7 +297,7 @@ void CHudSpeedMeter::OnThink()
         m_iRoundedVel = round(vel);
         m_iRoundedLastJump = round(lastJumpVel);
         SetDisplayValue(m_iRoundedVel);
-        SetShouldDisplaySecondaryValue(mom_speedometer_showlastjumpvel.GetBool());
+        SetShouldDisplaySecondaryValue(mom_hud_speedometer_showlastjumpvel.GetBool());
         SetSecondaryValue(m_iRoundedLastJump);
     }
 }
@@ -319,10 +319,10 @@ void CHudSpeedMeter::Paint()
     BaseClass::Paint();
 
     // Draw the enter speed split, if toggled on
-    if (mom_speedometer_showenterspeed.GetBool() && m_bTimerIsRunning)
+    if (mom_hud_speedometer_showenterspeed.GetBool() && m_bTimerIsRunning)
     {
         int split_xpos; // Dynamically set
-        int split_ypos = mom_speedometer_showlastjumpvel.GetBool()
+        int split_ypos = mom_hud_speedometer_showlastjumpvel.GetBool()
                              ? digit2_ypos + surface()->GetFontTall(m_hSmallNumberFont)
                              : digit2_ypos;
 

--- a/mp/src/game/client/momentum/ui/HUD/hud_strafesync.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_strafesync.cpp
@@ -15,20 +15,20 @@
 
 using namespace vgui;
 
-static ConVar strafesync_draw("mom_strafesync_draw", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
+static ConVar strafesync_draw("mom_hud_strafesync_draw", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
                               "Toggles displaying the strafesync data. (1 = only timer , 2 = always (except practice mode)) \n",
                               true, 0, true, 2);
 
-static ConVar strafesync_drawbar("mom_strafesync_drawbar", "1",
+static ConVar strafesync_drawbar("mom_hud_strafesync_drawbar", "1",
                                  FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
                                  "Toggles displaying the visual strafesync bar.\n", true, 0, true, 1);
 
 static ConVar strafesync_type(
-    "mom_strafesync_type", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
+    "mom_hud_strafesync_type", "1", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
     "1: Sync1 (perfect strafe ticks / total strafe ticks)\n 2: Sync2 (accel ticks / total strafe ticks)\n", true, 1,
     true, 2);
 
-static ConVar strafesync_colorize("mom_strafesync_colorize", "2",
+static ConVar strafesync_colorize("mom_hud_strafesync_colorize", "2",
                                   FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
                                   "Toggles strafesync data colorization type based on acceleration. 0 to disable\n",
                                   true, 0, true, 2);

--- a/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
@@ -21,10 +21,10 @@
 
 using namespace vgui;
 
-static ConVar mom_timer("mom_timer", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE,
+static ConVar mom_timer("mom_hud_timer", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE,
                         "Toggle displaying the timer. 0 = OFF, 1 = ON\n", true, 0, true, 1);
 
-static ConVar timer_mode("mom_timer_mode", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_REPLICATED,
+static ConVar timer_mode("mom_hud_timer_mode", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_REPLICATED,
                          "Set what type of timer you want.\n0 = Generic Timer (no splits)\n1 = Splits by Checkpoint\n");
 
 class C_HudTimer : public CHudElement, public Panel

--- a/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.cpp
@@ -62,8 +62,8 @@ void HudSettingsPage::OnApplyChanges()
 {
     BaseClass::OnApplyChanges();
 
-    ConVarRef units("mom_speedometer_units"), sync_type("mom_strafesync_type"),
-        sync_color("mom_strafesync_colorize"), speed_color("mom_speedometer_colorize");
+    ConVarRef units("mom_hud_speedometer_units"), sync_type("mom_hud_strafesync_type"),
+        sync_color("mom_hud_strafesync_colorize"), speed_color("mom_hud_speedometer_colorize");
 
     units.SetValue(m_pSpeedometerUnits->GetActiveItem() + 1);
     sync_type.SetValue(m_pSyncType->GetActiveItem() + 1); // Sync type needs +1 added to it before setting convar!
@@ -73,8 +73,8 @@ void HudSettingsPage::OnApplyChanges()
 
 void HudSettingsPage::LoadSettings()
 {
-    ConVarRef units("mom_speedometer_units"), sync_type("mom_strafesync_type"),
-        sync_color("mom_strafesync_colorize"), speed_color("mom_speedometer_colorize");
+    ConVarRef units("mom_hud_speedometer_units"), sync_type("mom_hud_strafesync_type"),
+        sync_color("mom_hud_strafesync_colorize"), speed_color("mom_hud_speedometer_colorize");
     m_pSpeedometerUnits->ActivateItemByRow(units.GetInt() - 1);
     m_pSyncType->ActivateItemByRow(sync_type.GetInt() - 1);
     m_pSyncColorize->ActivateItemByRow(sync_color.GetInt());


### PR DESCRIPTION
HUD convars were sometimes prefixed, sometimes not. _hud_ should be prepended to all convars so that they dont clutter the global console namespace or even the mom console command namespace.

I'm not sure of the macros are a good idea since the ConVar name might get too verbose and you just want a simpler name for the static var