### PR TITLE
Rocket jumping gamemode movement changes

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -160,11 +160,15 @@ static ConVar mom_trail_enable("mom_trail_enable", "0", FCVAR_CLIENTCMD_CAN_EXEC
                                "Paint a faint beam trail on the player. 0 = OFF, 1 = ON\n", true, 0, true, 1,
                                AppearanceCallback);
 
-// Rocket jump self damage ConVars
-// Equivalent to "tf_damageforcescale_self_soldier_rj", "tf_damageforcescale_self_soldier_badrj", and "tf_damagescale_self_soldier" in TF2
-static ConVar mom_damageforcescale_self_rocket_air("mom_damageforcescale_self_rocket_air", "10.0", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY);
+// Rocket jump force ConVars
+
+// Equivalent to "tf_damageforcescale_self_soldier_rj" (default 10.0) in TF2
+// NOTE: TF2 also uses "tf_damagescale_self_soldier" (default: 0.6) for reducing selfdamage taken midair ONLY.
+// Since we're not concerned with damage, just lower the force scale. (10.0 * 0.6 = 6.0)
+static ConVar mom_damageforcescale_self_rocket_air("mom_damageforcescale_self_rocket_air", "6.0", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY);
+
+// Equivalent to "tf_damageforcescale_self_soldier_badrj" (default: 5.0) in TF2
 static ConVar mom_damageforcescale_self_rocket("mom_damageforcescale_self_rocket", "5.0", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY);
-static ConVar mom_damagescale_self_rocket("mom_damagescale_self_rocket", "0.60", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY);
 
 // Handles ALL appearance changes by setting the proper appearance value in m_playerAppearanceProps,
 // as well as changing the appearance locally.
@@ -1795,32 +1799,6 @@ static float DamageForce(const Vector &size, float damage, float scale)
     }
 
     return force;
-}
-
-int CMomentumPlayer::OnTakeDamage(const CTakeDamageInfo &info)
-{
-    CTakeDamageInfo adjustedInfo = info;
-
-    if (GetFlags() & FL_GODMODE)
-        return 0;
-
-    // Early out if there's no damage
-    if (!adjustedInfo.GetDamage())
-        return 0;
-
-    if (!IsAlive())
-        return 0;
-
-    CBaseEntity *pAttacker = adjustedInfo.GetAttacker();
-    CBaseEntity *pInflictor = adjustedInfo.GetInflictor();
-
-    // Take reduced damage midair from own rockets
-    if (pAttacker == this && FClassnameIs(pInflictor, "momentum_rocket") && GetGroundEntity() == nullptr)
-    {
-        adjustedInfo.SetDamage(adjustedInfo.GetDamage() * mom_damagescale_self_rocket.GetFloat());
-    }
-
-    return CBaseCombatCharacter::OnTakeDamage(adjustedInfo);
 }
 
 int CMomentumPlayer::OnTakeDamage_Alive(const CTakeDamageInfo &info)

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -229,7 +229,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void PreThink() OVERRIDE;
     void PostThink() OVERRIDE;
 
-    int OnTakeDamage(const CTakeDamageInfo& info) OVERRIDE;
     int OnTakeDamage_Alive(const CTakeDamageInfo &info) OVERRIDE;
 
     void ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &vecDir);

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -227,6 +227,19 @@ void CMomentumGameMovement::WalkMove()
     // Set pmove velocity
     Accelerate(wishdir, wishspeed, sv_accelerate.GetFloat());
 
+    // Cap ground movement speed in RJ
+    static ConVarRef gm("mom_gamemode");
+    if (gm.GetInt() == GAMEMODE_RJ)
+    {
+        float flNewSpeed = VectorLength(mv->m_vecVelocity);
+        if (flNewSpeed > mv->m_flMaxSpeed)
+        {
+            float flScale = (mv->m_flMaxSpeed / flNewSpeed);
+            mv->m_vecVelocity.x *= flScale;
+            mv->m_vecVelocity.y *= flScale;
+        }
+    }
+
     // Add in any base velocity to the current velocity.
     VectorAdd(mv->m_vecVelocity, player->GetBaseVelocity(), mv->m_vecVelocity);
 

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -228,10 +228,8 @@ void CMomentumGameMovement::WalkMove()
     Accelerate(wishdir, wishspeed, sv_accelerate.GetFloat());
 
     // Cap ground movement speed in RJ
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
-        // Cap ground movement speed in RJ
         float flNewSpeed = VectorLength(mv->m_vecVelocity);
         if (flNewSpeed > mv->m_flMaxSpeed)
         {
@@ -851,8 +849,7 @@ void CMomentumGameMovement::FinishDuck(void)
     Vector hullSizeCrouch = VEC_DUCK_HULL_MAX - VEC_DUCK_HULL_MIN;
 
     float flViewScale = 0.5f;
-    static ConVarRef gm("mom_gamemode");
-    if (gm.GetInt() == GAMEMODE_RJ)
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
         flViewScale = 1.0f;
 
     Vector viewDelta = flViewScale * (hullSizeNormal - hullSizeCrouch);

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -824,7 +824,12 @@ void CMomentumGameMovement::FinishDuck(void)
     Vector hullSizeNormal = VEC_HULL_MAX - VEC_HULL_MIN;
     Vector hullSizeCrouch = VEC_DUCK_HULL_MAX - VEC_DUCK_HULL_MIN;
 
-    Vector viewDelta = 0.5f * (hullSizeNormal - hullSizeCrouch);
+    float flViewScale = 0.5f;
+    static ConVarRef gm("mom_gamemode");
+    if (gm.GetInt() == GAMEMODE_RJ)
+        flViewScale = 1.0f;
+
+    Vector viewDelta = flViewScale * (hullSizeNormal - hullSizeCrouch);
 
     player->SetViewOffset(GetPlayerViewOffset(true));
     player->AddFlag(FL_DUCKING);


### PR DESCRIPTION
Crouching and ground speed cap changes from #347.  
It still seems like rockets give too much speed compared to TF2. I've been debugging this for a while now and either I'm missing something dumb, or the way it's handled in TF2 has changed since 2007.