### PR TITLE
Added mom_rj_center_fire and make rocket launcher respect firing mode

### DIFF
--- a/mp/src/game/client/c_baseviewmodel.cpp
+++ b/mp/src/game/client/c_baseviewmodel.cpp
@@ -35,7 +35,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE, "Use right-handed view models." );
+ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Use right-handed view models." );
 
 #ifdef TF_CLIENT_DLL
 	ConVar cl_flipviewmodels( "cl_flipviewmodels", "0", FCVAR_USERINFO | FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Flip view models." );

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -1,8 +1,8 @@
 #include "cbase.h"
 
 #include "mom_player_shared.h"
-#include "weapon_mom_rocketlauncher.h"
 #include "mom_system_gamemode.h"
+#include "weapon_mom_rocketlauncher.h"
 
 #include "tier0/memdbgon.h"
 
@@ -42,6 +42,22 @@ void CMomentumRocketLauncher::Precache()
 //-----------------------------------------------------------------------------
 void CMomentumRocketLauncher::GetProjectileFireSetup(CMomentumPlayer *pPlayer, Vector vecOffset, Vector *vecSrc, QAngle *angForward)
 {
+#ifdef GAME_DLL
+    static ConVarRef cl_righthand("cl_righthand");
+#else
+    extern ConVar cl_righthand;
+    static ConVarRef mom_rj_center_fire("mom_rj_center_fire");
+#endif
+
+    if (mom_rj_center_fire.GetBool())
+    {
+        vecOffset.y = 0.0f;
+    }
+    else if (!cl_righthand.GetBool())
+    {
+        vecOffset.y *= -1.0f;
+    }
+
     Vector vecForward, vecRight, vecUp;
     AngleVectors(pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp);
 
@@ -89,7 +105,7 @@ void CMomentumRocketLauncher::RocketLauncherFire()
     // MOM_FIXME:
     // This will cause an assertion error.
     // Prevents us from using BaseGunFire() as well.
-    //SendWeaponAnim(ACT_VM_PRIMARYATTACK);
+    // SendWeaponAnim(ACT_VM_PRIMARYATTACK);
 
     // player "shoot" animation
     pPlayer->SetAnimation(PLAYER_ATTACK1);
@@ -114,10 +130,7 @@ void CMomentumRocketLauncher::RocketLauncherFire()
 #endif
 }
 
-void CMomentumRocketLauncher::PrimaryAttack()
-{
-    RocketLauncherFire();
-}
+void CMomentumRocketLauncher::PrimaryAttack() { RocketLauncherFire(); }
 
 bool CMomentumRocketLauncher::CanDeploy()
 {

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -17,6 +17,11 @@ END_PREDICTION_DATA()
 LINK_ENTITY_TO_CLASS(weapon_momentum_rocketlauncher, CMomentumRocketLauncher);
 PRECACHE_WEAPON_REGISTER(weapon_momentum_rocketlauncher);
 
+#ifdef GAME_DLL
+static MAKE_TOGGLE_CONVAR(mom_rj_center_fire, "0", FCVAR_ARCHIVE,
+                          "If enabled, all rockets will be fired from the center of the screen. 0 = OFF, 1 = ON\n");
+#endif
+
 CMomentumRocketLauncher::CMomentumRocketLauncher()
 {
     m_flTimeToIdleAfterFire = 0.8f;


### PR DESCRIPTION
#347 

`cl_righthand` controls if the rocket comes out of the left or right of the screen. It was made to be able to change cl_righthand only from the menu now, as per TF2's setting.

Introducing `mom_rj_center_fire`, a toggle var that controls if the rockets will come out of the center of the screen. While the rocket launcher does not currently display centered (visual bug to be fixed later), rockets will fire out of the dead center of the screen.