### PR TITLE
Rocket self-damage fixes

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1800,9 +1800,9 @@ void CMomentumPlayer::PostThink()
     BaseClass::PostThink();
 }
 
-static float DamageForce(const Vector &size, float damage, float scale)
+static float DamageForce(float damage, float scale)
 { 
-    float force = damage * ((48.0f * 48.0f * 82.0f) / (size.x * size.y * size.z)) * scale;
+    float force = damage * scale;
 
     if (force > 1000.0f)
     {
@@ -1863,7 +1863,16 @@ void CMomentumPlayer::ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &v
         flScale = mom_damageforcescale_self_rocket_air.GetFloat();
     }
 
-    Vector vecForce = vecDir * -DamageForce(WorldAlignSize(), info.GetDamage(), flScale);
+    // Scale force if we're ducked
+    if (GetFlags() & FL_DUCKING)
+    {
+        // TF2 crouching collision box height used to be 55 units,
+        // before it was changed to 62, the old height is still used
+        // for calculating force from explosions.
+        flScale *= 82.0f / 55.0f;
+    }
+
+    Vector vecForce = vecDir * -DamageForce(info.GetDamage(), flScale);
     ApplyAbsVelocityImpulse(vecForce);
 }
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1800,18 +1800,6 @@ void CMomentumPlayer::PostThink()
     BaseClass::PostThink();
 }
 
-static float DamageForce(float damage, float scale)
-{ 
-    float force = damage * scale;
-
-    if (force > 1000.0f)
-    {
-        force = 1000.0f;
-    }
-
-    return force;
-}
-
 int CMomentumPlayer::OnTakeDamage_Alive(const CTakeDamageInfo &info)
 {
     CBaseEntity *pAttacker = info.GetAttacker();
@@ -1872,7 +1860,9 @@ void CMomentumPlayer::ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &v
         flScale *= 82.0f / 55.0f;
     }
 
-    Vector vecForce = vecDir * -DamageForce(info.GetDamage(), flScale);
+    // Clamp force to 1000.0f
+    float force = Min(info.GetDamage() * flScale, 1000.0f);
+    Vector vecForce = -vecDir * force;
     ApplyAbsVelocityImpulse(vecForce);
 }
 


### PR DESCRIPTION
Fixed rockets giving too much speed and fixed crouched collision box being the incorrect height, thanks to ILDPRUT. (#347 )

There's probably a better way to do the RadiusDamage stuff if it is ever used for other weapons, all the changes I've made to the default implementation have been with just rocket jumping in mind.