### PR TITLE
Add +paint command

### DIFF
--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -137,7 +137,6 @@ static	kbutton_t	in_score;
 static	kbutton_t	in_break;
 static	kbutton_t	in_zoom;
 static  kbutton_t   in_grenade1;
-static  kbutton_t   in_grenade2;
 static	kbutton_t	in_attack3;
 kbutton_t	in_ducktoggle;
 
@@ -482,8 +481,6 @@ void IN_ZoomDown( const CCommand &args ) {KeyDown(&in_zoom, args[1] );}
 void IN_ZoomUp( const CCommand &args ) {KeyUp(&in_zoom, args[1] );}
 void IN_Grenade1Up( const CCommand &args ) { KeyUp( &in_grenade1, args[1] ); }
 void IN_Grenade1Down( const CCommand &args ) { KeyDown( &in_grenade1, args[1] ); }
-void IN_Grenade2Up( const CCommand &args ) { KeyUp( &in_grenade2, args[1] ); }
-void IN_Grenade2Down( const CCommand &args ) { KeyDown( &in_grenade2, args[1] ); }
 void IN_XboxStub( const CCommand &args ) { /*do nothing*/ }
 void IN_Attack3Down( const CCommand &args ) { KeyDown(&in_attack3, args[1] );}
 void IN_Attack3Up( const CCommand &args ) { KeyUp(&in_attack3, args[1] );}
@@ -1463,7 +1460,6 @@ int CInput::GetButtonBits( int iResetState )
 	CalcButtonBits( bits, IN_SCORE, s_ClearInputState, &in_score, iResetState );
 	CalcButtonBits( bits, IN_ZOOM, s_ClearInputState, &in_zoom, iResetState );
 	CalcButtonBits( bits, IN_GRENADE1, s_ClearInputState, &in_grenade1, iResetState );
-	CalcButtonBits( bits, IN_GRENADE2, s_ClearInputState, &in_grenade2, iResetState );
 	CalcButtonBits( bits, IN_ATTACK3, s_ClearInputState, &in_attack3, iResetState );
 	CalcButtonBits( bits, IN_STRAFE, s_ClearInputState, &in_strafe, iResetState );
 
@@ -1619,8 +1615,6 @@ static ConCommand startzoom("+zoom", IN_ZoomDown);
 static ConCommand endzoom("-zoom", IN_ZoomUp);
 static ConCommand endgrenade1( "-grenade1", IN_Grenade1Up );
 static ConCommand startgrenade1( "+grenade1", IN_Grenade1Down );
-static ConCommand endgrenade2( "-grenade2", IN_Grenade2Up );
-static ConCommand startgrenade2( "+grenade2", IN_Grenade2Down );
 static ConCommand startattack3("+attack3", IN_Attack3Down);
 static ConCommand endattack3("-attack3", IN_Attack3Up);
 

--- a/mp/src/game/client/in_main.cpp
+++ b/mp/src/game/client/in_main.cpp
@@ -307,7 +307,7 @@ CInput::CInput( void )
 	m_pCommands = NULL;
 	m_pCameraThirdData = NULL;
 	m_pVerifiedCommands = NULL;
-    s_ClearInputState = 0;
+	s_ClearInputState = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -605,12 +605,12 @@ float CInput::KeyState ( kbutton_t *key )
 
 	else if ( impulsedown && impulseup )
 	{
-        val = down ? 0.75 : 0.25;
+		val = down ? 0.75 : 0.25;
 	}
 
 
 	// clear impulses
-	key->state &= 1;		
+	key->state &= 1;
 	return val;
 }
 
@@ -1422,13 +1422,13 @@ void CInput::CalcButtonBits( int& bits, int in_button, int in_ignore, kbutton_t 
 	if ( reset )
 	{
 		button->state &= clearmask;
-        // @Gocnak: Needed for a CLEAR_STATE_NOW function for keys
-        // Added primarily for resetting stuck keys from demos/loading screens
-        if (reset >= 2)
-        {
-            button->down[0] = 0;
-            button->down[1] = 0;
-        }
+		// @Gocnak: Needed for a CLEAR_STATE_NOW function for keys
+		// Added primarily for resetting stuck keys from demos/loading screens
+		if (reset >= 2)
+		{
+			button->down[0] = 0;
+			button->down[1] = 0;
+		}
 	}
 }
 
@@ -1465,7 +1465,7 @@ int CInput::GetButtonBits( int iResetState )
 	CalcButtonBits( bits, IN_GRENADE1, s_ClearInputState, &in_grenade1, iResetState );
 	CalcButtonBits( bits, IN_GRENADE2, s_ClearInputState, &in_grenade2, iResetState );
 	CalcButtonBits( bits, IN_ATTACK3, s_ClearInputState, &in_attack3, iResetState );
-    CalcButtonBits( bits, IN_STRAFE, s_ClearInputState, &in_strafe, iResetState);
+	CalcButtonBits( bits, IN_STRAFE, s_ClearInputState, &in_strafe, iResetState );
 
 	if ( KeyState(&in_ducktoggle) )
 	{

--- a/mp/src/game/client/momentum/mom_in_main.cpp
+++ b/mp/src/game/client/momentum/mom_in_main.cpp
@@ -22,6 +22,7 @@ extern kbutton_t in_klook;
 
 static kbutton_t in_times;
 static kbutton_t in_lobby_members;
+static kbutton_t in_paint;
 
 //-----------------------------------------------------------------------------
 // Purpose: HL Input interface
@@ -44,6 +45,7 @@ int CMOMInput::GetButtonBits(int bResetState)
     int bits = 0;
     // First calculate all Momentum-specific toggle bits
     CalcButtonBits(bits, IN_SCORE, s_ClearInputState, &in_times, bResetState);
+    CalcButtonBits(bits, IN_PAINT, s_ClearInputState, &in_paint, bResetState);
 
     // Add on the normal input bits
     bits |= BaseClass::GetButtonBits(bResetState);
@@ -170,6 +172,9 @@ void IN_TimesUp(const CCommand &args)
     }
 }
 
+static ConCommand startshowtimes("+showtimes", IN_TimesDown);
+static ConCommand endshowtimes("-showtimes", IN_TimesUp);
+
 void IN_LobbyMemsDown(const CCommand &args)
 {
     KeyDown(&in_lobby_members, args[1]);
@@ -188,11 +193,21 @@ void IN_LobbyMemsUp(const CCommand &args)
     }
 }
 
-static ConCommand startshowtimes("+showtimes", IN_TimesDown);
-static ConCommand endshowtimes("-showtimes", IN_TimesUp);
-
 static ConCommand startshowlobbymembers("+show_lobby_members", IN_LobbyMemsDown);
 static ConCommand end_show_lobby_mems("-show_lobby_members", IN_LobbyMemsUp);
+
+void IN_PaintDown(const CCommand &args)
+{
+    KeyDown(&in_paint, args[1]);
+}
+
+void IN_PaintUp(const CCommand &args)
+{
+    KeyUp(&in_paint, args[1]);
+}
+
+static ConCommand startpaint("+paint", IN_PaintDown);
+static ConCommand endpaint("-paint", IN_PaintUp);
 
 // Expose this interface
 static CMOMInput g_Input;

--- a/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
@@ -206,8 +206,7 @@ void CHudKeyPressDisplay::Paint()
             m_fJumpColorUntil = gpGlobals->curtime + KEYDRAW_MIN;
         }
 
-        // Bullrush is Bhop being disabled
-        surface()->DrawSetTextColor((m_nDisabledButtons & IN_JUMP || m_nDisabledButtons & IN_BULLRUSH) ? m_Disabled
+        surface()->DrawSetTextColor((m_nDisabledButtons & IN_JUMP || m_nDisabledButtons & IN_BHOPDISABLED) ? m_Disabled
                                                                                                        : m_Normal);
         surface()->DrawSetTextPos(GetTextCenter(m_hWordTextFont, m_pwJump), jump_row_ypos);
         surface()->DrawPrintText(m_pwJump, wcslen(m_pwJump));
@@ -324,7 +323,7 @@ void CHudKeyPressDisplay::DrawKeyTemplates()
     surface()->DrawSetTextFont(m_hWordTextFont);
     // jump
     // Bullrush is Bhop being disabled
-    surface()->DrawSetTextColor((m_nDisabledButtons & IN_JUMP || m_nDisabledButtons & IN_BULLRUSH) ? m_Disabled
+    surface()->DrawSetTextColor((m_nDisabledButtons & IN_JUMP || m_nDisabledButtons & IN_BHOPDISABLED) ? m_Disabled
                                                                                                    : m_darkGray);
     surface()->DrawSetTextPos(GetTextCenter(m_hWordTextFont, m_pwJump), jump_row_ypos);
     surface()->DrawPrintText(m_pwJump, wcslen(m_pwJump));

--- a/mp/src/game/server/momentum/ghost_client.cpp
+++ b/mp/src/game/server/momentum/ghost_client.cpp
@@ -139,7 +139,7 @@ void CMomentumGhostClient::SetSpectatorTarget(CSteamID target, bool bStartedSpec
     g_pMomentumLobbySystem->SetSpectatorTarget(target, bStartedSpectating, bLeft);
 }
 
-void CMomentumGhostClient::SendDecalPacket(DecalPacket_t *packet)
+void CMomentumGhostClient::SendDecalPacket(DecalPacket *packet)
 {
     static ConVarRef host_timescale("host_timescale");
 
@@ -151,7 +151,7 @@ void CMomentumGhostClient::SendDecalPacket(DecalPacket_t *packet)
     // MOM_TODO: else let the player know their decal packets aren't being sent?
 }
 
-bool CMomentumGhostClient::SendSavelocReqPacket(CSteamID& target, SavelocReqPacket_t* packet)
+bool CMomentumGhostClient::SendSavelocReqPacket(CSteamID& target, SavelocReqPacket* packet)
 {
     // MOM_TODO: g_pMomentumServerSystem->SendSavelocReqPacket(target, packet);
     return g_pMomentumLobbySystem->SendSavelocReqPacket(target, packet);
@@ -172,7 +172,7 @@ CUtlMap<uint64, CMomentumOnlineGhostEntity*> *CMomentumGhostClient::GetOnlineGho
     return g_pMomentumLobbySystem->GetOnlineEntMap();
 }
 
-bool CMomentumGhostClient::CreateNewNetFrame(PositionPacket_t &into)
+bool CMomentumGhostClient::CreateNewNetFrame(PositionPacket &into)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
     if (pPlayer && !pPlayer->IsSpectatingGhost())
@@ -183,7 +183,7 @@ bool CMomentumGhostClient::CreateNewNetFrame(PositionPacket_t &into)
         if (!(orig.IsValid() && vel.IsValid() && eye.IsValid()))
             return false;
 
-        into = PositionPacket_t(
+        into = PositionPacket(
             eye,
             orig,
             vel,

--- a/mp/src/game/server/momentum/ghost_client.h
+++ b/mp/src/game/server/momentum/ghost_client.h
@@ -1,8 +1,8 @@
 #pragma once
 
-struct PositionPacket_t;
-struct DecalPacket_t;
-struct SavelocReqPacket_t;
+class PositionPacket;
+class DecalPacket;
+class SavelocReqPacket;
 struct GhostAppearance_t;
 class CMomentumOnlineGhostEntity;
 
@@ -28,15 +28,15 @@ public:
     void SendAppearanceData(GhostAppearance_t appearance);
     void SetIsSpectating(bool state);
     void SetSpectatorTarget(CSteamID target, bool bStartedSpectating, bool bLeft = false);
-    void SendDecalPacket(DecalPacket_t *packet);
-    bool SendSavelocReqPacket(CSteamID &target, SavelocReqPacket_t *packet);
+    void SendDecalPacket(DecalPacket *packet);
+    bool SendSavelocReqPacket(CSteamID &target, SavelocReqPacket *packet);
 
     CMomentumOnlineGhostEntity *GetOnlineGhostEntityFromID(const CSteamID &id) { return GetOnlineGhostEntityFromID(id.ConvertToUint64()); }
     CMomentumOnlineGhostEntity *GetOnlineGhostEntityFromID(const uint64 &id);
 
     CUtlMap<uint64, CMomentumOnlineGhostEntity*> *GetOnlineGhostMap();
 
-    static bool CreateNewNetFrame(PositionPacket_t &frame);
+    static bool CreateNewNetFrame(PositionPacket &frame);
 };
 
 extern CMomentumGhostClient *g_pMomentumGhostClient;

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -132,7 +132,7 @@ void CMomentumLobbySystem::ResetOtherAppearanceData()
     }
 }
 
-bool CMomentumLobbySystem::SendSavelocReqPacket(CSteamID& target, SavelocReqPacket_t* p)
+bool CMomentumLobbySystem::SendSavelocReqPacket(CSteamID& target, SavelocReqPacket* p)
 {
     return LobbyValid() && SendPacket(p, &target, k_EP2PSendReliable);
 }
@@ -156,7 +156,7 @@ void CMomentumLobbySystem::TeleportToLobbyMember(const char *pIDStr)
             if (pPlayer && pPlayer->GetObserverMode() == OBS_MODE_NONE && !g_pMomentumTimer->IsRunning())
             {
                 // Teleport em
-                PositionPacket_t p;
+                PositionPacket p;
                 if (pEnt->GetCurrentPositionPacketData(&p))
                 {
                     pPlayer->Teleport(&p.Position, &p.EyeAngle, nullptr);
@@ -374,7 +374,7 @@ void CMomentumLobbySystem::ClearCurrentGhosts(bool bRemoveEnts)
     }
 }
 
-bool CMomentumLobbySystem::SendPacket(MomentumPacket_t *packet, CSteamID *pTarget, EP2PSend sendType /* = k_EP2PSendUnreliable*/)
+bool CMomentumLobbySystem::SendPacket(MomentumPacket *packet, CSteamID *pTarget, EP2PSend sendType /* = k_EP2PSendUnreliable*/)
 {
     CHECK_STEAM_API_B(SteamNetworking());
 
@@ -718,7 +718,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
             {
             case PT_POS_DATA: // Position update frame
                 {
-                    PositionPacket_t frame(buf);
+                    PositionPacket frame(buf);
                     CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
                     if (pEntity)
                         pEntity->AddPositionFrame(frame);
@@ -726,7 +726,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                 break;
             case PT_DECAL_DATA:
                 {
-                    DecalPacket_t decals(buf);
+                    DecalPacket decals(buf);
                     CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
                     if (pEntity)
                     {
@@ -736,7 +736,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                 break;
             case PT_SPEC_UPDATE:
                 {
-                    SpecUpdatePacket_t update(buf);
+                    SpecUpdatePacket update(buf);
                     uint64 fromWhoID = fromWho.ConvertToUint64(), specTargetID = update.specTarget;
 
                     CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
@@ -753,7 +753,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
 
             case PT_SAVELOC_REQ:
                 {
-                    SavelocReqPacket_t saveloc(buf);
+                    SavelocReqPacket saveloc(buf);
 
                     // Done/fail states:
                     // 1. They hit "cancel" (most common)
@@ -783,7 +783,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                             g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64());
 
                             // Send them our saveloc count
-                            SavelocReqPacket_t response;
+                            SavelocReqPacket response;
                             response.stage = 2;
                             response.saveloc_count = g_pMOMSavelocSystem->GetSavelocCount();
 
@@ -804,7 +804,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                         {
                             DevLog(2, "Received a stage 3 saveloc request packet!\n");
                             // Somebody sent us the number of the savelocs they want, saveloc system pls help
-                            SavelocReqPacket_t response;
+                            SavelocReqPacket response;
                             response.stage = 4;
 
                             if (g_pMOMSavelocSystem->FillSavelocReq(true, &saveloc, &response))
@@ -818,7 +818,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                             if (g_pMOMSavelocSystem->FillSavelocReq(false, &saveloc, nullptr))
                             {
                                 // Send them a packet that we're all good
-                                SavelocReqPacket_t response;
+                                SavelocReqPacket response;
                                 response.stage = -1;
                                 if (SendPacket(&response, &fromWho, k_EP2PSendReliable))
                                 {
@@ -852,7 +852,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
         // Send position data
         if (m_flNextUpdateTime > 0 && gpGlobals->curtime > m_flNextUpdateTime)
         {
-            PositionPacket_t frame;
+            PositionPacket frame;
             if (g_pMomentumGhostClient->CreateNewNetFrame(frame) && SendPacket(&frame))
             {
                 m_flNextUpdateTime = gpGlobals->curtime + (1.0f / mm_updaterate.GetFloat());
@@ -875,7 +875,7 @@ bool CMomentumLobbySystem::GetIsSpectatingFromMemberData(const CSteamID &who)
     return (specChar && specChar[0]) ? true : false;
 }
 
-bool CMomentumLobbySystem::SendDecalPacket(DecalPacket_t *packet)
+bool CMomentumLobbySystem::SendDecalPacket(DecalPacket *packet)
 {
     return LobbyValid() && SendPacket(packet);
 }
@@ -913,7 +913,7 @@ void CMomentumLobbySystem::SetSpectatorTarget(const CSteamID &ghostTarget, bool 
 //Sends the spectator info update packet to all current ghosts
 void CMomentumLobbySystem::SendSpectatorUpdatePacket(const CSteamID &ghostTarget, SpectateMessageType_t type)
 {
-    SpecUpdatePacket_t newUpdate(ghostTarget.ConvertToUint64(), type);
+    SpecUpdatePacket newUpdate(ghostTarget.ConvertToUint64(), type);
     if (SendPacket(&newUpdate, nullptr, k_EP2PSendReliable))
     {
         uint64 playerID = SteamUser()->GetSteamID().ConvertToUint64();

--- a/mp/src/game/server/momentum/mom_lobby_system.h
+++ b/mp/src/game/server/momentum/mom_lobby_system.h
@@ -2,11 +2,11 @@
 
 #include "mom_shareddefs.h"
 
-struct MomentumPacket_t;
-struct DecalPacket_t;
-struct LobbyGhostAppearance_t;
-struct SavelocReqPacket_t;
+class MomentumPacket;
+class DecalPacket;
+class SavelocReqPacket;
 struct GhostAppearance_t;
+struct LobbyGhostAppearance_t;
 class CMomentumOnlineGhostEntity;
 
 class CMomentumLobbySystem
@@ -25,7 +25,7 @@ public:
 
     void SendChatMessage(char *pMessage); // Sent from the player, who is trying to say a message
     void ResetOtherAppearanceData(); // Sent when the player changes an override appearance cvar
-    bool SendSavelocReqPacket(CSteamID& target, SavelocReqPacket_t *p);
+    bool SendSavelocReqPacket(CSteamID& target, SavelocReqPacket *p);
     void TeleportToLobbyMember(const char *pIDStr);
 
     STEAM_CALLBACK(CMomentumLobbySystem, HandleLobbyEnter, LobbyEnter_t); // We entered this lobby (or failed to enter)
@@ -52,7 +52,7 @@ public:
     void SetIsSpectating(bool bSpec);
     void SendSpectatorUpdatePacket(const CSteamID &ghostTarget, SpectateMessageType_t type);
     bool GetIsSpectatingFromMemberData(const CSteamID &who);
-    bool SendDecalPacket(DecalPacket_t *packet);
+    bool SendDecalPacket(DecalPacket *packet);
 
     void OnLobbyMaxPlayersChanged(int newMax);
     void OnLobbyTypeChanged(int newType);
@@ -75,7 +75,7 @@ private:
     bool m_bHostingLobby;
 
     // Sends a packet to a specific person, or everybody (if pTarget is null)
-    bool SendPacket(MomentumPacket_t *packet, CSteamID *pTarget = nullptr, EP2PSend sendType = k_EP2PSendUnreliable);
+    bool SendPacket(MomentumPacket *packet, CSteamID *pTarget = nullptr, EP2PSend sendType = k_EP2PSendUnreliable);
 
     void WriteLobbyMessage(LobbyMessageType_t type, uint64 id);
     void WriteSpecMessage(SpectateMessageType_t type, uint64 playerID, uint64 ghostID);

--- a/mp/src/game/server/momentum/mom_online_ghost.h
+++ b/mp/src/game/server/momentum/mom_online_ghost.h
@@ -15,12 +15,12 @@ public:
     ~CMomentumOnlineGhostEntity();
 
     // Adds a position frame to the queue for processing
-    void AddPositionFrame(const PositionPacket_t &newFrame);
+    void AddPositionFrame(const PositionPacket &newFrame);
     // Adds a decal frame to the queue of processing
     // Note: We have to delay the decal packets to sort of sync up to position, to make spectating more accurate.
-    void AddDecalFrame(const DecalPacket_t &decal);
+    void AddDecalFrame(const DecalPacket &decal);
     // Places a decal in the world, according to the packet and decal type
-    void FireDecal(const DecalPacket_t &decal);
+    void FireDecal(const DecalPacket &decal);
 
     void SetGhostSteamID(const CSteamID &steamID);
     CSteamID GetGhostSteamID() const { return m_GhostSteamID; }
@@ -40,7 +40,7 @@ public:
     void UpdateStats(const Vector &ghostVel) OVERRIDE; // for hud display..
 
     // Fills the current data, returns false if it couldn't
-    bool GetCurrentPositionPacketData(PositionPacket_t *out) const;
+    bool GetCurrentPositionPacketData(PositionPacket *out) const;
 
     void UpdatePlayerSpectate();
 
@@ -59,14 +59,14 @@ protected:
     void FireGameEvent(IGameEvent *pEvent) OVERRIDE;
 
 private:
-    void DoPaint(const DecalPacket_t &packet);
-    void DoKnifeSlash(const DecalPacket_t &packet);
-    void ThrowGrenade(const DecalPacket_t &packet);
+    void DoPaint(const DecalPacket &packet);
+    void DoKnifeSlash(const DecalPacket &packet);
+    void ThrowGrenade(const DecalPacket &packet);
 
-    CUtlQueue<ReceivedFrame_t<PositionPacket_t>*> m_vecPositionPackets;
-    ReceivedFrame_t<PositionPacket_t>* m_pCurrentFrame;
-    ReceivedFrame_t<PositionPacket_t>* m_pNextFrame;
-    CUtlQueue<ReceivedFrame_t<DecalPacket_t>*> m_vecDecalPackets;
+    CUtlQueue<ReceivedFrame_t<PositionPacket>*> m_vecPositionPackets;
+    ReceivedFrame_t<PositionPacket>* m_pCurrentFrame;
+    ReceivedFrame_t<PositionPacket>* m_pNextFrame;
+    CUtlQueue<ReceivedFrame_t<DecalPacket>*> m_vecDecalPackets;
 
     CSteamID m_GhostSteamID;
     LobbyGhostAppearance_t m_CurrentAppearance;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -13,12 +13,14 @@
 #include "player_command.h"
 #include "predicted_viewmodel.h"
 #include "weapon/weapon_base_gun.h"
+#include "weapon/weapon_mom_paintgun.h"
 #include "mom_system_gamemode.h"
 #include "mom_system_saveloc.h"
 #include "util/mom_util.h"
 #include "mom_replay_system.h"
 #include "run/mom_replay_base.h"
 #include "mapzones.h"
+#include "fx_mom_shared.h"
 
 #include "tier0/memdbgon.h"
 
@@ -98,6 +100,24 @@ CON_COMMAND(
     }
 }
 
+static void StartPaint(const CCommand& args)
+{
+    auto pPlayer = CMomentumPlayer::GetLocalPlayer();
+    if (!pPlayer)
+        return;
+    pPlayer->SetIsPainting(true);
+}
+
+static void EndPaint(const CCommand& args)
+{
+    auto pPlayer = CMomentumPlayer::GetLocalPlayer();
+    if (!pPlayer)
+        return;
+    pPlayer->SetIsPainting(false);
+}
+static ConCommand startpaint("+paint", StartPaint);
+static ConCommand endpaint("-paint", EndPaint);
+
 CON_COMMAND(mom_strafesync_reset, "Reset the strafe sync. (works only when timer is disabled)\n")
 {
     CMomentumPlayer *pPlayer = dynamic_cast<CMomentumPlayer *>(UTIL_GetLocalPlayer());
@@ -131,7 +151,7 @@ SendPropDataTable(SENDINFO_DT(m_RunStats), &REFERENCE_SEND_TABLE(DT_MomRunStats)
 END_SEND_TABLE();
 
 BEGIN_DATADESC(CMomentumPlayer)
-    DEFINE_THINKFUNC(UpdateRunStats),
+    DEFINE_THINKFUNC(PlayerThink),
     DEFINE_THINKFUNC(CalculateAverageStats),
     /*DEFINE_THINKFUNC(LimitSpeedInStartZone),*/
 END_DATADESC();
@@ -220,6 +240,9 @@ CMomentumPlayer::CMomentumPlayer()
     m_iOldZone = 0;
 
     m_bWasSpectating = false;
+
+    SetIsPainting(false);
+    m_flNextPaintTime = gpGlobals->curtime;
 
     m_CurrentSlideTrigger = nullptr;
 
@@ -468,7 +491,7 @@ void CMomentumPlayer::Spawn()
     RegisterThinkContext("THINK_AVERAGE_STATS");
     // RegisterThinkContext("CURTIME_FOR_START");
     RegisterThinkContext("TWEEN");
-    SetContextThink(&CMomentumPlayer::UpdateRunStats, gpGlobals->curtime + gpGlobals->interval_per_tick,
+    SetContextThink(&CMomentumPlayer::PlayerThink, gpGlobals->curtime + gpGlobals->interval_per_tick,
                     "THINK_EVERY_TICK");
     SetContextThink(&CMomentumPlayer::CalculateAverageStats, gpGlobals->curtime + AVERAGE_STATS_INTERVAL,
                     "THINK_AVERAGE_STATS");
@@ -1092,7 +1115,7 @@ void CMomentumPlayer::Touch(CBaseEntity *pOther)
         g_MOMBlockFixer->PlayerTouch(this, pOther);
 }
 
-void CMomentumPlayer::UpdateRunStats()
+void CMomentumPlayer::PlayerThink()
 {
     // If we're in practicing mode, don't update.
     if (!m_bHasPracticeMode)
@@ -1108,6 +1131,9 @@ void CMomentumPlayer::UpdateRunStats()
         UpdateRunSync();
         // ----------
     }
+
+    if (m_bIsPainting && CanPaint())
+        DoPaint();
 
     // this might be used in a later update
     // m_flLastVelocity = velocity;
@@ -1876,4 +1902,18 @@ void CMomentumPlayer::ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &v
 
     Vector vecForce = vecDir * -DamageForce(WorldAlignSize(), info.GetDamage(), flScale);
     ApplyAbsVelocityImpulse(vecForce);
+}
+
+void CMomentumPlayer::SetIsPainting(bool bIsPainting) { m_bIsPainting = bIsPainting; }
+
+bool CMomentumPlayer::CanPaint() { return m_flNextPaintTime <= gpGlobals->curtime; }
+
+void CMomentumPlayer::DoPaint()
+{
+    // Fire a paintgun bullet (doesn't actually equip/use the paintgun weapon)
+    FX_FireBullets(entindex(), EyePosition(), EyeAngles(), WEAPON_PAINTGUN, Primary_Mode,
+                   GetPredictionRandomSeed() & 255, 0.0f);
+
+    // Delay next time we paint
+    m_flNextPaintTime = gpGlobals->curtime + CMomentumPaintGun::GetPrimaryCycleTime();
 }

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -50,6 +50,10 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void FlashlightTurnOff() OVERRIDE;
     void FlashlightTurnOff(bool bEmitSound);
 
+    // Set whether player is currently painting
+    // If true, player will be constantly firing paintgun bullets (regardless of whether it's equipped)
+    void SetIsPainting(bool bIsPainting);
+
     void SendAppearance();
 
     void Spawn() OVERRIDE;
@@ -80,15 +84,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void SetAutoBhopEnabled(bool bEnable);
     bool HasAutoBhop() const { return m_bAutoBhop; }
     bool DidPlayerBhop() const { return m_bDidPlayerBhop; }
-    // think function for detecting if player bhopped
-    void UpdateRunStats();
-    void UpdateRunSync();
-    void UpdateStrafes();
-    void UpdateMaxVelocity();
-    // slows down the player in a tween-y fashion
-    void TweenSlowdownPlayer();
     void ResetRunStats();
-    void CalculateAverageStats();
 
     void LimitSpeed(float flSpeedLimit, bool bSaveZ);
 
@@ -248,16 +244,35 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     bool IsInAirDueToJump() const { return m_bInAirDueToJump; }
 
     SavedState_t *GetSavedRunState() { return &m_SavedRunState; }
+
   private:
+    // Player think function called every tick
+    // Used to update run stats & handle painting command
+    void PlayerThink();
+    void UpdateRunSync();
+    void UpdateStrafes();
+    void UpdateMaxVelocity();
+    // slows down the player in a tween-y fashion
+    void TweenSlowdownPlayer();
+    void CalculateAverageStats();
+
+    // Whether enough time has passed since last paint to do another
+    bool CanPaint();
+    void DoPaint();
+
     // Spawn stuff
     bool SelectSpawnSpot(const char *pEntClassName, CBaseEntity *&pSpot);
     void SetPracticeModeState();
 
+  private:
     CSteamID m_sSpecTargetSteamID;
 
     bool m_bInAirDueToJump;
 
     bool m_bWasSpectating; // Was the player spectating and then respawned?
+
+    bool m_bIsPainting;
+    float m_flNextPaintTime;
 
     // Strafe sync.
     int m_nPerfectSyncTicks;

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -50,10 +50,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void FlashlightTurnOff() OVERRIDE;
     void FlashlightTurnOff(bool bEmitSound);
 
-    // Set whether player is currently painting
-    // If true, player will be constantly firing paintgun bullets (regardless of whether it's equipped)
-    void SetIsPainting(bool bIsPainting);
-
     void SendAppearance();
 
     void Spawn() OVERRIDE;
@@ -64,6 +60,8 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void SetupVisibility(CBaseEntity *pViewEntity, unsigned char *pvs, int pvssize) OVERRIDE;
 
     void FireGameEvent(IGameEvent *pEvent) OVERRIDE;
+
+    void ItemPostFrame() OVERRIDE;
 
     // Make sure we don't pick up weapons we shouldn't (default behaviour is weird)
     bool BumpWeapon(CBaseCombatWeapon *pWeapon) OVERRIDE;
@@ -247,7 +245,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
   private:
     // Player think function called every tick
-    // Used to update run stats & handle painting command
+    // Used to update run stats
     void PlayerThink();
     void UpdateRunSync();
     void UpdateStrafes();
@@ -271,7 +269,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     bool m_bWasSpectating; // Was the player spectating and then respawned?
 
-    bool m_bIsPainting;
     float m_flNextPaintTime;
 
     // Strafe sync.

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -220,7 +220,7 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
     if (stage == 1)
     {
         // They clicked "request savelocs" from a player, UI just opened, get the count to send back
-        SavelocReqPacket_t packet;
+        SavelocReqPacket packet;
         packet.stage = 1;
         if (g_pMomentumGhostClient->SendSavelocReqPacket(target, &packet))
         {
@@ -232,7 +232,7 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
     else if (stage == 3)
     {
         // They clicked on the # of savelocs to request, build a request packet and get these bad boys
-        SavelocReqPacket_t packet;
+        SavelocReqPacket packet;
         packet.stage = 3;
         packet.saveloc_count = pKv->GetInt("count");
         packet.dataBuf.CopyBuffer(pKv->GetPtr("nums"), sizeof(int) * packet.saveloc_count);
@@ -244,7 +244,7 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
         SetRequestingSavelocsFrom(0);
 
         // Let our requestee know
-        SavelocReqPacket_t packet;
+        SavelocReqPacket packet;
         packet.stage = -1;
         g_pMomentumGhostClient->SendSavelocReqPacket(target, &packet);
     }
@@ -284,7 +284,7 @@ void CMOMSaveLocSystem::SetRequestingSavelocsFrom(const uint64& from)
     m_iRequesting = from;
 }
 
-bool CMOMSaveLocSystem::FillSavelocReq(const bool sending, SavelocReqPacket_t *input, SavelocReqPacket_t *outputBuf)
+bool CMOMSaveLocSystem::FillSavelocReq(const bool sending, SavelocReqPacket *input, SavelocReqPacket *outputBuf)
 {
     if (sending)
     {
@@ -481,7 +481,7 @@ void CMOMSaveLocSystem::UpdateRequesters()
         return;
 
     // Send them our saveloc count
-    SavelocReqPacket_t response;
+    SavelocReqPacket response;
     response.stage = 2;
     response.saveloc_count = m_rcSavelocs.Count();
 

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -3,7 +3,7 @@
 #include "eventqueue.h"
 
 class CMomentumPlayer;
-struct SavelocReqPacket_t;
+class SavelocReqPacket;
 
 // Saved Location used in the "Saveloc menu"
 struct SavedLocation_t
@@ -57,7 +57,7 @@ public:
     // Called when a saveloc request is completed.
     // When sending (our savelocs to them), input = the nums, output = binary savelocs
     // When !sending (recv savelocs from them), input = the savelocs, output = not needed
-    bool FillSavelocReq(bool sending, SavelocReqPacket_t *input, SavelocReqPacket_t *outputBuf);
+    bool FillSavelocReq(bool sending, SavelocReqPacket *input, SavelocReqPacket *outputBuf);
 
     // Local
     // Gets the current menu Saveloc index

--- a/mp/src/game/shared/in_buttons.h
+++ b/mp/src/game/shared/in_buttons.h
@@ -35,9 +35,8 @@
 #define IN_WEAPON2		(1 << 21)	// weapon defines these bits
 #define IN_BHOPDISABLED	(1 << 22)	// used for displaying when bhop is disabled
 #define IN_GRENADE1		(1 << 23)	// grenade 1
-#define IN_GRENADE2		(1 << 24)	// grenade 2
+#define IN_PAINT		(1 << 24)	// grenade 2
 #define	IN_ATTACK3		(1 << 25)
 #define IN_STRAFE       (1 << 26)
-#define IN_PAINT        (1 << 27)
 
 #endif // IN_BUTTONS_H

--- a/mp/src/game/shared/in_buttons.h
+++ b/mp/src/game/shared/in_buttons.h
@@ -38,5 +38,6 @@
 #define IN_GRENADE2		(1 << 24)	// grenade 2
 #define	IN_ATTACK3		(1 << 25)
 #define IN_STRAFE       (1 << 26)
+#define IN_PAINT        (1 << 27)
 
 #endif // IN_BUTTONS_H

--- a/mp/src/game/shared/in_buttons.h
+++ b/mp/src/game/shared/in_buttons.h
@@ -33,7 +33,7 @@
 #define IN_ZOOM			(1 << 19)	// Zoom key for HUD zoom
 #define IN_WEAPON1		(1 << 20)	// weapon defines these bits
 #define IN_WEAPON2		(1 << 21)	// weapon defines these bits
-#define IN_BULLRUSH		(1 << 22)   // used for displaying when bhop is disabled
+#define IN_BHOPDISABLED	(1 << 22)	// used for displaying when bhop is disabled
 #define IN_GRENADE1		(1 << 23)	// grenade 1
 #define IN_GRENADE2		(1 << 24)	// grenade 2
 #define	IN_ATTACK3		(1 << 25)

--- a/mp/src/game/shared/momentum/fx_mom_shared.cpp
+++ b/mp/src/game/shared/momentum/fx_mom_shared.cpp
@@ -119,19 +119,18 @@ void FX_FireBullets(int iEntIndex, const Vector &vOrigin, const QAngle &vAngles,
 
     if (pPlayer) // Only send this packet if it was us firing the bullet(s) all along
     {
-        DecalPacket_t decalPacket;
+        DecalPacket decalPacket;
         if (iWeaponID == WEAPON_PAINTGUN)
         {
             Color decalColor;
             if (!MomUtil::GetColorFromHex(ConVarRef("mom_paintgun_color").GetString(), decalColor))
                 decalColor = COLOR_WHITE;
 
-            decalPacket = DecalPacket_t(DECAL_PAINT, vOrigin, vAngles, decalColor.GetRawColor(), 0, 0,
-                                        ConVarRef("mom_paintgun_scale").GetFloat());
+            decalPacket = DecalPacket::Paint(vOrigin, vAngles, decalColor, ConVarRef("mom_paintgun_scale").GetFloat());
         }
         else
         {
-            decalPacket = DecalPacket_t(DECAL_BULLET, vOrigin, vAngles, iWeaponID, iMode, iSeed, flSpread);
+            decalPacket = DecalPacket::Bullet( vOrigin, vAngles, iWeaponID, iMode, iSeed, flSpread);
         }
 
         g_pMomentumGhostClient->SendDecalPacket(&decalPacket);

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1404,9 +1404,9 @@ void CMomentumGameMovement::FullWalkMove()
 
     // For the HUD (see hud_timer.cpp)
     if (bPlayerBhopBlocked)
-        m_pPlayer->m_afButtonDisabled |= IN_BULLRUSH;
+        m_pPlayer->m_afButtonDisabled |= IN_BHOPDISABLED;
     else
-        m_pPlayer->m_afButtonDisabled &= ~IN_BULLRUSH;
+        m_pPlayer->m_afButtonDisabled &= ~IN_BHOPDISABLED;
 }
 
 // This limits the player's speed in the start zone, depending on which gamemode the player is currently playing.

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -3,7 +3,7 @@
 #include "utlbuffer.h"
 #include "mom_shareddefs.h"
 
-enum PacketTypes
+enum PacketType
 {
     PT_CONN_REQ = 0,
     PT_CONN_ACK,
@@ -26,12 +26,13 @@ enum PacketTypes
 #define DEFAULT_STEAM_PORT 9001
 #define DEFAULT_MASTER_SERVER_PORT 9002
 
-struct MomentumPacket_t
+class MomentumPacket
 {
-    uint8 type;
-    virtual ~MomentumPacket_t() {};
+  public:
+    virtual PacketType GetType() const = 0;
+    virtual ~MomentumPacket() {};
 
-    virtual void Write(CUtlBuffer &buf) { buf.PutUnsignedChar(type); }
+    virtual void Write(CUtlBuffer &buf) { buf.PutUnsignedChar(GetType()); }
 };
 
 //Describes all data for visual apperence of players ingame
@@ -99,17 +100,17 @@ struct LobbyGhostAppearance_t
 
 
 // Based on CReplayFrame, describes data needed for ghost's physical properties 
-struct PositionPacket_t : MomentumPacket_t
+class PositionPacket : public MomentumPacket
 {
+  public:
     int Buttons;
     float ViewOffset;
     QAngle EyeAngle;
     Vector Position;
     Vector Velocity;
-    PositionPacket_t(const QAngle eyeAngle, const Vector position, const Vector velocity, 
+    PositionPacket(const QAngle eyeAngle, const Vector position, const Vector velocity, 
         const float viewOffsetZ, const int buttons)
     {
-        type = PT_POS_DATA;
         EyeAngle = eyeAngle;
         Position = position;
         Velocity = velocity;
@@ -118,13 +119,11 @@ struct PositionPacket_t : MomentumPacket_t
         ViewOffset = viewOffsetZ;
     }
 
-    PositionPacket_t(): Buttons(0), ViewOffset(0)
+    PositionPacket(): Buttons(0), ViewOffset(0)
     {
-        type = PT_POS_DATA;
     }
-    PositionPacket_t(CUtlBuffer &buf)
+    PositionPacket(CUtlBuffer &buf)
     {
-        type = PT_POS_DATA;
         buf.Get(&EyeAngle, sizeof(QAngle));
         buf.Get(&Position, sizeof(Vector));
         buf.Get(&Velocity, sizeof(Vector));
@@ -132,9 +131,11 @@ struct PositionPacket_t : MomentumPacket_t
         ViewOffset = buf.GetFloat();
     }
 
+    PacketType GetType() const OVERRIDE { return PT_POS_DATA; }
+
     void Write(CUtlBuffer& buf) OVERRIDE
     {
-        MomentumPacket_t::Write(buf);
+        MomentumPacket::Write(buf);
         buf.Put(&EyeAngle, sizeof(QAngle));
         buf.Put(&Position, sizeof(Vector));
         buf.Put(&Velocity, sizeof(Vector));
@@ -142,7 +143,7 @@ struct PositionPacket_t : MomentumPacket_t
         buf.PutFloat(ViewOffset);
     }
 
-    PositionPacket_t& operator=(const PositionPacket_t &other)
+    PositionPacket& operator=(const PositionPacket &other)
     {
         Buttons = other.Buttons;
         ViewOffset = other.ViewOffset;
@@ -152,7 +153,7 @@ struct PositionPacket_t : MomentumPacket_t
         return *this;
     }
 
-    bool operator==(const PositionPacket_t &other) const
+    bool operator==(const PositionPacket &other) const
     {
         return EyeAngle == other.EyeAngle &&
             Position == other.Position &&
@@ -180,112 +181,145 @@ struct ReceivedFrame_t
 
 
 
-struct SpecUpdatePacket_t : MomentumPacket_t
+class SpecUpdatePacket : public MomentumPacket
 {
+  public:
     uint64 specTarget;
     SpectateMessageType_t spec_type;
 
-    SpecUpdatePacket_t(uint64 uID, SpectateMessageType_t specType)
+    SpecUpdatePacket(uint64 uID, SpectateMessageType_t specType)
     {
-        type = PT_SPEC_UPDATE;
         specTarget = uID;
         spec_type = specType;
     }
 
-    SpecUpdatePacket_t(CUtlBuffer &buf)
+    SpecUpdatePacket(CUtlBuffer &buf)
     {
-        type = PT_SPEC_UPDATE;
         specTarget = static_cast<uint64>(buf.GetInt64());
         spec_type = static_cast<SpectateMessageType_t>(buf.GetInt());
     }
 
+    PacketType GetType() const OVERRIDE { return PT_SPEC_UPDATE; }
+
     void Write(CUtlBuffer& buf) OVERRIDE
     {
-        MomentumPacket_t::Write(buf);
+        MomentumPacket::Write(buf);
         buf.PutUint64(specTarget);
         buf.PutInt(spec_type);
     }
 };
 
-typedef enum
+enum DecalType
 {
     DECAL_BULLET = 0,
     DECAL_PAINT,
     DECAL_KNIFE
     // etc
+};
 
-} DECAL_TYPE;
-
-struct DecalPacket_t : MomentumPacket_t
+struct BulletDecalData
 {
-    // Type of decal.
-    DECAL_TYPE decal_type;
+    int iWeaponID;
+    int iMode;
+    int iSeed;
+    float fSpread;
+};
 
-    Vector vOrigin;
-    QAngle vAngle;
+struct PaintDecalData
+{
+    Color color;
+    float fDecalRadius;
+};
 
-    int iWeaponID; // or colorRed or bStab for knife
-    int iMode;     // or colorGreen
-    int iSeed;     // or colorBlue
-    float fSpread; // or Radius of decal
+struct KnifeDecalData
+{
+    bool bStab;
+};
 
-    DecalPacket_t() : decal_type(DECAL_BULLET), iWeaponID(0), iMode(0), iSeed(0), fSpread(0)
+class DecalPacket : public MomentumPacket
+{
+  private:
+    DecalPacket(DecalType decalType, Vector origin, QAngle angle)
     {
-        type = PT_DECAL_DATA;
-    }
-
-    DecalPacket_t(DECAL_TYPE decalType, Vector origin, QAngle angle, int weaponID, int mode, int seed, float spread)
-    {
-        type = PT_DECAL_DATA;
         decal_type = decalType;
         vOrigin = origin;
         vAngle = angle;
-        iWeaponID = weaponID;
-        iMode = mode;
-        iSeed = seed;
-        fSpread = spread;
+    }
+  public:
+    Vector vOrigin;
+    
+    DecalType decal_type;
+    
+    QAngle vAngle;
+
+    union DecalData
+    {
+        DecalData() {}
+        BulletDecalData bullet; // When decal type is DECAL_BULLET
+        PaintDecalData paint;   // When decal type is DECAL_PAINT
+        KnifeDecalData knife;   // When decal type is DECAL_KNIFE
+    };
+    DecalData data;
+
+    DecalPacket() {}
+
+    static DecalPacket Bullet(Vector origin, QAngle angle, int iWeaponID, int iMode, int iSeed, float fSpread)
+    {
+        DecalPacket packet(DECAL_BULLET, origin, angle);
+        packet.data.bullet.iWeaponID = iWeaponID;
+        packet.data.bullet.iMode = iMode;
+        packet.data.bullet.iSeed = iSeed;
+        packet.data.bullet.fSpread = fSpread;
+        return packet;
     }
 
-    DecalPacket_t(CUtlBuffer &buf)
+    static DecalPacket Paint(Vector origin, QAngle angle, Color color, float fDecalRadius)
     {
-        type = PT_DECAL_DATA;
-        decal_type = static_cast<DECAL_TYPE>(buf.GetUnsignedChar());
+        DecalPacket packet(DECAL_PAINT, origin, angle);
+        packet.data.paint.color = color;
+        packet.data.paint.fDecalRadius = fDecalRadius;
+        return packet;
+    }
+
+    static DecalPacket Knife( Vector origin, QAngle angle, bool bStab )
+    {
+        DecalPacket packet(DECAL_KNIFE, origin, angle);
+        packet.data.knife.bStab = bStab;
+        return packet;
+    }
+
+    DecalPacket(CUtlBuffer &buf)
+    {
+        decal_type = static_cast<DecalType>(buf.GetUnsignedChar());
         buf.Get(&vOrigin, sizeof(Vector));
         buf.Get(&vAngle, sizeof(QAngle));
-        iWeaponID = buf.GetInt();
-        iMode = buf.GetInt();
-        iSeed = buf.GetInt();
-        fSpread = buf.GetFloat();
+        buf.Get(&data, sizeof(data));
     }
 
-    DecalPacket_t& operator=(const DecalPacket_t &other)
+    DecalPacket& operator=(const DecalPacket &other)
     {
-        type = other.type;
         decal_type = other.decal_type;
         vOrigin = other.vOrigin;
         vAngle = other.vAngle;
-        iWeaponID = other.iWeaponID;
-        iMode = other.iMode;
-        iSeed = other.iSeed;
-        fSpread = other.fSpread;
+        memcpy(&data, &other.data, sizeof(data));
         return *this;
     }
 
+    PacketType GetType() const OVERRIDE { return PT_DECAL_DATA; }
+
     void Write(CUtlBuffer& buf) OVERRIDE
     {
-        MomentumPacket_t::Write(buf);
+        MomentumPacket::Write(buf);
         buf.PutUnsignedChar(decal_type);
         buf.Put(&vOrigin, sizeof(Vector));
         buf.Put(&vAngle, sizeof(QAngle));
-        buf.PutInt(iWeaponID); // MOM_TODO: We don't use all 32 bits here, write a lower precision?
-        buf.PutInt(iMode);
-        buf.PutInt(iSeed);
-        buf.PutFloat(fSpread);
+        buf.Put(&data, sizeof(data));
     }
 };
 
-struct SavelocReqPacket_t : MomentumPacket_t
+class SavelocReqPacket : public MomentumPacket
 {
+  public:
     // Stage type
     int stage;
 
@@ -297,35 +331,31 @@ struct SavelocReqPacket_t : MomentumPacket_t
     // Stage == 4 ? (The actual saveloc data, in binary)
     CUtlBuffer dataBuf;
 
-    SavelocReqPacket_t(): stage(0), saveloc_count(0)
+    SavelocReqPacket(): stage(0), saveloc_count(0)
     {
-        type = PT_SAVELOC_REQ;
         dataBuf.SetBigEndian(false);
     }
 
-    SavelocReqPacket_t(CUtlBuffer &buf)
+    SavelocReqPacket(CUtlBuffer &buf)
     {
-        type = PT_SAVELOC_REQ;
         stage = buf.GetInt();
-        if (stage == 2)
+        if (stage > 1)
         {
             saveloc_count = buf.GetInt();
-        }
-        else if (stage > 2)
-        {
-            dataBuf.CopyBuffer(buf);
-            // The CopyBuffer method clears the dataBuf and swallows everything inside of buf.
-            // We first need to skip over the 5 bytes used for type + stage
-            dataBuf.SeekGet(CUtlBuffer::SEEK_CURRENT, 5);
-            // And now pull out the saveloc count
-            saveloc_count = dataBuf.GetInt();
-            // And now our buffer's Get is currently in the location for reading the data
+
+            if (stage > 2)
+            {
+                dataBuf.Clear();
+                dataBuf.Put(buf.PeekGet(), buf.GetBytesRemaining());
+            }
         }
     }
 
+    PacketType GetType() const OVERRIDE { return PT_SAVELOC_REQ; }
+
     void Write(CUtlBuffer& buf) OVERRIDE
     {
-        MomentumPacket_t::Write(buf);
+        MomentumPacket::Write(buf);
         buf.PutInt(stage);
         if (stage > 1)
         {

--- a/mp/src/game/shared/momentum/weapon/weapon_knife.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_knife.cpp
@@ -189,7 +189,7 @@ bool CKnife::SwingOrStab(bool bStab)
     // MOM_TODO: Determine if we should pass this into KnifeTrace
     // bool bFirstSwing = (m_flNextPrimaryAttack + 0.4) < gpGlobals->curtime;
 
-    DecalPacket_t packet(DECAL_KNIFE, pPlayer->Weapon_ShootPosition(), pPlayer->EyeAngles(), bStab, 0, 0, 0);
+    DecalPacket packet = DecalPacket::Knife(pPlayer->Weapon_ShootPosition(), pPlayer->EyeAngles(), bStab);
     g_pMomentumGhostClient->SendDecalPacket(&packet);
 #endif
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.cpp
@@ -337,7 +337,7 @@ void CMomentumGrenade::ThrowGrenade()
 #ifdef GAME_DLL
     QAngle vecThrowOnline(vecThrow.x, vecThrow.y,
                           vecThrow.z); // Online uses angles, but we're packing 3 floats so whatever
-    DecalPacket_t packet(DECAL_BULLET, vecSrc, vecThrowOnline, WEAPON_GRENADE, impulseInt, 0, 0.0f);
+    DecalPacket packet = DecalPacket::Bullet(vecSrc, vecThrowOnline, WEAPON_GRENADE, impulseInt, 0, 0.0f);
     g_pMomentumGhostClient->SendDecalPacket(&packet);
 #endif
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_paintgun.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_paintgun.cpp
@@ -44,7 +44,7 @@ CMomentumPaintGun::~CMomentumPaintGun()
 void CMomentumPaintGun::RifleFire()
 {
     // Hardcoded here so people don't change the text files for easy spam
-    if (!BaseGunFire(0.0f, 0.1f, true))
+    if (!BaseGunFire(0.0f, GetPrimaryCycleTime(), true))
         return;
 }
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_paintgun.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_paintgun.h
@@ -22,6 +22,7 @@ class CMomentumPaintGun : public CWeaponBaseGun
     void PrimaryAttack() OVERRIDE;
     void SecondaryAttack() OVERRIDE;
     CWeaponID GetWeaponID(void) const OVERRIDE { return WEAPON_PAINTGUN; }
+    static float GetPrimaryCycleTime() { return 0.1f; }
 
     void RifleFire();
     


### PR DESCRIPTION
Allows players to paint, without needing to pull out their hefty paintgun, by using `+paint`.

Also did some minor cleanup on some of the code:
* Privatized some needlessly public functions in `CMomentumPlayer`
* Changed packet structs in ghostdefs to classes & removed the `_t` suffix (it's weird to have structs with inheritance/virtuals)
* Changed the disgusting DIY aliasing on the decal packet into a union for clearer code

Closes #281