### PR TITLE
Fix teleports being interpolated in replays

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -620,22 +620,22 @@ void CMomentumPlayer::Teleport(const Vector *newPosition, const QAngle *newAngle
     g_ReplaySystem.SetTeleportedThisFrame();
 }
 
-bool CMomentumPlayer::KeyValue( const char *szKeyName, const char *szValue )
+bool CMomentumPlayer::KeyValue(const char *szKeyName, const char *szValue)
 {
     //
     // It's possible for some maps to use "AddOutput -> origin x y z
     // for teleports.
     //
-    if ( FStrEq( szKeyName, "origin" ) )
+    if (FStrEq(szKeyName, "origin"))
     {
         // Copy of CBaseEntity::KeyValue
         Vector vecOrigin;
-        UTIL_StringToVector( vecOrigin.Base(), szValue );
+        UTIL_StringToVector(vecOrigin.Base(), szValue);
 
         // If you're hitting this assert, it's probably because you're
         // calling SetLocalOrigin from within a KeyValues method.. use SetAbsOrigin instead!
-        Assert( (GetMoveParent() == NULL) && !IsEFlagSet( EFL_DIRTY_ABSTRANSFORM ) );
-        SetAbsOrigin( vecOrigin );
+        Assert((GetMoveParent() == NULL) && !IsEFlagSet(EFL_DIRTY_ABSTRANSFORM));
+        SetAbsOrigin(vecOrigin);
 
 
 
@@ -652,7 +652,7 @@ bool CMomentumPlayer::KeyValue( const char *szKeyName, const char *szValue )
 
 // These two are overridden because of a weird compiler error,
 // otherwise they serve no purpose.
-bool CMomentumPlayer::KeyValue( const char *szKeyName, float flValue ) 
+bool CMomentumPlayer::KeyValue(const char *szKeyName, float flValue) 
 {
     return BaseClass::KeyValue(szKeyName, flValue);
 }

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -616,6 +616,50 @@ void CMomentumPlayer::Teleport(const Vector *newPosition, const QAngle *newAngle
     // No need to remove the trail here, CreateTrail() already does it for us
     BaseClass::Teleport(newPosition, newAngles, newVelocity);
     CreateTrail();
+
+    g_ReplaySystem.SetTeleportedThisFrame();
+}
+
+bool CMomentumPlayer::KeyValue( const char *szKeyName, const char *szValue )
+{
+    //
+    // It's possible for some maps to use "AddOutput -> origin x y z
+    // for teleports.
+    //
+    if ( FStrEq( szKeyName, "origin" ) )
+    {
+        // Copy of CBaseEntity::KeyValue
+        Vector vecOrigin;
+        UTIL_StringToVector( vecOrigin.Base(), szValue );
+
+        // If you're hitting this assert, it's probably because you're
+        // calling SetLocalOrigin from within a KeyValues method.. use SetAbsOrigin instead!
+        Assert( (GetMoveParent() == NULL) && !IsEFlagSet( EFL_DIRTY_ABSTRANSFORM ) );
+        SetAbsOrigin( vecOrigin );
+
+
+
+        // TODO: Throw this into OnTeleport() or something?
+        CreateTrail();
+
+        g_ReplaySystem.SetTeleportedThisFrame();
+
+        return true;
+    }
+
+    return BaseClass::KeyValue(szKeyName, szValue);
+}
+
+// These two are overridden because of a weird compiler error,
+// otherwise they serve no purpose.
+bool CMomentumPlayer::KeyValue( const char *szKeyName, float flValue ) 
+{
+    return BaseClass::KeyValue(szKeyName, flValue);
+}
+
+bool CMomentumPlayer::KeyValue(const char *szKeyName, const Vector &vecValue)
+{
+    return BaseClass::KeyValue(szKeyName, vecValue);
 }
 
 void CMomentumPlayer::CreateTrail()

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -172,6 +172,9 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public IM
 
     // Trail Methods
     void Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity) OVERRIDE;
+    bool KeyValue(const char *szKeyName, const char *szValue) OVERRIDE;
+    bool KeyValue(const char *szKeyName, float flValue) OVERRIDE;
+    bool KeyValue(const char *szKeyName, const Vector &vecValue) OVERRIDE;
     void CreateTrail();
     void RemoveTrail();
      

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -28,7 +28,7 @@ END_DATADESC();
 CMomentumReplayGhostEntity::CMomentumReplayGhostEntity()
     : m_bIsActive(false), m_bReplayFirstPerson(false), m_pPlaybackReplay(nullptr), m_bHasJumped(false),
       m_flLastSyncVelocity(0), m_nStrafeTicks(0), m_nPerfectSyncTicks(0), m_nAccelTicks(0), m_nOldReplayButtons(0),
-      m_RunStats(&m_SrvData.m_RunStatsData, g_pMomentumTimer->GetZoneCount()), m_cvarReplaySelection("mom_replay_selection")
+      m_RunStats(&m_SrvData.m_RunStatsData, g_pMomentumTimer->GetZoneCount()), m_cvarReplaySelection("mom_replay_selection"), m_vecLastVel(vec3_origin)
 {
     StdDataToReplay = (DataToReplayFn)(GetProcAddress(GetModuleHandle(CLIENT_DLL_NAME), "StdDataToReplay"));
 
@@ -377,7 +377,6 @@ void CMomentumReplayGhostEntity::HandleGhostFirstPerson()
 
         Vector interpolatedVel;
         const float maxvel = sv_maxvelocity.GetFloat();
-        static Vector lastVel = vec3_origin;
 
         if (!bTeleportedNextFrame)
         {
@@ -389,12 +388,12 @@ void CMomentumReplayGhostEntity::HandleGhostFirstPerson()
             const float distZ = fabs(pPlayerCurrentOrigin.z - pPlayerNextOrigin.z);
             interpolatedVel = Vector(distX, distY, distZ) / gpGlobals->interval_per_tick;
 
-            lastVel = interpolatedVel;
+            m_vecLastVel = interpolatedVel;
         }
         else
         {
             // HACK: Can't interpolate so just assume last one.
-            interpolatedVel = lastVel;
+            interpolatedVel = m_vecLastVel;
         }
 
         if (bTeleportedThisFrame)

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -583,13 +583,13 @@ CReplayFrame *CMomentumReplayGhostEntity::GetPreviousStep()
     {
         ++nextStep;
 
-        nextStep = max(nextStep, 0);
+        nextStep = min(nextStep, m_pPlaybackReplay->GetFrameCount() - 1);
     }
     else
     {
         --nextStep;
 
-        nextStep = min(nextStep, m_pPlaybackReplay->GetFrameCount() - 1);
+        nextStep = max(nextStep, 0);
     }
 
     return m_pPlaybackReplay->GetFrame(nextStep);

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -379,7 +379,7 @@ void CMomentumReplayGhostEntity::HandleGhostFirstPerson()
         const float maxvel = sv_maxvelocity.GetFloat();
         static Vector lastVel = vec3_origin;
 
-        if ( !bTeleportedNextFrame )
+        if (!bTeleportedNextFrame)
         {
             // interpolate vel from difference in origin
             const Vector &pPlayerCurrentOrigin = currentStep->PlayerOrigin();
@@ -397,7 +397,7 @@ void CMomentumReplayGhostEntity::HandleGhostFirstPerson()
             interpolatedVel = lastVel;
         }
 
-        if ( bTeleportedThisFrame )
+        if (bTeleportedThisFrame)
         {
             // Fix teleporting being interpolated.
             IncrementInterpolationFrame();

--- a/mp/src/game/server/momentum/mom_replay_entity.h
+++ b/mp/src/game/server/momentum/mom_replay_entity.h
@@ -71,4 +71,5 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
     QAngle m_angLastEyeAngle;
     float m_flLastSyncVelocity;
     int m_nStrafeTicks, m_nPerfectSyncTicks, m_nAccelTicks, m_nOldReplayButtons, m_iTickElapsed;
+    Vector m_vecLastVel;
 };

--- a/mp/src/game/server/momentum/mom_replay_entity.h
+++ b/mp/src/game/server/momentum/mom_replay_entity.h
@@ -38,6 +38,7 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
 
     CReplayFrame* GetCurrentStep();
     CReplayFrame *GetNextStep();
+    CReplayFrame *GetPreviousStep();
 
     bool IsReplayEnt() { return true; }
     void (*StdDataToReplay)(StdReplayDataFromServer *from);

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -288,7 +288,7 @@ void CMomentumReplaySystem::TogglePause() { m_bPaused = !m_bPaused; }
 
 void CMomentumReplaySystem::SetTeleportedThisFrame()
 {
-    if ( m_bRecording )
+    if (m_bRecording)
     {
         m_bTeleportedThisFrame = true;
     }

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -25,7 +25,8 @@ CMomentumReplaySystem::CMomentumReplaySystem(const char* pName):
     m_iTickCount(0),
     m_iStartRecordingTick(-1),
     m_iStartTimerTick(-1),
-    m_fRecEndTime(-1.0f)
+    m_fRecEndTime(-1.0f),
+    m_bTeleportedThisFrame(false)
 {
     m_szMapHash[0] = '\0';
     m_pRecordingReplay = g_ReplayFactory.CreateEmptyReplay(0);
@@ -225,7 +226,8 @@ void CMomentumReplaySystem::UpdateRecordingParams()
         if (!m_pPlayer->m_SrvData.m_bHasPracticeMode) // MOM_TODO: && !m_player->IsSpectating
         {
             m_pRecordingReplay->AddFrame(CReplayFrame(m_pPlayer->EyeAngles(), m_pPlayer->GetAbsOrigin(), m_pPlayer->GetViewOffset(),
-                                             m_pPlayer->m_nButtons));
+                                             m_pPlayer->m_nButtons, m_bTeleportedThisFrame));
+            m_bTeleportedThisFrame = false;
         }
         else
         {
@@ -283,6 +285,14 @@ void CMomentumReplaySystem::SetRunStats()
 }
 
 void CMomentumReplaySystem::TogglePause() { m_bPaused = !m_bPaused; }
+
+void CMomentumReplaySystem::SetTeleportedThisFrame()
+{
+    if ( m_bRecording )
+    {
+        m_bTeleportedThisFrame = true;
+    }
+}
 
 void CMomentumReplaySystem::StartPlayback(bool firstperson)
 {

--- a/mp/src/game/server/momentum/mom_replay_system.h
+++ b/mp/src/game/server/momentum/mom_replay_system.h
@@ -41,6 +41,8 @@ public:
 
     void TogglePause();
 
+    void SetTeleportedThisFrame(); // Call me when player teleports.
+
     //CMomRunStats *SavedRunStats() { return &m_SavedRunStats; }
 
   public:
@@ -69,6 +71,7 @@ public:
     //CMomRunStats m_SavedRunStats;
     // Map SHA1 hash for version purposes
     char m_szMapHash[41];
+    bool m_bTeleportedThisFrame;
 };
 
 extern CMomentumReplaySystem g_ReplaySystem;

--- a/mp/src/game/shared/momentum/run/mom_replay_data.h
+++ b/mp/src/game/shared/momentum/run/mom_replay_data.h
@@ -3,6 +3,11 @@
 #include <momentum/util/serialization.h>
 #include "utlbuffer.h"
 
+
+// HACK: To keep compatibility, store teleport flag in the buttons
+// Remember to update me if more button flags are added!!!
+#define IN_REPLAY_TELEPORTED            (1 << 27)
+
 // A single frame of the replay.
 class CReplayFrame : public ISerializable
 {
@@ -27,9 +32,11 @@ class CReplayFrame : public ISerializable
         m_iPlayerButtons = reader.GetInt();
     }
 
-    CReplayFrame(const QAngle &eye, const Vector &origin, const Vector &viewoffset, int buttons)
+    CReplayFrame(const QAngle &eye, const Vector &origin, const Vector &viewoffset, int buttons, bool teleported)
         : m_angEyeAngles(eye), m_vPlayerOrigin(origin), m_fPlayerViewOffset(viewoffset.z), m_iPlayerButtons(buttons)
     {
+        if ( teleported )
+            m_iPlayerButtons |= IN_REPLAY_TELEPORTED;
     }
 
   public:
@@ -53,6 +60,7 @@ class CReplayFrame : public ISerializable
     inline Vector PlayerOrigin() const { return m_vPlayerOrigin; }
     inline float PlayerViewOffset() const { return m_fPlayerViewOffset; }
     inline int PlayerButtons() const { return m_iPlayerButtons; }
+    inline bool Teleported() const { return (m_iPlayerButtons & IN_REPLAY_TELEPORTED) ? true : false; }
 
   private:
     QAngle m_angEyeAngles;


### PR DESCRIPTION
This does NOT fix jerkiness when ping > 0, AFAIK for that you need to predict the replay on the client.
Keeps compatibility with previous replays.
