### PR TITLE
Add Flashlights to Online Ghosts

### DIFF
--- a/mp/src/game/client/c_baseplayer.cpp
+++ b/mp/src/game/client/c_baseplayer.cpp
@@ -1250,7 +1250,7 @@ void C_BasePlayer::UpdateFlashlight()
 	{
 		// Turned off the flashlight; delete it.
 		delete m_pFlashlight;
-		m_pFlashlight = NULL;
+		m_pFlashlight = nullptr;
 	}
 }
 
@@ -1263,11 +1263,11 @@ void C_BasePlayer::Flashlight( void )
 	UpdateFlashlight();
 
 	// Check for muzzle flash and apply to view model
-	C_BaseAnimating *ve = this;
+	/*C_BaseAnimating *ve = this;
 	if ( GetObserverMode() == OBS_MODE_IN_EYE )
 	{
 		ve = dynamic_cast< C_BaseAnimating* >( GetObserverTarget() );
-	}
+	}*/
 }
 
 

--- a/mp/src/game/client/momentum/c_mom_online_ghost.cpp
+++ b/mp/src/game/client/momentum/c_mom_online_ghost.cpp
@@ -7,7 +7,10 @@
 
 IMPLEMENT_CLIENTCLASS_DT(C_MomentumOnlineGhostEntity, DT_MOM_OnlineGhost, CMomentumOnlineGhostEntity)
     RecvPropInt(RECVINFO(m_uiAccountID), SPROP_UNSIGNED),
-    RecvPropBool(RECVINFO(m_bSpectating))
+    RecvPropBool(RECVINFO(m_bSpectating)),
+    RecvPropFloat(RECVINFO(m_vecViewOffset[0])),
+    RecvPropFloat(RECVINFO(m_vecViewOffset[1])),
+    RecvPropFloat(RECVINFO(m_vecViewOffset[2])),
 END_RECV_TABLE();
 
 C_MomentumOnlineGhostEntity::C_MomentumOnlineGhostEntity(): m_uiAccountID(0), m_bSpectating(false), m_pEntityPanel(nullptr)

--- a/mp/src/game/client/momentum/c_mom_online_ghost.h
+++ b/mp/src/game/client/momentum/c_mom_online_ghost.h
@@ -26,7 +26,10 @@ public:
 
     RUN_ENT_TYPE GetEntType() OVERRIDE { return RUN_ENT_ONLINE; }
 
-private:
+    void Simulate() OVERRIDE;
+    void CreateLightEffects() OVERRIDE;
 
+private:
+    CFlashlightEffect *m_pFlashlight;
     CGhostEntityPanel *m_pEntityPanel;
 };

--- a/mp/src/game/server/momentum/mom_online_ghost.cpp
+++ b/mp/src/game/server/momentum/mom_online_ghost.cpp
@@ -18,6 +18,9 @@ LINK_ENTITY_TO_CLASS(mom_online_ghost, CMomentumOnlineGhostEntity);
 IMPLEMENT_SERVERCLASS_ST(CMomentumOnlineGhostEntity, DT_MOM_OnlineGhost)
 SendPropInt(SENDINFO(m_uiAccountID), -1, SPROP_UNSIGNED),
 SendPropBool(SENDINFO(m_bSpectating)),
+SendPropFloat(SENDINFO_VECTORELEM(m_vecViewOffset, 0), 8, SPROP_ROUNDDOWN, -32.0, 32.0f),
+SendPropFloat(SENDINFO_VECTORELEM(m_vecViewOffset, 1), 8, SPROP_ROUNDDOWN, -32.0, 32.0f),
+SendPropFloat(SENDINFO_VECTORELEM(m_vecViewOffset, 2), 20, SPROP_CHANGES_OFTEN, 0.0f, 256.0f),
 END_SEND_TABLE();
 
 BEGIN_DATADESC(CMomentumOnlineGhostEntity)

--- a/mp/src/game/server/momentum/mom_online_ghost.cpp
+++ b/mp/src/game/server/momentum/mom_online_ghost.cpp
@@ -48,6 +48,8 @@ static MAKE_TOGGLE_CONVAR_C(mom_ghost_online_trail_enable, "1", FCVAR_REPLICATED
                             "Toggles drawing other ghost's trails. 0 = OFF, 1 = ON\n", RefreshGhostData);
 extern ConVar mom_paintgun_shoot_sound;
 
+static MAKE_TOGGLE_CONVAR_C(mom_ghost_online_flashlights_enable, "1", FCVAR_ARCHIVE | FCVAR_REPLICATED, "Toggles drawing other ghosts' flashlights. 0 = OFF, 1 = ON\n", RefreshGhostData);
+
 CMomentumOnlineGhostEntity::CMomentumOnlineGhostEntity(): m_pCurrentFrame(nullptr), m_pNextFrame(nullptr)
 {
     ListenForGameEvent("mapfinished_panel_closed");
@@ -395,6 +397,14 @@ void CMomentumOnlineGhostEntity::SetGhostColor(const uint32 newHexColor)
 
 void CMomentumOnlineGhostEntity::SetGhostFlashlight(bool bEnable)
 {
+    if (!mom_ghost_online_flashlights_enable.GetBool())
+    {
+        // In case they have it on still
+        if (GetEffects() & EF_DIMLIGHT)
+            RemoveEffects(EF_DIMLIGHT);
+        return;
+    }
+
     if (bEnable)
     {
         AddEffects(EF_DIMLIGHT);

--- a/mp/src/game/server/momentum/mom_online_ghost.h
+++ b/mp/src/game/server/momentum/mom_online_ghost.h
@@ -47,6 +47,8 @@ public:
     CNetworkVar(uint32, m_uiAccountID);
     CNetworkVar(bool, m_bSpectating);
 
+    IMPLEMENT_NETWORK_VAR_FOR_DERIVED(m_vecViewOffset);
+
     QAngle m_vecLookAngles; // Used for storage reasons
 
 protected:


### PR DESCRIPTION
Instead of boring normal dimlights, full blown flashlights are supported.

Control this with `mom_online_ghost_flashlights_enable [0/1]`.

### Only tested with two people in the lobby! Dunno how well it performs at 10+ lobby members....