### PR TITLE
Fix behaviour when exiting end zone with mapfinished panel open

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -950,6 +950,13 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
         {
         case ZONE_TYPE_START:
         {
+            // Get rid of map finished panel
+            if (m_Data.m_bMapFinished)
+            {
+                m_Data.m_bMapFinished = false;
+                SetLaggedMovementValue(1.0f);
+            }
+
             const auto pStartTrigger = static_cast<CTriggerTimerStart*>(pTrigger);
 
             m_Data.m_iCurrentTrack = pStartTrigger->GetTrackNumber();

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -950,12 +950,7 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
         {
         case ZONE_TYPE_START:
         {
-            // Get rid of map finished panel
-            if (m_Data.m_bMapFinished)
-            {
-                m_Data.m_bMapFinished = false;
-                SetLaggedMovementValue(1.0f);
-            }
+            ResetProps();
 
             const auto pStartTrigger = static_cast<CTriggerTimerStart*>(pTrigger);
 
@@ -1095,7 +1090,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
         case ZONE_TYPE_STOP:
             m_Data.m_iCurrentTrack = m_iOldTrack;
             m_Data.m_iCurrentZone = m_iOldZone;
-            SetLaggedMovementValue(1.0f); // Reset slow motion
+            ResetProps();
             break;
         case ZONE_TYPE_CHECKPOINT:
             break;
@@ -1129,6 +1124,11 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
 
         CMomRunEntity::OnZoneExit(pTrigger);
     }
+}
+
+void CMomentumPlayer::ResetProps()
+{
+    SetLaggedMovementValue(1.0f);
 }
 
 void CMomentumPlayer::Touch(CBaseEntity *pOther)

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -273,6 +273,9 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void SetPracticeModeState();
 
     void DestroyRockets();
+    
+    // Resets all player properties to their default state
+    void ResetProps();
 
     CSteamID m_sSpecTargetSteamID;
 

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -587,7 +587,6 @@ void CMomentumReplayGhostEntity::OnZoneEnter(CTriggerZone *pTrigger)
     {
     case ZONE_TYPE_START:
         m_Data.m_iCurrentTrack = pTrigger->GetTrackNumber();
-        m_Data.m_bMapFinished = false;
         m_Data.m_bTimerRunning = false;
         break;
     case ZONE_TYPE_STOP:

--- a/mp/src/game/shared/momentum/run/mom_run_entity.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_entity.cpp
@@ -67,7 +67,6 @@ void CMomRunEntity::OnZoneExit(CTriggerZone *pTrigger)
         break;
     }
 
-    pData->m_bMapFinished = false;
     pData->m_bIsInZone = false;
 
     IGameEvent *pEvent = gameeventmanager->CreateEvent("zone_exit");

--- a/mp/src/game/shared/momentum/run/mom_run_entity.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_entity.cpp
@@ -26,6 +26,7 @@ void CMomRunEntity::OnZoneEnter(CTriggerZone *pTrigger)
     switch (pTrigger->GetZoneType())
     {
     case ZONE_TYPE_START:
+        pData->m_bMapFinished = false;
         break;
     case ZONE_TYPE_STOP:
         break;


### PR DESCRIPTION
Exiting the end zone with the mapfinished panel still open will automatically close, leaving no opportunity for the user to look at it. This fixes that behaviour so that the mapfinished panel remains open until the player closes it or enters start zone by restarting.

Closes #185 