### PR TITLE
Remove references to typeinfo.h

### DIFF
--- a/mp/src/game/client/c_baseentity.cpp
+++ b/mp/src/game/client/c_baseentity.cpp
@@ -4835,12 +4835,6 @@ C_BaseEntity *C_BaseEntity::Instance( int iEnt )
 	return ClientEntityList().GetBaseEntity( iEnt );
 }
 
-#ifdef WIN32
-#pragma warning( push )
-#include <typeinfo.h>
-#pragma warning( pop )
-#endif
-
 //-----------------------------------------------------------------------------
 // Purpose: 
 // Output : char const

--- a/mp/src/game/client/hud_pdump.cpp
+++ b/mp/src/game/client/hud_pdump.cpp
@@ -16,16 +16,6 @@
 
 static CPDumpPanel *g_pPDumpPanel = NULL;
 
-
-// OKAY, so typeinfo.h somewhere re-enables a bunch of warnings about float to int conversion, etc., that
-//  we pragma'd away in platform.h, so this little compiler specific hack will eliminate those warnings while
-//  retaining our own warning setup...ywb
-#ifdef WIN32
-#pragma warning( push )
-#include <typeinfo.h>
-#pragma warning( pop )
-#endif
-
 using namespace vgui;
 
 CPDumpPanel *GetPDumpPanel()

--- a/mp/src/game/client/particlemgr.h
+++ b/mp/src/game/client/particlemgr.h
@@ -105,9 +105,7 @@ entities. Each one is useful under different conditions.
 #ifndef PARTICLEMGR_H
 #define PARTICLEMGR_H
 
-#ifdef _WIN32
 #pragma once
-#endif
 
 #include "materialsystem/imaterial.h"
 #include "materialsystem/imaterialsystem.h"
@@ -119,13 +117,9 @@ entities. Each one is useful under different conditions.
 #include "tier0/fasttimer.h"
 #include "utllinkedlist.h"
 #include "utldict.h"
-#ifdef WIN32
-#include <typeinfo.h>
-#else
-#include <typeinfo>
-#endif
 #include "tier1/utlintrusivelist.h"
 #include "tier1/utlstring.h"
+#include <typeinfo>
 
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/client/physics_main_client.cpp
+++ b/mp/src/game/client/physics_main_client.cpp
@@ -6,9 +6,6 @@
 //=============================================================================//
 #include "cbase.h"
 #include "c_baseentity.h"
-#ifdef WIN32
-#include <typeinfo.h>
-#endif
 #include "tier0/vprof.h"
 
 // memdbgon must be the last include file in a .cpp file!!!

--- a/mp/src/game/server/physics_main.cpp
+++ b/mp/src/game/server/physics_main.cpp
@@ -7,15 +7,8 @@
 
 
 #include "cbase.h"
-#ifdef _WIN32
-#include "typeinfo.h"
-// BUGBUG: typeinfo stomps some of the warning settings (in yvals.h)
-#pragma warning(disable:4244)
-#elif POSIX
+
 #include <typeinfo>
-#else
-#error "need typeinfo defined"
-#endif
 
 #include "player.h"
 #include "ai_basenpc.h"
@@ -948,8 +941,8 @@ void CBaseEntity::PhysicsDispatchThink( BASEPTR thinkFunc )
 	if ( thinkLimit )
 	{
 		// calculate running time of the AI in milliseconds
-		float time = ( engine->Time() - startTime ) * 1000.0f;
-		if ( time > thinkLimit )
+		float fTime = ( engine->Time() - startTime ) * 1000.0f;
+		if ( fTime > thinkLimit )
 		{
 #if defined( _XBOX ) && !defined( _RETAIL )
 			if ( vprof_think_limit.GetBool() )
@@ -962,14 +955,14 @@ void CBaseEntity::PhysicsDispatchThink( BASEPTR thinkFunc )
 			CAI_BaseNPC *pNPC = MyNPCPointer();
 			if (pNPC && pNPC->GetCurSchedule())
 			{
-				pNPC->ReportOverThinkLimit( time );
+				pNPC->ReportOverThinkLimit( fTime );
 			}
 			else
 			{
 #ifdef _WIN32
-				Msg( "%s(%s) thinking for %.02f ms!!!\n", GetClassname(), typeid(this).raw_name(), time );
+				Msg( "%s(%s) thinking for %.02f ms!!!\n", GetClassname(), typeid(this).raw_name(), fTime );
 #elif POSIX
-				Msg( "%s(%s) thinking for %.02f ms!!!\n", GetClassname(), typeid(this).name(), time );
+				Msg( "%s(%s) thinking for %.02f ms!!!\n", GetClassname(), typeid(this).name(), fTime );
 #else
 #error "typeinfo"
 #endif

--- a/mp/src/public/tier0/memalloc.h
+++ b/mp/src/public/tier0/memalloc.h
@@ -382,7 +382,7 @@ public:
 
 	#pragma warning(disable:4290)
 	#pragma warning(push)
-	#include <typeinfo.h>
+    #include <typeinfo>
 
 	// MEM_DEBUG_CLASSNAME is opt-in.
 	// Note: typeid().name() is not threadsafe, so if the project needs to access it in multiple threads


### PR DESCRIPTION
New versions of Visual Studio 2019 have removed this file altogether (integrated into the compiler?) and POSIX just uses `<typeinfo>` anyways.

Closes #390 