### PR TITLE
added rudimentary tricksurf support

### DIFF
--- a/mp/src/game/client/momentum/mom_map_cache.cpp
+++ b/mp/src/game/client/momentum/mom_map_cache.cpp
@@ -1017,6 +1017,10 @@ void CMapCache::SetMapGamemode(const char *pMapName /* = nullptr*/)
         {
             gm.SetValue(GAMEMODE_KZ);
         }
+		else if (!Q_strnicmp(pMapName, "tricksurf_", 10))
+		{
+			gm.SetValue(GAMEMODE_TRICKSURF);
+		}
         else
         {
             gm.SetValue(GAMEMODE_UNKNOWN);

--- a/mp/src/game/client/momentum/mom_map_cache.cpp
+++ b/mp/src/game/client/momentum/mom_map_cache.cpp
@@ -1017,10 +1017,10 @@ void CMapCache::SetMapGamemode(const char *pMapName /* = nullptr*/)
         {
             gm.SetValue(GAMEMODE_KZ);
         }
-		else if (!Q_strnicmp(pMapName, "tricksurf_", 10))
-		{
-			gm.SetValue(GAMEMODE_TRICKSURF);
-		}
+        else if (!Q_strnicmp(pMapName, "tricksurf_", 10))
+        {
+            gm.SetValue(GAMEMODE_TRICKSURF);
+        }
         else
         {
             gm.SetValue(GAMEMODE_UNKNOWN);

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -342,29 +342,39 @@ void CMomentumTimer::SetGameModeConVars()
     case GAMEMODE_SURF:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(150);
+		sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     case GAMEMODE_BHOP:
         sv_maxvelocity.SetValue(100000);
         sv_airaccelerate.SetValue(1000);
+		sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     case GAMEMODE_KZ:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(100);
+		sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(250);
         break;
+	case GAMEMODE_TRICKSURF:
+		sv_maxvelocity.SetValue(100000);
+		sv_airaccelerate.SetValue(1000);
+		sv_accelerate.SetValue(10);
+		sv_maxspeed.SetValue(260);
+		break;
     case GAMEMODE_UNKNOWN:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(150);
+		sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     default:
         DevWarning("[%i] GameMode not defined.\n", gm.GetInt());
         break;
     }
-    DevMsg("CTimer set values:\nsv_maxvelocity: %i\nsv_airaccelerate: %i \nsv_maxspeed: %i\n", sv_maxvelocity.GetInt(),
-           sv_airaccelerate.GetInt(), sv_maxspeed.GetInt());
+    DevMsg("CTimer set values:\nsv_maxvelocity: %i\nsv_airaccelerate: %i\nsv_accelerate: %i\nsv_maxspeed: %i\n", sv_maxvelocity.GetInt(),
+           sv_airaccelerate.GetInt(), sv_accelerate.GetInt(), sv_maxspeed.GetInt());
 }
 
 // Practice mode that stops the timer and allows the player to noclip.

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -342,31 +342,31 @@ void CMomentumTimer::SetGameModeConVars()
     case GAMEMODE_SURF:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(150);
-		sv_accelerate.SetValue(5);
+        sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     case GAMEMODE_BHOP:
         sv_maxvelocity.SetValue(100000);
         sv_airaccelerate.SetValue(1000);
-		sv_accelerate.SetValue(5);
+        sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     case GAMEMODE_KZ:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(100);
-		sv_accelerate.SetValue(5);
+        sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(250);
         break;
-	case GAMEMODE_TRICKSURF:
-		sv_maxvelocity.SetValue(100000);
-		sv_airaccelerate.SetValue(1000);
-		sv_accelerate.SetValue(10);
-		sv_maxspeed.SetValue(260);
-		break;
+    case GAMEMODE_TRICKSURF:
+        sv_maxvelocity.SetValue(100000);
+        sv_airaccelerate.SetValue(1000);
+        sv_accelerate.SetValue(10);
+        sv_maxspeed.SetValue(260);
+        break;
     case GAMEMODE_UNKNOWN:
         sv_maxvelocity.SetValue(3500);
         sv_airaccelerate.SetValue(150);
-		sv_accelerate.SetValue(5);
+        sv_accelerate.SetValue(5);
         sv_maxspeed.SetValue(260);
         break;
     default:

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -100,8 +100,7 @@ bool TickSet::SetTickrate(int gameMode)
     switch (gameMode)
     {
     case GAMEMODE_TRICKSURF:
-		return SetTickrate(s_DefinedRates[TICKRATE_100]);
-	case GAMEMODE_BHOP:
+    case GAMEMODE_BHOP:
     case GAMEMODE_KZ:
         //MOM_TODO: add more gamemodes
         return SetTickrate(s_DefinedRates[TICKRATE_100]);

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -99,7 +99,9 @@ bool TickSet::SetTickrate(int gameMode)
 {
     switch (gameMode)
     {
-    case GAMEMODE_BHOP:
+    case GAMEMODE_TRICKSURF:
+		return SetTickrate(s_DefinedRates[TICKRATE_100]);
+	case GAMEMODE_BHOP:
     case GAMEMODE_KZ:
         //MOM_TODO: add more gamemodes
         return SetTickrate(s_DefinedRates[TICKRATE_100]);

--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -240,6 +240,7 @@ static const char * const g_szWhitelistedCommands[] = {
     "sv_gravity",
     "sv_maxvelocity",
     "sv_airaccelerate",
+	"sv_accelerate",
     "disconnect"
 };
 

--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -240,7 +240,7 @@ static const char * const g_szWhitelistedCommands[] = {
     "sv_gravity",
     "sv_maxvelocity",
     "sv_airaccelerate",
-	"sv_accelerate",
+    "sv_accelerate",
     "disconnect"
 };
 


### PR DESCRIPTION
now when you load a map starting with tricksurf_ it will use tricksurf settings

mp/src/game/client/momentum/mom_map_cache.cpp:
added check for "tricksurf_"

mp/src/game/server/momentum/mom_timer.cpp:
added sv_accelerate to all gamemodes
added GAMEMODE_TRICKSURF to the switch in CMomentumTimer::SetGameModeConVars()
added sv_accelerate to the devmsg

mp/src/game/server/momentum/tickset.cpp:
added GAMEMODE_TRICKSURF to the switch in TickSet::SetTickrate(int gameMode)

 mp/src/game/shared/momentum/mom_gamerules.cpp:
added sv_accelerate to g_szWhitelistedCommands[]
