### PR TITLE
Goodbye, Bugfix_and_QoL

### DIFF
--- a/mp/game/momentum/resource/LeaderboardsScheme.res
+++ b/mp/game/momentum/resource/LeaderboardsScheme.res
@@ -1021,6 +1021,45 @@ Scheme
 				}
 			}
 		}
+        LeaderboardsPlayerBorder
+		{
+			"inset" "0 0 0 0"
+			Left
+			{
+				"1"
+				{
+					"color" "MomentumBlue"
+					"offset" "0 0"
+				}
+			}
+
+			Right
+			{
+				"1"
+				{
+					"color" "MomentumBlue"
+					"offset" "0 0"
+				}
+			}
+
+			Top
+			{
+				"1"
+				{
+					"color" "MomentumBlue"
+					"offset" "0 0"
+				}
+			}
+
+			Bottom
+			{
+				"1"
+				{
+					"color" "MomentumBlue"
+					"offset" "0 0"
+				}
+			}
+		}
 	}
 
 	

--- a/mp/game/momentum/resource/ui/Spectator.res
+++ b/mp/game/momentum/resource/ui/Spectator.res
@@ -79,24 +79,6 @@
         "tabPosition"		"0"
         "textAlignment"		"center"
     }
-    //"Map" label
-    "MapLabel"
-    {
-        "ControlName"		"Label"
-        "fieldName"			"MapLabel"
-        "xpos"				"10"
-        "ypos"				"12"
-        "wide"				"81"
-        "tall"				"15"
-        "autoResize"		"0"
-        "pinCorner"			"0"
-        "visible"			"1"
-        "enabled"			"1"
-        "textAlignment"		"west"
-        "dulltext"			"0"
-        "brighttext"		"0"
-        "auto_wide_tocontents" "1"
-    }
     
     "ClosePanel"
     {

--- a/mp/src/game/client/momentum/mom_api_models.cpp
+++ b/mp/src/game/client/momentum/mom_api_models.cpp
@@ -398,7 +398,7 @@ MapData::MapData(const MapData& src)
     m_MainTrack = src.m_MainTrack;
     m_Submitter = src.m_Submitter;
     m_vecCredits.RemoveAll();
-    m_vecCredits.AddMultipleToTail(src.m_vecCredits.Count(), src.m_vecCredits.Base());
+    m_vecCredits.AddVectorToTail(src.m_vecCredits);
     m_vecImages.RemoveAll();
     m_vecImages.AddVectorToTail(src.m_vecImages);
     m_Thumbnail = src.m_Thumbnail;
@@ -683,7 +683,7 @@ MapData& MapData::operator=(const MapData& src)
     if (src.m_vecCredits.Count())
     {
         m_vecCredits.RemoveAll();
-        m_vecCredits.AddMultipleToTail(src.m_vecCredits.Count(), src.m_vecCredits.Base());
+        m_vecCredits.AddVectorToTail(src.m_vecCredits);
     }
     if (src.m_vecImages.Count())
     {

--- a/mp/src/game/client/momentum/mom_map_cache.cpp
+++ b/mp/src/game/client/momentum/mom_map_cache.cpp
@@ -786,11 +786,19 @@ void CMapCache::LoadMapCacheFromDisk()
     pMapData->UsesEscapeSequences(true);
     if (pMapData->LoadFromFile(g_pFullFileSystem, MAP_CACHE_FILE_NAME, "MOD"))
     {
-        AddMapsToCache(pMapData, MODEL_FROM_DISK);
+        KeyValues *pVersion = pMapData->FindKey(MOM_CURRENT_VERSION);
+        if (pVersion)
+        {
+            AddMapsToCache(pVersion, MODEL_FROM_DISK);
+        }
+        else
+        {
+            Log("Map cache file exists but is an older version, ignoring it...\n");
+        }
     }
     else
     {
-        DevLog(2, "Map cache file doesn't exist, creating it...\n");
+        Log("Map cache file doesn't exist, creating it...\n");
     }
 }
 
@@ -799,9 +807,12 @@ void CMapCache::SaveMapCacheToDisk()
     KeyValuesAD pMapData("MapCacheData");
     pMapData->UsesEscapeSequences(true);
 
+    KeyValues *pVersion = new KeyValues(MOM_CURRENT_VERSION);
+    pMapData->AddSubKey(pVersion);
+
     FOR_EACH_MAP(m_mapMapCache, i)
     {
-        KeyValues *pMap = pMapData->CreateNewKey();
+        KeyValues *pMap = pVersion->CreateNewKey();
         m_mapMapCache[i]->ToKV(pMap);
     }
 

--- a/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
@@ -90,6 +90,7 @@ CLeaderboardsTimes::CLeaderboardsTimes(CClientTimesDisplay* pParent) : BaseClass
     SetDefLessFunc(m_mapAvatarsToImageList);
     SetDefLessFunc(m_mapReplayDownloads);
 
+    pPlayerBorder = nullptr;
     m_pImageList = nullptr;
     LevelInit();
 }
@@ -506,9 +507,8 @@ void CLeaderboardsTimes::OnlineTimesVectorToLeaderboards(TimeType_t type)
                 pList->ModifyItem(itemID, m_iSectionId, runEntry->m_kv);
             }
 
-            // MOM_TODO: highlight the local player's thing (some outline?), if it's in the list!
-            //if (runEntry->steamid == SteamUser()->GetSteamID().ConvertToUint64())
-            //    pList->SetBorderForItem(itemID, someBorder);
+            if (runEntry->steamid == SteamUser()->GetSteamID().ConvertToUint64() && pPlayerBorder)
+                pList->SetItemBorder(itemID, pPlayerBorder);
         }
 
         SetPlaceColors(pList, type);
@@ -955,6 +955,8 @@ void CLeaderboardsTimes::ApplySchemeSettings(vgui::IScheme* pScheme)
     m_cFirstPlace = pScheme->GetColor("FirstPlace", Color(240, 210, 147, 50));
     m_cSecondPlace = pScheme->GetColor("SecondPlace", Color(175, 175, 175, 50));
     m_cThirdPlace = pScheme->GetColor("ThirdPlace", Color(205, 127, 50, 50));
+
+    pPlayerBorder = pScheme->GetBorder("LeaderboardsPlayerBorder");
 
     const char *columnNames[] = { DATESTRING, RANKSTRING, TIMESTRING };
 

--- a/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.h
@@ -145,6 +145,7 @@ private:
     };
 
     Color m_cFirstPlace, m_cSecondPlace, m_cThirdPlace;
+    vgui::IBorder *pPlayerBorder;
 
     Panel *m_pCurrentLeaderboards;
     CClientTimesDisplay *m_pParentPanel;

--- a/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.cpp
+++ b/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.cpp
@@ -64,7 +64,6 @@ CMOMSpectatorGUI::CMOMSpectatorGUI(IViewPort *pViewPort) : EditablePanel(nullptr
     m_pTopBar = new Panel(this, "TopBar");
     m_pPlayerLabel = new Label(this, "PlayerLabel", "#MOM_ReplayPlayer");
     m_pReplayLabel = new Label(this, "ReplayLabel", "#MOM_WatchingReplay");
-    m_pMapLabel = new Label(this, "MapLabel", "#Spec_Map");
     m_pTimeLabel = new Label(this, "TimeLabel", "#MOM_MF_RunTime");
     m_pGainControlLabel = new Label(this, "DetachInfo", "#MOM_SpecGUI_GainControl");
     m_pCloseButton = new ImagePanel(this, "ClosePanel");
@@ -300,11 +299,6 @@ void CMOMSpectatorGUI::Update()
                 // Close button tooltip
                 m_pCloseButton->GetTooltip()->SetText("#MOM_SpecGUI_StopPlayback");
 
-                // Show the current map
-                wchar_t wMapName[BUFSIZELOCL];
-                ANSI_TO_UNICODE(g_pGameRules->MapName(), wMapName);
-                m_pMapLabel->SetText(CConstructLocalizedString(m_pwSpecMap, wMapName));
-
                 m_pShowControls->SetVisible(true);
 
                 if (m_pReplayControls && !m_pReplayControls->IsVisible() && !m_pReplayControls->WasClosed())
@@ -318,7 +312,6 @@ void CMOMSpectatorGUI::Update()
             {
                 // "REPLAY" label
                 m_pReplayLabel->SetText(m_pwWatchingGhost);
-                m_pMapLabel->SetText("");
                 m_pTimeLabel->SetText("");
 
                 // Close button tooltip
@@ -335,7 +328,6 @@ void CMOMSpectatorGUI::Update()
         else
         {
             m_pReplayLabel->SetText("");
-            m_pMapLabel->SetText("");
             m_pTimeLabel->SetText("");
             m_pPlayerLabel->SetText("");
         }

--- a/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.h
+++ b/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.h
@@ -49,7 +49,6 @@ class CMOMSpectatorGUI : public vgui::EditablePanel, public IViewPortPanel, publ
     vgui::Label *m_pPlayerLabel;
     vgui::Label *m_pReplayLabel;
     vgui::Label *m_pGainControlLabel;
-    vgui::Label *m_pMapLabel;
     vgui::Label *m_pTimeLabel;
 
     Color m_cBarColor;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1022,7 +1022,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
         case ZONE_TYPE_START:
             // g_pMomentumTimer->CalculateTickIntervalOffset(this, ZONE_TYPE_START, 1);
             g_pMomentumTimer->TryStart(this, true);
-            if (m_bShouldLimitPlayerSpeed && !m_bHasPracticeMode)
+            if (m_bShouldLimitPlayerSpeed && !m_bHasPracticeMode && !g_pMOMSavelocSystem->IsUsingSaveLocMenu())
             {
                 const auto pStart = static_cast<CTriggerTimerStart*>(pTrigger);
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -249,6 +249,7 @@ CMomentumPlayer::~CMomentumPlayer()
     RemoveAllOnehops();
 
     // Clear our spectating status just in case we leave the map while spectating
+    StopObserverMode();
     g_pMomentumGhostClient->SetSpectatorTarget(k_steamIDNil, false, true);
 }
 

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -404,7 +404,7 @@ void CTriggerMomentumTeleport::HandleTeleport(CBaseEntity *pOther)
 {
     if (pOther)
     {
-        if (m_hDestinationEnt.Get())
+        if (!m_hDestinationEnt.Get())
         {
             if (m_target != NULL_STRING)
                 m_hDestinationEnt = gEntList.FindEntityByName(nullptr, m_target, nullptr, pOther, pOther);

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -172,4 +172,4 @@ static void OnTickRateChange(IConVar *var, const char* pOldValue, float fOldValu
 
 static ConVar intervalPerTick("sv_interval_per_tick", "0.015", 0,
                               "Changes the interval per tick of the engine. Interval per tick is 1/tickrate, so 100 tickrate = 0.01",
-                              OnTickRateChange);
+                              true, 0.001f, true, 0.1f, OnTickRateChange);

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -172,7 +172,7 @@ bool MomUtil::GetTimeAgoString(time_t *input, char* pOut, size_t outLen)
         count = diff;
     }
 
-    if (!pUnitString || count == 0)
+    if (!pUnitString || count <= 0)
         Q_strncpy(pOut, "just now", outLen);
     else
         Q_snprintf(pOut, outLen, "%i %s%s ago", count, pUnitString, (count > 1 ? "s" : ""));

--- a/mp/src/public/vgui_controls/SectionedListPanel.h
+++ b/mp/src/public/vgui_controls/SectionedListPanel.h
@@ -213,6 +213,9 @@ public:
 
 	ScrollBar *GetScrollBar( void ) { return m_pScrollBar; }
 
+    virtual void SetItemBorder(int itemID, vgui::IBorder *pBorder);
+    virtual vgui::IBorder *GetItemBorder(int itemID);
+
 protected:
 	virtual void PerformLayout();
 	virtual void ApplySchemeSettings(IScheme *pScheme);

--- a/mp/src/vgui2/vgui_controls/SectionedListPanel.cpp
+++ b/mp/src/vgui2/vgui_controls/SectionedListPanel.cpp
@@ -1654,6 +1654,25 @@ void SectionedListPanel::MoveSelectionUp( void )
 	ScrollToItem(newItemID);
 }
 
+void SectionedListPanel::SetItemBorder(int itemID, IBorder *pBorder)
+{
+    Assert(m_Items.IsValidIndex(itemID));
+    if (!m_Items.IsValidIndex(itemID))
+        return;
+
+    m_Items[itemID]->SetBorder(pBorder);
+    m_Items[itemID]->InvalidateLayout();
+}
+
+IBorder *SectionedListPanel::GetItemBorder(int itemID)
+{
+    Assert(m_Items.IsValidIndex(itemID));
+    if (!m_Items.IsValidIndex(itemID))
+        return nullptr;
+
+    return m_Items[itemID]->GetBorder();
+}
+
 void SectionedListPanel::NavigateTo( void )
 {
 	BaseClass::NavigateTo();


### PR DESCRIPTION
Last merge from this branch, as we're moving to an individual card-per-branch workflow.

# Added
Outline to local player's time on the leaderboards

# Improved
Capped sv_interval_per_tick to the engine max and minimum
Do not limit player speed if using a saveloc out of the start zone
Versioned the map-cache.dat file so any game updates force it to refresh

# Fixed
Fixed player spectate state not resetting on map shutdown
Fixed time-ago strings showing "-1 seconds ago"
Fixed momentum teleport triggers

# Removed
Removed redundant map label inside spectator GUI
