### PR TITLE
Don't allow multiple weapons to be equipped at same slot

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -308,6 +308,25 @@ void CMomentumPlayer::FireGameEvent(IGameEvent *pEvent)
     }
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: Player reacts to bumping a weapon.
+// Input  : pWeapon - the weapon that the player bumped into.
+// Output : Returns true if player picked up the weapon
+//-----------------------------------------------------------------------------
+bool CMomentumPlayer::BumpWeapon(CBaseCombatWeapon *pWeapon)
+{
+    // Get the weapon that we currently have at that slot
+    CBaseCombatWeapon *pCurrWeapon = Weapon_GetSlot(pWeapon->GetSlot());
+    if (pCurrWeapon != nullptr)
+    {
+        // Switch to that weapon for convenience
+        Weapon_Switch(pCurrWeapon);
+        return false;
+    }
+    // Otherwise we can try to pick up that weapon
+    return BaseClass::BumpWeapon(pWeapon);
+}
+
 void CMomentumPlayer::FlashlightTurnOn()
 {
     // Emit sound by default

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -61,6 +61,9 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     void FireGameEvent(IGameEvent *pEvent) OVERRIDE;
 
+    // Make sure we don't pick up weapons we shouldn't (default behaviour is weird)
+    bool BumpWeapon(CBaseCombatWeapon *pWeapon) OVERRIDE;
+
     // MOM_TODO: This is called when the player spawns so that HUD elements can be updated
     // void InitHUD() OVERRIDE;
 


### PR DESCRIPTION
If it's attempted, switch to the weapon that's currently at that slot and leave the new weapon on the ground. Not sure if this is the exact behavior we want.

Closes #325