### PR TITLE
Don't reserve big memory buffer for packets

### DIFF
--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -326,8 +326,7 @@ bool CMomentumLobbySystem::SendPacket(MomentumPacket_t *packet, CSteamID *pTarge
         return false;
 
     // Write the packet out to binary
-    const int size = sendType >= k_EP2PSendReliable ? 1000000 : 1200;
-    CUtlBuffer buf(0, size);
+    CUtlBuffer buf;
     buf.SetBigEndian(false);
     packet->Write(buf);
 


### PR DESCRIPTION
The CUtlBuffer class automatically grows as needed and does not need to reserve this much memory for how small the packets are.
Alternatively, rework how the packet base class works so it can be used bidirectionally where the size is always known beforehand.
