### PR TITLE
Fix lobby member panel duplicating names

### DIFF
--- a/mp/src/game/client/momentum/mom_system_discord.cpp
+++ b/mp/src/game/client/momentum/mom_system_discord.cpp
@@ -347,7 +347,7 @@ bool CMomentumDiscord::JoinMapFromUserSteamID(uint64 steamID)
     CSteamID targetPlayerSteamID = CSteamID(steamID);
     const char *targetMapName = GetMapOfPlayerFromSteamID(&targetPlayerSteamID);
 
-    if (!targetMapName[0])
+    if (!(targetMapName && targetMapName[0]))
     {
         return false;
     }

--- a/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
@@ -154,6 +154,8 @@ void LobbyMembersPanel::UpdateLobbyMemberData(const CSteamID& memberID)
             pData->SetBool("isOwner", memberID == owner);
 
             const char *pMap = SteamMatchmaking()->GetLobbyMemberData(m_idLobby, memberID, LOBBY_DATA_MAP);
+            if (!pMap)
+                pMap = "";
             const auto bMainMenu = Q_strlen(pMap) == 0;
             auto bCredits = false;
             auto bBackground = false;
@@ -167,7 +169,7 @@ void LobbyMembersPanel::UpdateLobbyMemberData(const CSteamID& memberID)
             pData->SetString("map", bMainMenu ? "Main Menu" : pMap);
 
             const auto pSpec = SteamMatchmaking()->GetLobbyMemberData(m_idLobby, memberID, LOBBY_DATA_IS_SPEC);
-            if (pSpec[0])
+            if (pSpec && pSpec[0])
                 pData->SetString("state", "#MOM_Lobby_Member_Spectating");
             else if (!(bMainMenu || bCredits || bBackground))
                 pData->SetString("state", "#MOM_ReplayStatusPlaying");

--- a/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
@@ -120,8 +120,12 @@ void LobbyMembersPanel::OnLobbyChatUpdate(LobbyChatUpdate_t* pParam)
     else if (pParam->m_rgfChatMemberStateChange & (k_EChatMemberStateChangeLeft | k_EChatMemberStateChangeDisconnected))
     {
         // Get em outta here
-        m_pMemberList->RemoveItem(FindItemIDForLobbyMember(pParam->m_ulSteamIDUserChanged));
-        UpdateLobbyMemberCount();
+        const auto itemID = FindItemIDForLobbyMember(pParam->m_ulSteamIDUserChanged);
+        if (itemID > -1)
+        {
+            m_pMemberList->RemoveItem(itemID);
+            UpdateLobbyMemberCount();
+        }
     }
 }
 

--- a/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
@@ -116,6 +116,7 @@ void LobbyMembersPanel::OnLobbyChatUpdate(LobbyChatUpdate_t* pParam)
         // Add this user to the panel
         AddLobbyMember(CSteamID(pParam->m_ulSteamIDUserChanged));
         UpdateLobbyMemberCount();
+        m_pMemberList->InvalidateLayout(true);
     }
     else if (pParam->m_rgfChatMemberStateChange & (k_EChatMemberStateChangeLeft | k_EChatMemberStateChangeDisconnected))
     {
@@ -125,6 +126,7 @@ void LobbyMembersPanel::OnLobbyChatUpdate(LobbyChatUpdate_t* pParam)
         {
             m_pMemberList->RemoveItem(itemID);
             UpdateLobbyMemberCount();
+            m_pMemberList->SortList();
         }
     }
 }
@@ -235,12 +237,16 @@ int LobbyMembersPanel::StaticLobbyMemberSortFunc(ListPanel* list, const ListPane
 
 int LobbyMembersPanel::FindItemIDForLobbyMember(const uint64 steamID)
 {
-    for (int i = 0; i <= m_pMemberList->GetItemCount(); i++)
+    for (int row = 0; row <= m_pMemberList->GetItemCount(); row++)
     {
-        const auto pKv = m_pMemberList->GetItem(i);
-        if (pKv && pKv->GetUint64("steamid") == steamID)
+        const auto itemID = m_pMemberList->GetItemIDFromRow(row);
+        if (itemID > -1)
         {
-            return i;
+            const auto pKv = m_pMemberList->GetItem(itemID);
+            if (pKv && pKv->GetUint64("steamid") == steamID)
+            {
+                return itemID;
+            }
         }
     }
     return -1;

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -871,7 +871,7 @@ bool CMomentumLobbySystem::GetIsSpectatingFromMemberData(const CSteamID &who)
 {
     CHECK_STEAM_API_B(SteamMatchmaking());
     const char* specChar = SteamMatchmaking()->GetLobbyMemberData(m_sLobbyID, who, LOBBY_DATA_IS_SPEC);
-    return specChar[0] ? true : false;
+    return (specChar && specChar[0]) ? true : false;
 }
 
 bool CMomentumLobbySystem::SendDecalPacket(DecalPacket_t *packet)


### PR DESCRIPTION
Main culprit was the FindItemIDForLobbyMember method not properly using the itemID versus row syntax valve has in VGUI.

Fixed some crashes with lobbies due to lack of null checks and not checking the itemID when removing users from the panel.

Closes #297 