### PR TITLE
Game Mode Interface

### DIFF
--- a/mp/src/game/client/client_momentum.vpc
+++ b/mp/src/game/client/client_momentum.vpc
@@ -288,6 +288,8 @@ $Project "Client (Momentum)"
                 }
             }
 
+            $File   "$SRCDIR\game\shared\momentum\mom_system_gamemode.cpp"
+            $File   "$SRCDIR\game\shared\momentum\mom_system_gamemode.h"
             $File   "$SRCDIR\game\shared\momentum\mom_grenade_projectile.cpp"
             $File   "$SRCDIR\game\shared\momentum\mom_grenade_projectile.h"
             $File   "$SRCDIR\game\shared\momentum\mom_gamemovement.cpp"

--- a/mp/src/game/client/momentum/mom_map_cache.cpp
+++ b/mp/src/game/client/momentum/mom_map_cache.cpp
@@ -9,6 +9,7 @@
 
 #include "filesystem.h"
 #include "fmtstr.h"
+#include "mom_system_gamemode.h"
 
 #include "tier0/valve_minmax_off.h"
 // These two are wrapped by minmax_off due to Valve making a macro for min and max...
@@ -370,47 +371,16 @@ uint32 CMapCache::GetUpdateIntervalForMap(MapData* pData)
 
 void CMapCache::SetMapGamemode(const char *pMapName /* = nullptr*/)
 {
-    ConVarRef gm("mom_gamemode");
-
     if (!pMapName)
         pMapName = MapName();
 
-    if (!pMapName)
-    {
-        gm.SetValue(GAMEMODE_UNKNOWN);
-        return;
-    }
-
     if (m_pCurrentMapData)
     {
-        gm.SetValue(m_pCurrentMapData->m_eType);
+        g_pGameModeSystem->SetGameMode(m_pCurrentMapData->m_eType);
     }
     else // Backup method, use map name for unofficial maps
     {
-        if (!Q_strnicmp(pMapName, "surf_", 5))
-        {
-            gm.SetValue(GAMEMODE_SURF);
-        }
-        else if (!Q_strnicmp(pMapName, "bhop_", 5))
-        {
-            gm.SetValue(GAMEMODE_BHOP);
-        }
-        else if (!Q_strnicmp(pMapName, "kz_", 3))
-        {
-            gm.SetValue(GAMEMODE_KZ);
-        }
-        else if (!Q_strnicmp(pMapName, "jump_", 5))
-        {
-            gm.SetValue(GAMEMODE_RJ);
-        }
-        else if (!Q_strnicmp(pMapName, "tricksurf_", 10))
-        {
-            gm.SetValue(GAMEMODE_TRICKSURF);
-        }
-        else
-        {
-            gm.SetValue(GAMEMODE_UNKNOWN);
-        }
+        g_pGameModeSystem->SetGameModeFromMapName(pMapName);
     }
 }
 

--- a/mp/src/game/client/momentum/mom_system_discord.cpp
+++ b/mp/src/game/client/momentum/mom_system_discord.cpp
@@ -1,6 +1,7 @@
 #include "cbase.h"
 
 #include "mom_system_discord.h"
+#include "mom_system_gamemode.h"
 
 #include "discord_rpc.h"
 
@@ -18,17 +19,6 @@
 
 #define MAIN_MENU_STR "Main Menu"
 #define MOM_ICON_LOGO "mom"
-
-const char * const szGamemodeIcons[]
-{
-    MOM_ICON_LOGO,
-    "mom_icon_surf",
-    "mom_icon_bhop",
-    "mom_icon_kz",
-    "mom_icon_rj",
-    "mom_icon_tricksurf",
-    "mom_icon_trikz"
-};
 
 // How many frames to wait before updating discord
 // (some things are still updated each frame such as checking callbacks)
@@ -135,15 +125,13 @@ void CMomentumDiscord::LevelInitPostEntity()
 
     m_bInMap = true;
 
-    const int gameMode = clamp<int>(ConVarRef("mom_gamemode").GetInt(), GAMEMODE_UNKNOWN, GAMEMODE_COUNT - 1);
-    if (gameMode == GAMEMODE_UNKNOWN)
+    V_strncpy(m_szDiscordLargeImageKey, g_pGameModeSystem->GetGameMode()->GetDiscordIcon(), sizeof(m_szDiscordLargeImageKey));
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_UNKNOWN))
     {
-        V_strncpy(m_szDiscordLargeImageKey, MOM_ICON_LOGO, sizeof(m_szDiscordLargeImageKey));
         m_szDiscordSmallImageKey[0] = '\0';
     }
     else
     {
-        V_strncpy(m_szDiscordLargeImageKey, szGamemodeIcons[gameMode], sizeof(m_szDiscordLargeImageKey));
         V_strncpy(m_szDiscordSmallImageKey, MOM_ICON_LOGO, sizeof(m_szDiscordSmallImageKey));
     }
 

--- a/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
@@ -23,6 +23,7 @@
 #include "run/mom_replay_factory.h"
 #include "filesystem.h"
 #include "fmtstr.h"
+#include "mom_system_gamemode.h"
 
 #include "tier0/memdbgon.h"
 
@@ -528,7 +529,6 @@ void CLeaderboardsTimes::OnlineTimesVectorToLeaderboards(TimeType_t type)
 
 bool CLeaderboardsTimes::GetPlayerTimes(KeyValues* outPlayerInfo, bool fullUpdate)
 {
-    ConVarRef gm("mom_gamemode");
     if (!outPlayerInfo)
         return false;
 
@@ -539,7 +539,7 @@ bool CLeaderboardsTimes::GetPlayerTimes(KeyValues* outPlayerInfo, bool fullUpdat
     LoadLocalTimes(pLocal);
     pLeaderboards->AddSubKey(pLocal);
 
-    if (gm.GetInt() > GAMEMODE_UNKNOWN)
+    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_UNKNOWN))
     {
         for (int i = 1; i < TIMES_COUNT; i++) // Skip over local
         {

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -5,6 +5,7 @@
 #include "filesystem.h"
 #include "ghost_client.h"
 #include "mom_online_ghost.h"
+#include "mom_system_gamemode.h"
 #include "mom_system_saveloc.h"
 #include "mom_player_shared.h"
 #include "mom_modulecomms.h"
@@ -968,31 +969,11 @@ void CMomentumLobbySystem::OnLobbyTypeChanged(int newType)
 void CMomentumLobbySystem::SetGameInfoStatus()
 {
     CHECK_STEAM_API(SteamFriends());
-    ConVarRef gm("mom_gamemode");
-    const char *gameMode;
-    switch (gm.GetInt())
-    {
-    case GAMEMODE_SURF:
-        gameMode = "Surfing";
-        break;
-    case GAMEMODE_BHOP:
-        gameMode = "Bhopping";
-        break;
-    case GAMEMODE_KZ:
-        gameMode = "Climbing";
-        break;
-    case GAMEMODE_RJ:
-        gameMode = "Jumping";
-        break;
-    case GAMEMODE_UNKNOWN:
-    default:
-        gameMode = "Playing";
-        break;
-    }
+    CHECK_STEAM_API(SteamMatchmaking());
     char gameInfoStr[64];// , connectStr[64];
     int numPlayers = SteamMatchmaking()->GetNumLobbyMembers(m_sLobbyID);
     V_snprintf(gameInfoStr, sizeof(gameInfoStr), numPlayers <= 1 ? "%s on %s" : "%s on %s with %i other player%s",
-               gameMode, STRING(gpGlobals->mapname), numPlayers - 1, numPlayers > 2 ? "s" : "");
+               g_pGameModeSystem->GetGameMode()->GetStatusString(), STRING(gpGlobals->mapname), numPlayers - 1, numPlayers > 2 ? "s" : "");
     //V_snprintf(connectStr, 64, "+connect_lobby %llu +map %s", m_sLobbyID, gpGlobals->mapname);
 
     //SteamFriends()->SetRichPresence("connect", connectStr);

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -13,6 +13,7 @@
 #include "player_command.h"
 #include "predicted_viewmodel.h"
 #include "weapon/weapon_base_gun.h"
+#include "mom_system_gamemode.h"
 #include "mom_system_saveloc.h"
 #include "util/mom_util.h"
 #include "mom_replay_system.h"
@@ -502,7 +503,7 @@ void CMomentumPlayer::Spawn()
     // Reset current checkpoint trigger upon spawn
     m_CurrentProgress.Term();
 
-    g_pMomentumTimer->OnPlayerSpawn(this);
+    g_pGameModeSystem->GetGameMode()->OnPlayerSpawn(this);
 }
 
 // Obtains a player's previous origin X ticks backwards (0 is still previous, depends when this is called ofc!)
@@ -532,6 +533,12 @@ CBaseEntity *CMomentumPlayer::EntSelectSpawnPoint()
 
     Warning("No valid spawn point found!\n");
     return Instance(INDEXENT(0));
+}
+
+void CMomentumPlayer::SetAutoBhopEnabled(bool bEnable)
+{
+    m_bAutoBhop = bEnable;
+    DevLog("%s autobhop\n", bEnable ? "Enabled" : "Disabled");
 }
 
 void CMomentumPlayer::OnJump()
@@ -1083,17 +1090,6 @@ void CMomentumPlayer::Touch(CBaseEntity *pOther)
 
     if (g_MOMBlockFixer->IsBhopBlock(pOther->entindex()))
         g_MOMBlockFixer->PlayerTouch(this, pOther);
-}
-
-void CMomentumPlayer::EnableAutoBhop()
-{
-    m_bAutoBhop = true;
-    DevLog("Enabled autobhop\n");
-}
-void CMomentumPlayer::DisableAutoBhop()
-{
-    m_bAutoBhop = false;
-    DevLog("Disabled autobhop\n");
 }
 
 void CMomentumPlayer::UpdateRunStats()

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -77,8 +77,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     // SPAWNING
     CBaseEntity *EntSelectSpawnPoint() OVERRIDE;
 
-    void EnableAutoBhop();
-    void DisableAutoBhop();
+    void SetAutoBhopEnabled(bool bEnable);
     bool HasAutoBhop() const { return m_bAutoBhop; }
     bool DidPlayerBhop() const { return m_bDidPlayerBhop; }
     // think function for detecting if player bhopped

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -450,8 +450,6 @@ void CMOMSaveLocSystem::SetUsingSavelocMenu(bool bIsUsingSLMenu)
 
 void CMOMSaveLocSystem::CheckTimer()
 {
-    // static ConVarRef gamemode("mom_gamemode");
-
     if (g_pMomentumTimer->IsRunning())
     {
 

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -36,7 +36,6 @@ CMomentumTimer::CMomentumTimer() : CAutoGameSystemPerFrame("CMomentumTimer"),
 
 void CMomentumTimer::LevelInitPostEntity()
 {
-    SetGameModeConVars();
     m_bWasCheatsMsgShown = false;
 }
 
@@ -172,23 +171,6 @@ void CMomentumTimer::Reset(CMomentumPlayer *pPlayer)
 
     // Reset our CanStart bool
     m_bCanStart = true;
-}
-
-void CMomentumTimer::OnPlayerSpawn(CMomentumPlayer *pPlayer)
-{
-    // MOM_TODO
-    // If we do implement a gamemode interface this would be much better suited there
-    static ConVarRef mom_gamemode("mom_gamemode");
-    switch (mom_gamemode.GetInt())
-    {
-    case GAMEMODE_KZ:
-    case GAMEMODE_RJ:
-        pPlayer->DisableAutoBhop();
-        break;
-    default:
-        pPlayer->EnableAutoBhop();
-        break;
-    }
 }
 
 void CMomentumTimer::TryStart(CMomentumPlayer *pPlayer, bool bUseStartZoneOffset)
@@ -343,67 +325,6 @@ bool CTimeTriggerTraceEnum::EnumEntity(IHandleEntity *pHandleEntity)
     }
 
     return false;
-}
-
-// set ConVars according to Gamemode. Tickrate is by in tickset.h
-void CMomentumTimer::SetGameModeConVars()
-{
-    ConVarRef gm("mom_gamemode");
-    switch (gm.GetInt())
-    {
-    case GAMEMODE_SURF:
-        sv_maxvelocity.SetValue(3500);
-        sv_airaccelerate.SetValue(150);
-        sv_accelerate.SetValue(5);
-        sv_maxspeed.SetValue(260);
-        break;
-    case GAMEMODE_BHOP:
-        sv_maxvelocity.SetValue(100000);
-        sv_airaccelerate.SetValue(1000);
-        sv_accelerate.SetValue(5);
-        sv_maxspeed.SetValue(260);
-        break;
-    case GAMEMODE_KZ:
-        sv_maxvelocity.SetValue(3500);
-        sv_airaccelerate.SetValue(100);
-        sv_accelerate.SetValue(5);
-        sv_maxspeed.SetValue(250);
-        break;
-    case GAMEMODE_RJ:
-        sv_maxvelocity.SetValue(3500);
-        sv_airaccelerate.SetValue(10);
-        sv_accelerate.SetValue(10);
-        sv_maxspeed.SetValue(240);
-        break;
-    case GAMEMODE_TRICKSURF:
-        sv_maxvelocity.SetValue(100000);
-        sv_airaccelerate.SetValue(1000);
-        sv_accelerate.SetValue(10);
-        sv_maxspeed.SetValue(260);
-        break;
-    case GAMEMODE_UNKNOWN:
-        sv_maxvelocity.SetValue(3500);
-        sv_airaccelerate.SetValue(150);
-        sv_accelerate.SetValue(5);
-        sv_maxspeed.SetValue(260);
-        break;
-    default:
-        DevWarning("[%i] GameMode not defined.\n", gm.GetInt());
-        break;
-    }
-
-    PrintGameModeConVars();
-}
-
-void CMomentumTimer::PrintGameModeConVars()
-{
-    const auto pStrToPrint = "Set game mode ConVars:\n\n"
-            "sv_maxvelocity: %i\n"
-            "sv_airaccelerate: %i\n"
-            "sv_maxspeed: %i\n"
-            "sv_gravity: %i\n"
-            "sv_friction: %i\n";
-    Msg(pStrToPrint, sv_maxvelocity.GetInt(), sv_airaccelerate.GetInt(), sv_accelerate.GetInt(), sv_maxspeed.GetInt(), sv_gravity.GetInt(), sv_friction.GetInt());
 }
 
 // Practice mode that stops the timer and allows the player to noclip.
@@ -585,11 +506,6 @@ CON_COMMAND_F(mom_stage_tele, "Teleports the player to the desired stage. Stops 
             Warning("Could not teleport to stage %i! Perhaps it doesn't exist?\n", desiredIndex);
         }
     }
-}
-
-CON_COMMAND(mom_print_gamemode_vars, "Prints out the currently set values for commands like sv_maxvelocity, airaccel, etc")
-{
-    g_pMomentumTimer->PrintGameModeConVars();
 }
 
 static CMomentumTimer s_Timer;

--- a/mp/src/game/server/momentum/mom_timer.h
+++ b/mp/src/game/server/momentum/mom_timer.h
@@ -57,9 +57,6 @@ class CMomentumTimer : public CAutoGameSystemPerFrame
     void EnablePractice(CMomentumPlayer *pPlayer);
     void DisablePractice(CMomentumPlayer *pPlayer);
 
-    void SetGameModeConVars();
-    void PrintGameModeConVars();
-
     int GetTrackNumber() const { return m_iTrackNumber; }
 
     bool ShouldUseStartZoneOffset() const { return m_bShouldUseStartZoneOffset; }
@@ -69,8 +66,6 @@ class CMomentumTimer : public CAutoGameSystemPerFrame
     // creates fraction of a tick to be used as a time "offset" in precicely calculating the real run time.
     void CalculateTickIntervalOffset(CMomentumPlayer *pPlayer, int zoneType, int iZoneNumber);
     void SetIntervalOffset(int stage, float offset) { m_flTickOffsetFix[stage] = offset; }
-
-    void OnPlayerSpawn(CMomentumPlayer *pPlayer);
 
     // tries to start timer, if successful also sets all the player vars and starts replay
     void TryStart(CMomentumPlayer *pPlayer, bool bUseStartZoneOffset);

--- a/mp/src/game/server/momentum/server_events.cpp
+++ b/mp/src/game/server/momentum/server_events.cpp
@@ -1,4 +1,5 @@
 #include "cbase.h"
+
 #include "filesystem.h"
 #include "server_events.h"
 #include "tickset.h"

--- a/mp/src/game/server/server_momentum.vpc
+++ b/mp/src/game/server/server_momentum.vpc
@@ -179,6 +179,9 @@ $Project "Server (Momentum)"
             $File "momentum\mom_timer.cpp"
             $File "momentum\mom_ghost_base.h"
             $File "momentum\mom_ghost_base.cpp"
+            
+            $File   "$SRCDIR\game\shared\momentum\mom_system_gamemode.cpp"
+            $File   "$SRCDIR\game\shared\momentum\mom_system_gamemode.h"
         }
         
         $File "hl2\Func_Monitor.cpp"

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -492,7 +492,7 @@ void CMomentumGameMovement::HandleDuckingSpeedCrop()
         return BaseClass::HandleDuckingSpeedCrop();
     }
 
-    if (!m_iSpeedCropped & SPEED_CROPPED_DUCK)
+    if (!(m_iSpeedCropped & SPEED_CROPPED_DUCK))
     {
         if ((mv->m_nButtons & IN_DUCK) || (player->m_Local.m_bDucking) || (player->GetFlags() & FL_DUCKING))
         {

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -5,6 +5,7 @@
 #include "mom_player_shared.h"
 #include "movevars_shared.h"
 #include "rumble_shared.h"
+#include "mom_system_gamemode.h"
 
 #ifdef CLIENT_DLL
 #include "c_mom_triggers.h"
@@ -16,8 +17,6 @@
 #endif
 
 #include "tier0/memdbgon.h"
-
-static ConVarRef mom_gamemode("mom_gamemode");
 
 // remove this eventually
 ConVar sv_slope_fix("sv_slope_fix", "1");
@@ -163,7 +162,7 @@ void CMomentumGameMovement::WalkMove()
     trace_t pm;
     Vector forward, right, up;
 
-    if (mom_gamemode.GetInt() == GAMEMODE_KZ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_KZ))
     {
         if (m_pPlayer->m_flStamina > 0)
         {
@@ -485,8 +484,7 @@ bool CMomentumGameMovement::LadderMove(void)
 
 void CMomentumGameMovement::HandleDuckingSpeedCrop()
 {
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
         // TF2 uses default speed cropping
         return BaseClass::HandleDuckingSpeedCrop();
@@ -945,8 +943,7 @@ bool CMomentumGameMovement::CheckJumpButton()
         return false;
     }
 
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
         // Cannot jump while ducked
         if (player->GetFlags() & FL_DUCKING)
@@ -1007,7 +1004,7 @@ bool CMomentumGameMovement::CheckJumpButton()
     // Acclerate upward
     float startz = mv->m_vecVelocity[2];
 
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
         // TF2 uses two different ways of setting vertical velocity when jumping,
         // this might be what allows techniques such as ctaps in rocket jump.
@@ -1026,7 +1023,7 @@ bool CMomentumGameMovement::CheckJumpButton()
     }
 
     // stamina stuff (scroll/kz gamemode only)
-    if (gm.GetInt() == GAMEMODE_KZ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_KZ))
     {
         if (m_pPlayer->m_flStamina > 0)
         {
@@ -1044,7 +1041,7 @@ bool CMomentumGameMovement::CheckJumpButton()
     mv->m_outWishVel.z += mv->m_vecVelocity[2] - startz;
     mv->m_outStepHeight += 0.1f;
 
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
         mv->m_outStepHeight += 0.05f; // 0.15f total
 
     // First do a trace all the way down to the ground
@@ -2128,8 +2125,7 @@ void CMomentumGameMovement::CheckParameters(void)
         mv->m_flClientMaxSpeed = CS_WALK_SPEED;
     }
 
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
         // Walk slower backwards if not crouched
         if (mv->m_nButtons & IN_BACK && !(mv->m_nButtons & IN_DUCK) && !(mv->m_nButtons & IN_FORWARD) &&

--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -5,14 +5,13 @@
 #include "voice_gamemgr.h"
 #include "weapon/cs_ammodef.h"
 #include "weapon/weapon_base_gun.h"
-#include "mom_player_shared.h"
 #include "filesystem.h"
 #include "movevars_shared.h"
+#include "mom_system_gamemode.h"
 
 #ifndef CLIENT_DLL
-#include "momentum/tickset.h"
 #include "momentum/mapzones.h"
-#include "momentum/mom_timer.h"
+#include "momentum/mom_player.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -141,8 +140,7 @@ static CViewVectors g_MOMViewVectorsRJ(Vector(0, 0, 68), // eye position
 
 const CViewVectors *CMomentumGameRules::GetViewVectors() const
 {
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
         return &g_MOMViewVectorsRJ;
 
     return &g_MOMViewVectors;

--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -295,28 +295,6 @@ void CMomentumGameRules::PointCommandWhitelisted(const char *pCmd)
     vec.PurgeAndDeleteElements();
 }
 
-static void OnGamemodeChanged(IConVar *var, const char *pOldValue, float fOldValue)
-{
-    ConVarRef gm(var);
-    int gamemode = gm.GetInt();
-    if (gamemode < 0)
-    {
-        // This will never happen. but better be safe than sorry, right?
-        DevWarning("Cannot set a game mode under 0!\n");
-        gm.SetValue(gm.GetDefault());
-        return;
-    }
-    
-    TickSet::SetTickrate(gamemode);
-
-    // set the value of sv_interval_per_tick so it updates when gamemode changes the tickrate.
-    ConVarRef tr("sv_interval_per_tick");
-    tr.SetValue(TickSet::GetTickrate());
-}
-
-static ConVar gamemode("mom_gamemode", "0", FCVAR_REPLICATED | FCVAR_NOT_CONNECTED | FCVAR_HIDDEN | FCVAR_CLIENTCMD_CAN_EXECUTE, 
-                       "", true, 0, false, 0, OnGamemodeChanged);
-
 static MAKE_TOGGLE_CONVAR(mom_bhop_playblocksound, "1", FCVAR_ARCHIVE, "Makes the door bhop blocks silent or not");
 
 void CMomentumGameRules::PlayerSpawn(CBasePlayer *pPlayer)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -1,0 +1,181 @@
+#include "cbase.h"
+
+#include "mom_system_gamemode.h"
+#include "movevars_shared.h"
+#include "mom_player_shared.h"
+
+#ifdef GAME_DLL
+#include "momentum/tickset.h"
+#endif
+
+#include "tier0/memdbgon.h"
+
+#ifdef GAME_DLL
+CON_COMMAND(mom_print_gamemode_vars, "Prints out the currently set values for commands like sv_maxvelocity, airaccel, etc")
+{
+    g_pGameModeSystem->PrintGameModeVars();
+}
+
+static void OnGamemodeChanged(IConVar* var, const char* pOldValue, float fOldValue)
+{
+    ConVarRef gm(var);
+    const auto gamemode = gm.GetInt();
+
+    TickSet::SetTickrate(gamemode);
+    // set the value of sv_interval_per_tick so it updates when gamemode changes the tickrate.
+    ConVarRef tr("sv_interval_per_tick");
+    tr.SetValue(TickSet::GetTickrate());
+
+    g_pGameModeSystem->SetGameMode((GameMode_t)gamemode);
+}
+
+static ConVar mom_gamemode("mom_gamemode", "0", FCVAR_REPLICATED | FCVAR_NOT_CONNECTED | FCVAR_HIDDEN | FCVAR_CLIENTCMD_CAN_EXECUTE,
+                       "", true, 0, false, 0, OnGamemodeChanged);
+#endif
+
+void CGameModeBase::SetGameModeVars()
+{
+    // Default game mode vars
+    sv_maxvelocity.SetValue(3500);
+    sv_airaccelerate.SetValue(150);
+    sv_accelerate.SetValue(5);
+    sv_maxspeed.SetValue(260);
+}
+
+void CGameModeBase::OnPlayerSpawn(CMomentumPlayer *pPlayer)
+{
+#ifdef GAME_DLL
+    pPlayer->SetAutoBhopEnabled(PlayerHasAutoBhop());
+#endif
+}
+
+void CGameMode_Bhop::SetGameModeVars()
+{
+    CGameModeBase::SetGameModeVars();
+
+    // Bhop-specific
+    sv_maxvelocity.SetValue(100000);
+    sv_airaccelerate.SetValue(1000);
+}
+
+void CGameMode_KZ::SetGameModeVars()
+{
+    CGameModeBase::SetGameModeVars();
+
+    // KZ-specific
+    sv_airaccelerate.SetValue(100);
+    sv_maxspeed.SetValue(250);
+}
+
+void CGameMode_RJ::SetGameModeVars()
+{
+    CGameModeBase::SetGameModeVars();
+
+    // RJ-specific
+    sv_airaccelerate.SetValue(10);
+    sv_accelerate.SetValue(10);
+    sv_maxspeed.SetValue(240);
+}
+
+void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
+{
+#ifdef GAME_DLL
+    pPlayer->GiveNamedItem("weapon_momentum_rocketlauncher");
+    pPlayer->GiveNamedItem("weapon_momentum_shotgun");
+#endif
+}
+
+void CGameMode_Tricksurf::SetGameModeVars()
+{
+    CGameModeBase::SetGameModeVars();
+
+    // Tricksurf-specific
+    sv_airaccelerate.SetValue(1000);
+    sv_accelerate.SetValue(10);
+}
+
+CGameModeSystem::CGameModeSystem() : CAutoGameSystem("CGameModeSystem")
+{
+    m_pCurrentGameMode = new CGameModeBase; // Unknown game mode
+    m_vecGameModes.AddToTail(m_pCurrentGameMode);
+    m_vecGameModes.AddToTail(new CGameMode_Surf);
+    m_vecGameModes.AddToTail(new CGameMode_Bhop);
+    m_vecGameModes.AddToTail(new CGameMode_KZ);
+    m_vecGameModes.AddToTail(new CGameMode_RJ);
+    m_vecGameModes.AddToTail(new CGameMode_Tricksurf);
+    m_vecGameModes.AddToTail(new CGameMode_Trikz);
+}
+
+CGameModeSystem::~CGameModeSystem()
+{
+    m_vecGameModes.PurgeAndDeleteElements();
+}
+
+void CGameModeSystem::LevelInitPostEntity()
+{
+#ifdef GAME_DLL
+    m_pCurrentGameMode->SetGameModeVars();
+    PrintGameModeVars();
+#endif
+}
+
+void CGameModeSystem::SetGameMode(GameMode_t eMode)
+{
+    m_pCurrentGameMode = m_vecGameModes[eMode];
+#ifdef CLIENT_DLL
+    static ConVarRef mom_gamemode("mom_gamemode");
+    // Throw the change to the server too
+    mom_gamemode.SetValue(m_pCurrentGameMode->GetType());
+#endif
+}
+
+void CGameModeSystem::SetGameModeFromMapName(const char *pMapName)
+{
+    // Set to unknown for now
+    m_pCurrentGameMode = m_vecGameModes[0];
+
+    if (!pMapName)
+        return;
+
+    if (pMapName)
+    {
+        // Skip over unknown in the loop
+        for (auto i = 1; i < m_vecGameModes.Count(); ++i)
+        {
+            const auto pPrefix = m_vecGameModes[i]->GetMapPrefix();
+            const auto strLen = Q_strlen(pPrefix);
+            if (!Q_strnicmp(pPrefix, pMapName, strLen))
+            {
+                m_pCurrentGameMode = m_vecGameModes[i];
+                break;
+            }
+        }
+    }
+
+#ifdef CLIENT_DLL
+    static ConVarRef mom_gamemode("mom_gamemode");
+    // Throw the change to the server too
+    mom_gamemode.SetValue(m_pCurrentGameMode->GetType());
+#endif
+}
+
+void CGameModeSystem::PrintGameModeVars()
+{
+    Msg("Set game mode ConVars:\n\n"
+        "sv_maxvelocity: %i\n"
+        "sv_airaccelerate: %i\n"
+        "sv_accelerate: %i\n"
+        "sv_maxspeed: %i\n"
+        "sv_gravity: %i\n"
+        "sv_friction: %i\n",
+        sv_maxvelocity.GetInt(),
+        sv_airaccelerate.GetInt(),
+        sv_accelerate.GetInt(),
+        sv_maxspeed.GetInt(),
+        sv_gravity.GetInt(),
+        sv_friction.GetInt());
+}
+
+// Expose to DLL
+CGameModeSystem s_GameModeSys;
+CGameModeSystem *g_pGameModeSystem = &s_GameModeSys;

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -134,9 +134,6 @@ void CGameModeSystem::SetGameModeFromMapName(const char *pMapName)
     // Set to unknown for now
     m_pCurrentGameMode = m_vecGameModes[0];
 
-    if (!pMapName)
-        return;
-
     if (pMapName)
     {
         // Skip over unknown in the loop

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include "mom_shareddefs.h"
+
+#ifdef CLIENT_DLL
+#define CMomentumPlayer C_MomentumPlayer
+#endif
+
+class CMomentumPlayer;
+
+abstract_class IGameMode
+{
+public:
+    virtual GameMode_t  GetType() = 0;
+    virtual const char *GetStatusString() = 0;
+    virtual const char *GetDiscordIcon() = 0;
+    virtual const char *GetMapPrefix() = 0;
+    virtual void        SetGameModeVars() = 0;
+    virtual bool        PlayerHasAutoBhop() = 0;
+    virtual void        OnPlayerSpawn(CMomentumPlayer *pPlayer) = 0;
+
+    virtual ~IGameMode() {}
+};
+
+// Unknown ("default") game mode
+class CGameModeBase : public IGameMode
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_UNKNOWN; }
+    const char* GetStatusString() override { return "Playing"; }
+    const char* GetDiscordIcon() override { return "mom"; }
+    const char* GetMapPrefix() override { return ""; }
+    void SetGameModeVars() override;
+    bool PlayerHasAutoBhop() override { return true; }
+    void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
+};
+
+class CGameMode_Surf : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_SURF; }
+    const char* GetStatusString() override { return "Surfing"; }
+    const char* GetDiscordIcon() override { return "mom_icon_surf"; }
+    const char* GetMapPrefix() override { return "surf_"; }
+};
+
+class CGameMode_Bhop : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_BHOP; }
+    const char* GetStatusString() override { return "Bhopping"; }
+    const char* GetDiscordIcon() override { return "mom_icon_bhop"; }
+    const char* GetMapPrefix() override { return "bhop_"; }
+    void SetGameModeVars() override;
+};
+
+class CGameMode_KZ : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_KZ; }
+    const char* GetStatusString() override { return "Climbing"; }
+    const char* GetDiscordIcon() override { return "mom_icon_kz"; }
+    const char* GetMapPrefix() override { return "kz_"; }
+    void SetGameModeVars() override;
+    bool PlayerHasAutoBhop() override { return false; }
+};
+
+class CGameMode_RJ : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_RJ; }
+    const char* GetStatusString() override { return "Rocket Jumping"; }
+    const char* GetDiscordIcon() override { return "mom_icon_rj"; }
+    const char* GetMapPrefix() override { return "jump_"; }
+    void SetGameModeVars() override;
+    bool PlayerHasAutoBhop() override { return false; }
+    void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
+};
+
+class CGameMode_Tricksurf : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_TRICKSURF; }
+    const char* GetStatusString() override { return "Surfing"; }
+    const char* GetDiscordIcon() override { return "mom_icon_tricksurf"; }
+    const char* GetMapPrefix() override { return "tricksurf_"; }
+    void SetGameModeVars() override;
+};
+
+// MOM_TODO
+class CGameMode_Trikz : public CGameModeBase
+{
+public:
+    GameMode_t GetType() override { return GAMEMODE_TRIKZ; }
+    const char* GetDiscordIcon() override { return "mom_icon_trikz"; }
+    const char* GetMapPrefix() override { return "trikz_"; }
+};
+
+class CGameModeSystem : public CAutoGameSystem
+{
+public:
+    CGameModeSystem();
+    ~CGameModeSystem();
+
+    // IGameSystem overrides
+    void LevelInitPostEntity() override;
+
+    // Extra methods
+    /// Gets current game mode
+    IGameMode *GetGameMode() const { return m_pCurrentGameMode; }
+    /// Checks if the game mode is the given one.
+    /// (convenience method; functionally equivalent to `GetGameMode()->GetGameModeType() == eCheck`)
+    bool GameModeIs(GameMode_t eCheck) const { return m_pCurrentGameMode->GetType() == eCheck; }
+    /// Sets the game mode directly
+    void SetGameMode(GameMode_t eMode);
+    /// Sets the game mode from a map name (backup method)
+    void SetGameModeFromMapName(const char *pMapName);
+    /// Prints out the game mode's vars
+    void PrintGameModeVars();
+
+private:
+    IGameMode *m_pCurrentGameMode;
+    CUtlVector<IGameMode*> m_vecGameModes;
+};
+
+extern CGameModeSystem *g_pGameModeSystem;

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -2,6 +2,7 @@
 
 #include "mom_player_shared.h"
 #include "weapon_mom_rocketlauncher.h"
+#include "mom_system_gamemode.h"
 
 #include "tier0/memdbgon.h"
 
@@ -115,8 +116,7 @@ void CMomentumRocketLauncher::PrimaryAttack()
 
 bool CMomentumRocketLauncher::CanDeploy()
 {
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() != GAMEMODE_RJ)
+    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
         return false;
 
     return BaseClass::CanDeploy();


### PR DESCRIPTION
A simple refactor to clarify structure and make game modes a little more flexible.

Instead of being embedded all over the place, game modes have now moved to their own interface. Game modes themselves are classes now, and events (On Map Start, OnPlayerSpawn, etc) are applied to them, so they have full control over what they actually do. Everything's nice and organized in mom_system_gamemode, and it is shared and synchronized across server and client (client actually sets it first, server updates next/same? tick). [If we had engine it'd be there]

The expansion part of this is already starting to be explored; RJ now gives the player the rocket and shotgun to start off with. Things like bhop could give knife, trikz grenades, etc. It's up to us to see what players want by default.

Closes #352 
Closes #330 