### PR TITLE
Default to using 0 cl_interp and cl_interp_ratio

### DIFF
--- a/mp/src/game/client/cdll_bounded_cvars.cpp
+++ b/mp/src/game/client/cdll_bounded_cvars.cpp
@@ -65,24 +65,15 @@ class CBoundedCvar_InterpRatio : public ConVar_ServerBounded
 public:
 	CBoundedCvar_InterpRatio() :
 	  ConVar_ServerBounded( "cl_interp_ratio", 
-		  "2.0", 
+		  "0", 
 		  FCVAR_USERINFO | FCVAR_NOT_CONNECTED, 
-		  "Sets the interpolation amount (final amount is cl_interp_ratio / cl_updaterate)." )
+		  "Sets the interpolation amount (final amount is cl_interp_ratio / cl_updaterate).", true, 0.0f, false, 0.0f )
 	  {
 	  }
 
 	  virtual float GetFloat() const
 	  {
-		  static const ConVar *pMin = g_pCVar->FindVar( "sv_client_min_interp_ratio" );
-		  static const ConVar *pMax = g_pCVar->FindVar( "sv_client_max_interp_ratio" );
-		  if ( pMin && pMax && pMin->GetFloat() != -1 )
-		  {
-			  return clamp( GetBaseFloatValue(), pMin->GetFloat(), pMax->GetFloat() );
-		  }
-		  else
-		  {
-			  return GetBaseFloatValue();
-		  }
+		  return GetBaseFloatValue();
 	  }
 };
 
@@ -99,7 +90,7 @@ class CBoundedCvar_Interp : public ConVar_ServerBounded
 public:
 	CBoundedCvar_Interp() :
 	  ConVar_ServerBounded( "cl_interp",
-		  "0.1", 
+		  "0", 
 		  FCVAR_USERINFO | FCVAR_NOT_CONNECTED, 
 		  "Sets the interpolation amount (bounded on low side by server interp ratio settings).", true, 0.0f, true, 0.5f )
 	  {
@@ -107,16 +98,7 @@ public:
 
 	  virtual float GetFloat() const
 	  {
-		  static const ConVar *pUpdateRate = g_pCVar->FindVar( "cl_updaterate" );
-		  static const ConVar *pMin = g_pCVar->FindVar( "sv_client_min_interp_ratio" );
-		  if ( pUpdateRate && pMin && pMin->GetFloat() != -1 )
-		  {
-			  return MAX( GetBaseFloatValue(), pMin->GetFloat() / pUpdateRate->GetFloat() );
-		  }
-		  else
-		  {
-			  return GetBaseFloatValue();
-		  }
+		  return GetBaseFloatValue();
 	  }
 };
 

--- a/mp/src/game/server/gameinterface.cpp
+++ b/mp/src/game/server/gameinterface.cpp
@@ -2838,21 +2838,10 @@ void CServerGameClients::ClientSettingsChanged( edict_t *pEdict )
 	if ( useInterpolation )
 	{
 		float flLerpRatio = Q_atof( QUICKGETCVARVALUE("cl_interp_ratio") );
-		if ( flLerpRatio == 0 )
-			flLerpRatio = 1.0f;
+		if ( flLerpRatio < 0.0f )
+			flLerpRatio = 0.0f;
 		float flLerpAmount = Q_atof( QUICKGETCVARVALUE("cl_interp") );
 
-		static const ConVar *pMin = g_pCVar->FindVar( "sv_client_min_interp_ratio" );
-		static const ConVar *pMax = g_pCVar->FindVar( "sv_client_max_interp_ratio" );
-		if ( pMin && pMax && pMin->GetFloat() != -1 )
-		{
-			flLerpRatio = clamp( flLerpRatio, pMin->GetFloat(), pMax->GetFloat() );
-		}
-		else
-		{
-			if ( flLerpRatio == 0 )
-				flLerpRatio = 1.0f;
-		}
 		// #define FIXME_INTERP_RATIO
 		player->m_fLerpTime = MAX( flLerpAmount, flLerpRatio / player->m_nUpdateRate );
 	}

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -229,6 +229,7 @@ CMomentumPlayer::CMomentumPlayer()
     m_iLastBlock = -1;
     m_iOldTrack = 0;
     m_iOldZone = 0;
+    m_fLerpTime = 0.0f;
 
     m_bWasSpectating = false;
 


### PR DESCRIPTION
Preferred in RJ and seemingly has no effect on anything else