### PR TITLE
Fixed weapon equipping / switching

### DIFF
--- a/mp/src/game/server/basecombatcharacter.cpp
+++ b/mp/src/game/server/basecombatcharacter.cpp
@@ -2221,20 +2221,26 @@ bool CBaseCombatCharacter::Weapon_SlotOccupied( CBaseCombatWeapon *pWeapon )
 //-----------------------------------------------------------------------------
 CBaseCombatWeapon *CBaseCombatCharacter::Weapon_GetSlot( int slot ) const
 {
-	int	targetSlot = slot;
+    return Weapon_GetSlotAndPosition(slot);
+}
 
-	// Check for that slot being occupied already
-	for ( int i=0; i < MAX_WEAPONS; i++ )
-	{
-		if ( m_hMyWeapons[i].Get() != NULL )
-		{
-			// If the slots match, it's already occupied
-			if ( m_hMyWeapons[i]->GetSlot() == targetSlot )
-				return m_hMyWeapons[i];
-		}
-	}
-	
-	return NULL;
+CBaseCombatWeapon *CBaseCombatCharacter::Weapon_GetSlotAndPosition( int slot, int pos /*= INT_MIN*/ ) const
+{
+    // Check for that slot being occupied already
+    for (auto i = 0; i < MAX_WEAPONS; i++)
+    {
+        const auto pWeapon = m_hMyWeapons[i].Get();
+        if (pWeapon && pWeapon->GetSlot() == slot)
+        {
+            // If the slots match, check the position as well, if we should
+            if (pos != INT_MIN && pWeapon->GetPosition() != pos)
+                continue;
+            
+            return m_hMyWeapons[i];
+        }
+    }
+
+    return nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/server/basecombatcharacter.h
+++ b/mp/src/game/server/basecombatcharacter.h
@@ -236,6 +236,7 @@ public:
 	virtual	bool		Weapon_CanSwitchTo(CBaseCombatWeapon *pWeapon);
 	virtual bool		Weapon_SlotOccupied( CBaseCombatWeapon *pWeapon );
 	virtual CBaseCombatWeapon *Weapon_GetSlot( int slot ) const;
+    virtual CBaseCombatWeapon *Weapon_GetSlotAndPosition( int slot, int pos = INT_MIN ) const;
 	CBaseCombatWeapon	*Weapon_GetWpnForAmmo( int iAmmoIndex );
 
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -395,8 +395,8 @@ void CMomentumPlayer::ItemPostFrame()
 bool CMomentumPlayer::BumpWeapon(CBaseCombatWeapon *pWeapon)
 {
     // Get the weapon that we currently have at that slot
-    CBaseCombatWeapon *pCurrWeapon = Weapon_GetSlot(pWeapon->GetSlot());
-    if (pCurrWeapon != nullptr)
+    const auto pCurrWeapon = Weapon_GetSlotAndPosition(pWeapon->GetSlot(), pWeapon->GetPosition());
+    if (pCurrWeapon)
     {
         // Switch to that weapon for convenience
         Weapon_Switch(pCurrWeapon);

--- a/mp/src/game/shared/momentum/weapon/weapon_cs_guns.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_cs_guns.cpp
@@ -11,7 +11,7 @@
 
 // Macro used to override the CS weapons
 #ifdef CLIENT_DLL
-#define CS_WEP_OVERRIDE(csGun, momGun, entName)                                                                        \
+#define CS_WEP_OVERRIDE(csGun, momGun, entName, momEntName)                                                            \
     class C_##csGun : public momGun                                                                                    \
     {                                                                                                                  \
       public:                                                                                                          \
@@ -27,13 +27,14 @@
     LINK_ENTITY_TO_CLASS(entName, C_##csGun)                                                                           \
     PRECACHE_WEAPON_REGISTER(entName)
 #else
-#define CS_WEP_OVERRIDE(csGun, momGun, entName)                                                                        \
+#define CS_WEP_OVERRIDE(csGun, momGun, entName, momEntName)                                                            \
     class csGun : public momGun                                                                                        \
     {                                                                                                                  \
       public:                                                                                                          \
         DECLARE_CLASS(csGun, momGun);                                                                                  \
         DECLARE_PREDICTABLE();                                                                                         \
         csGun(){};                                                                                                     \
+        void PostConstructor( const char *pszClassname ) OVERRIDE { BaseClass::PostConstructor(#momEntName); }         \
                                                                                                                        \
       private:                                                                                                         \
         csGun(const csGun &){};                                                                                        \
@@ -45,42 +46,42 @@
 #endif
 
 //Rifles
-CS_WEP_OVERRIDE(CAK47, CMomentumRifle, weapon_ak47);
-CS_WEP_OVERRIDE(CWeaponAug, CMomentumRifle, weapon_aug);
-CS_WEP_OVERRIDE(CWeaponFamas, CMomentumRifle, weapon_famas);
-CS_WEP_OVERRIDE(CWeaponGalil, CMomentumRifle, weapon_galil);
-CS_WEP_OVERRIDE(CWeaponM4A1, CMomentumRifle, weapon_m4a1);
-CS_WEP_OVERRIDE(CWeaponSG552, CMomentumRifle, weapon_sg552);
+CS_WEP_OVERRIDE(CAK47,        CMomentumRifle, weapon_ak47,  weapon_momentum_rifle);
+CS_WEP_OVERRIDE(CWeaponAug,   CMomentumRifle, weapon_aug,   weapon_momentum_rifle);
+CS_WEP_OVERRIDE(CWeaponFamas, CMomentumRifle, weapon_famas, weapon_momentum_rifle);
+CS_WEP_OVERRIDE(CWeaponGalil, CMomentumRifle, weapon_galil, weapon_momentum_rifle);
+CS_WEP_OVERRIDE(CWeaponM4A1,  CMomentumRifle, weapon_m4a1,  weapon_momentum_rifle);
+CS_WEP_OVERRIDE(CWeaponSG552, CMomentumRifle, weapon_sg552, weapon_momentum_rifle);
 
 //Snipers
-CS_WEP_OVERRIDE(CWeaponScout, CMomentumSniper, weapon_scout);
-CS_WEP_OVERRIDE(CWeaponG3SG1, CMomentumSniper, weapon_g3sg1);
-CS_WEP_OVERRIDE(CWeaponSG550, CMomentumSniper, weapon_sg550);
-CS_WEP_OVERRIDE(CWeaponAWP, CMomentumSniper, weapon_awp);
+CS_WEP_OVERRIDE(CWeaponScout, CMomentumSniper, weapon_scout, weapon_momentum_sniper);
+CS_WEP_OVERRIDE(CWeaponG3SG1, CMomentumSniper, weapon_g3sg1, weapon_momentum_sniper);
+CS_WEP_OVERRIDE(CWeaponSG550, CMomentumSniper, weapon_sg550, weapon_momentum_sniper);
+CS_WEP_OVERRIDE(CWeaponAWP,   CMomentumSniper, weapon_awp,   weapon_momentum_sniper);
 
 //Pistols
-CS_WEP_OVERRIDE(CDeagle, CMomentumPistol, weapon_deagle);
-CS_WEP_OVERRIDE(CWeaponElite, CMomentumPistol, weapon_elite);
-CS_WEP_OVERRIDE(CWeaponFiveSeven, CMomentumPistol, weapon_fiveseven);
-CS_WEP_OVERRIDE(CWeaponGlock, CMomentumPistol, weapon_glock);
-CS_WEP_OVERRIDE(CWeaponP228, CMomentumPistol, weapon_p228);
-CS_WEP_OVERRIDE(CWeaponUSP, CMomentumPistol, weapon_usp);
+CS_WEP_OVERRIDE(CDeagle,            CMomentumPistol, weapon_deagle,     weapon_momentum_pistol);
+CS_WEP_OVERRIDE(CWeaponElite,       CMomentumPistol, weapon_elite,      weapon_momentum_pistol);
+CS_WEP_OVERRIDE(CWeaponFiveSeven,   CMomentumPistol, weapon_fiveseven,  weapon_momentum_pistol);
+CS_WEP_OVERRIDE(CWeaponGlock,       CMomentumPistol, weapon_glock,      weapon_momentum_pistol);
+CS_WEP_OVERRIDE(CWeaponP228,        CMomentumPistol, weapon_p228,       weapon_momentum_pistol);
+CS_WEP_OVERRIDE(CWeaponUSP,         CMomentumPistol, weapon_usp,        weapon_momentum_pistol);
 
 //SMGs
-CS_WEP_OVERRIDE(CWeaponMAC10, CMomentumSMG, weapon_mac10);
-CS_WEP_OVERRIDE(CWeaponMP5Navy, CMomentumSMG, weapon_mp5navy);
-CS_WEP_OVERRIDE(CWeaponP90, CMomentumSMG, weapon_p90);
-CS_WEP_OVERRIDE(CWeaponTMP, CMomentumSMG, weapon_tmp);
-CS_WEP_OVERRIDE(CWeaponUMP45, CMomentumSMG, weapon_ump45);
+CS_WEP_OVERRIDE(CWeaponMAC10,   CMomentumSMG, weapon_mac10,     weapon_momentum_smg);
+CS_WEP_OVERRIDE(CWeaponMP5Navy, CMomentumSMG, weapon_mp5navy,   weapon_momentum_smg);
+CS_WEP_OVERRIDE(CWeaponP90,     CMomentumSMG, weapon_p90,       weapon_momentum_smg);
+CS_WEP_OVERRIDE(CWeaponTMP,     CMomentumSMG, weapon_tmp,       weapon_momentum_smg);
+CS_WEP_OVERRIDE(CWeaponUMP45,   CMomentumSMG, weapon_ump45,     weapon_momentum_smg);
 
 //Shotguns
-CS_WEP_OVERRIDE(CWeaponXM1014, CMomentumShotgun, weapon_xm1014);
-CS_WEP_OVERRIDE(CWeaponM3, CMomentumShotgun, weapon_m3);
+CS_WEP_OVERRIDE(CWeaponXM1014,  CMomentumShotgun, weapon_xm1014,    weapon_momentum_shotgun);
+CS_WEP_OVERRIDE(CWeaponM3,      CMomentumShotgun, weapon_m3,        weapon_momentum_shotgun);
 
 //LMG
-CS_WEP_OVERRIDE(CWeaponM249, CMomentumLMG, weapon_m249);
+CS_WEP_OVERRIDE(CWeaponM249, CMomentumLMG, weapon_m249, weapon_momentum_lmg);
 
 //Grenades
-CS_WEP_OVERRIDE(CHEGrenade, CMomentumGrenade, weapon_hegrenade);
-CS_WEP_OVERRIDE(CFlashbang, CMomentumGrenade, weapon_flashbang);
-CS_WEP_OVERRIDE(CSmokeGrenade, CMomentumGrenade, weapon_smokegrenade);
+CS_WEP_OVERRIDE(CHEGrenade,     CMomentumGrenade, weapon_hegrenade,     weapon_momentum_grenade);
+CS_WEP_OVERRIDE(CFlashbang,     CMomentumGrenade, weapon_flashbang,     weapon_momentum_grenade);
+CS_WEP_OVERRIDE(CSmokeGrenade,  CMomentumGrenade, weapon_smokegrenade,  weapon_momentum_grenade);


### PR DESCRIPTION
Closes #353 
Testing the new PBR weapons was annoying when you couldn't pick up all of them at once. 

This fixes two things:
1. A regression introduced in https://github.com/momentum-mod/game/commit/87d2429d3df7b745e6d8ea9a76dcf7dfff894f65
2. The weapon switching bug (giving yourself a cs gun and couldn't switch to it) was mainly due to the CS weapon overrides not having the correct class name.