### PR TITLE
Update Linux Workflow to Steam Runtime Chroot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@ jobs:
 
   build_linux:
     docker:
-      - image: gocnak/sourcesdk_steamrt_image
+      - image: gocnak/steam-runtime-i386
       
     working_directory: ~/mom_build
     resource_class: large
+    environment:
+      USING_DOCKER: h*ckyeahIam
     
     steps:
       - checkout
@@ -29,9 +31,7 @@ jobs:
           command: |
             cd ~/mom_build/mp/game
             rm -rf bin/*.dbg
-            rm -rf bin/*_srv.so
             rm -rf momentum/bin/*.dbg
-            rm -rf momentum/bin/*_srv.so
             rm -rf momentum/bin/*.dll
         
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   build_linux:
     docker:
-      - image: gocnak/steam-runtime-i386
+      - image: gocnak/steam-runtime-i386:momentum
       
     working_directory: ~/mom_build
     resource_class: large

--- a/mp/src/devtools/makefile_base_posix.mak
+++ b/mp/src/devtools/makefile_base_posix.mak
@@ -80,32 +80,23 @@ COPY_DLL_TO_SRV = 0
 # http://linux.die.net/man/1/ld and http://fedoraproject.org/wiki/Releases/FeatureBuildId.http://fedoraproject.org/wiki/Releases/FeatureBuildId
 LDFLAGS += -Wl,--build-id
 
+# Building the game on Linux requires a CHROOT environment, please read https://github.com/momentum-mod/game/wiki/Building-The-Game/#linux for more info!
+CHROOT_NAME=steamrt_scout_i386
+
 #
 # If we should be running in a chroot, check to see if we are. If not, then prefix everything with the 
 # required chroot
 #
-ifdef MAKE_CHROOT
-	export STEAM_RUNTIME_PATH := /usr
-	ifneq ("$(SCHROOT_CHROOT_NAME)", "$(CHROOT_NAME)")
+export STEAM_RUNTIME_PATH := /usr
+ifndef USING_DOCKER
+    ifneq ("$(SCHROOT_CHROOT_NAME)", "$(CHROOT_NAME)")
         $(info '$(SCHROOT_CHROOT_NAME)' is not '$(CHROOT_NAME)')
         $(error This makefile should be run from within a chroot. 'schroot --chroot $(CHROOT_NAME) -- $(MAKE) $(MAKEFLAGS)')  
-	endif
-	GCC_VER = -4.8
-	P4BIN = $(SRCROOT)/devtools/bin/linux/p4
-	CRYPTOPPDIR=ubuntu12_32_gcc48
-else ifeq ($(USE_VALVE_BINDIR),1)
-	# Using /valve/bin directory.
-	export STEAM_RUNTIME_PATH ?= /valve
-	GCC_VER = -4.6
-	P4BIN = p4
-	CRYPTOPPDIR=linux32
-else
-	# Not using chroot, use old steam-runtime. (gcc 4.6.3)
-	export STEAM_RUNTIME_PATH ?= /valve/steam-runtime
-	GCC_VER =
-	P4BIN = p4
-	CRYPTOPPDIR=ubuntu12_32
+    endif
 endif
+GCC_VER = -4.8
+P4BIN = p4
+CRYPTOPPDIR=ubuntu12_32
 
 ifeq ($(TARGET_PLATFORM),linux64)
 	MARCH_TARGET = core2
@@ -198,11 +189,6 @@ else
 	STRIP ?= true
 endif
 VSIGN ?= true
-
-ifeq ($(SOURCE_SDK), 1)
-	Srv_GAMEOUTPUTFILE := $(GAMEOUTPUTFILE:.so=_srv.so)
-	COPY_DLL_TO_SRV := 1
-endif
 
 LINK_MAP_FLAGS = -Wl,-Map,$(@:.so=).map
 

--- a/mp/src/game/client/clientshadowmgr.cpp
+++ b/mp/src/game/client/clientshadowmgr.cpp
@@ -2535,7 +2535,7 @@ void CClientShadowMgr::BuildRenderToTextureShadow( IClientRenderable* pRenderabl
 	Vector boxSize;
 	VectorSubtract( maxs, mins, boxSize );
 	
-	Vector yvec;
+	Vector yvec = vec3_origin;
 	float fProjMax = 0.0f;
 	for( int i = 0; i != 3; ++i )
 	{

--- a/mp/src/game/client/momentum/mom_map_cache.cpp
+++ b/mp/src/game/client/momentum/mom_map_cache.cpp
@@ -9,8 +9,13 @@
 
 #include "filesystem.h"
 #include "fmtstr.h"
+
+#include "tier0/valve_minmax_off.h"
+// These two are wrapped by minmax_off due to Valve making a macro for min and max...
 #include <cryptopp/osrng.h>
 #include <cryptopp/hex.h>
+// Now we can unwrap
+#include "tier0/valve_minmax_on.h"
 
 #include "tier0/memdbgon.h"
 
@@ -460,9 +465,9 @@ void MapData::FromKV(KeyValues* pMap)
     {
         Q_strncpy(m_szMapName, pMap->GetString("name"), sizeof(m_szMapName));
         KeyValues *pFavorites = pMap->FindKey("favorites");
-        m_bInFavorites = m_eSource == MODEL_FROM_FAVORITES_API_CALL || pFavorites && !pFavorites->IsEmpty();
+        m_bInFavorites = (m_eSource == MODEL_FROM_FAVORITES_API_CALL) || (pFavorites && !pFavorites->IsEmpty());
         KeyValues *pLibrary = pMap->FindKey("libraryEntries");
-        m_bInLibrary = m_eSource == MODEL_FROM_LIBRARY_API_CALL || pLibrary && !pLibrary->IsEmpty();
+        m_bInLibrary = (m_eSource == MODEL_FROM_LIBRARY_API_CALL) || (pLibrary && !pLibrary->IsEmpty());
         m_bMapFileNeedsUpdate = m_eSource == MODEL_FROM_LIBRARY_API_CALL;
     }
 

--- a/mp/src/game/client/momentum/mom_run_poster.cpp
+++ b/mp/src/game/client/momentum/mom_run_poster.cpp
@@ -292,7 +292,7 @@ void CRunPoster::CreateSessionCallback(KeyValues *pKv)
     if (pData)
     {
         m_uRunSessionID = pData->GetUint64("id");
-        ConColorMsg(2, COLOR_GREEN, "Got the run session ID! %u\n", m_uRunSessionID);
+        ConColorMsg(2, COLOR_GREEN, "Got the run session ID! %lld\n", m_uRunSessionID);
     }
     else if (pErr)
     {

--- a/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
@@ -865,7 +865,7 @@ void CLeaderboardsTimes::OnReplayDownloadEnd(KeyValues* pKvEnd)
         else
         {
             // MOM_TODO: show success on the progress bar here
-            DevLog("Successfully downloaded the replay with ID: %i\n", m_mapReplayDownloads[fileIndx]);
+            DevLog("Successfully downloaded the replay with ID: %lld\n", m_mapReplayDownloads[fileIndx]);
 
             // Play it
             CFmtStr command("mom_replay_play %s/%s-%lld%s\n", RECORDING_ONLINE_PATH, m_pParentPanel->MapName(), m_mapReplayDownloads[fileIndx], EXT_RECORDING_FILE);

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -3,7 +3,6 @@
 #include "mom_lobby_system.h"
 
 #include "filesystem.h"
-#include <cryptopp/base64.h>
 #include "ghost_client.h"
 #include "mom_online_ghost.h"
 #include "mom_system_saveloc.h"
@@ -11,6 +10,12 @@
 #include "mom_modulecomms.h"
 #include "mom_timer.h"
 #include "fmtstr.h"
+
+#include "tier0/valve_minmax_off.h"
+// This is wrapped by minmax_off due to Valve making a macro for min and max...
+#include <cryptopp/base64.h>
+// Now we can unwrap
+#include "tier0/valve_minmax_on.h"
 
 #include "tier0/memdbgon.h"
 

--- a/mp/src/game/shared/momentum/util/jsontokv.cpp
+++ b/mp/src/game/shared/momentum/util/jsontokv.cpp
@@ -1,8 +1,13 @@
 #include "cbase.h"
 
 #include "jsontokv.h"
-#include "rapidjson/document.h"
 #include "fmtstr.h"
+
+#include "tier0/valve_minmax_off.h"
+// This is wrapped by minmax_off due to Valve making a macro for min and max...
+#include "rapidjson/document.h"
+// Now we can unwrap
+#include "tier0/valve_minmax_on.h"
 
 #include "tier0/memdbgon.h"
 

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -14,9 +14,13 @@
 #include "materialsystem/imaterialvar.h"
 #endif
 
+#include "tier0/valve_minmax_off.h"
+// These are wrapped by minmax_off/on due to Valve making a macro for min and max...
 #include "cryptopp/sha.h"
 #include <cryptopp/files.h>
 #include <cryptopp/hex.h>
+// Now we can unwrap
+#include "tier0/valve_minmax_on.h"
 
 #include "tier0/memdbgon.h"
 


### PR DESCRIPTION
Which means we update from GCC 4.6 to 4.8, which allows us to use the `override` keyword and constructors within the same class, to name a few...

See the [Linux compile instructions](https://github.com/momentum-mod/game/wiki/Building-The-Game#linux) for the new workflow setup.

Closes #260 