### PR TITLE
Targetname/classname fixes

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -249,8 +249,6 @@ CMomentumPlayer::CMomentumPlayer()
 
     m_RunStats.Init();
 
-    Q_strncpy(m_pszDefaultEntName, GetEntityName().ToCStr(), sizeof m_pszDefaultEntName);
-
     ListenForGameEvent("mapfinished_panel_closed");
 
     for (int i = 0; i < MAX_TRACKS; i++)
@@ -444,7 +442,6 @@ void CMomentumPlayer::SendAppearance() { g_pMomentumGhostClient->SendAppearanceD
 
 void CMomentumPlayer::Spawn()
 {
-    SetName(MAKE_STRING(m_pszDefaultEntName));
     SetModel(ENTITY_MODEL);
     SetBodygroup(1, 11); // BODY_PROLATE_ELLIPSE
     // BASECLASS SPAWN MUST BE AFTER SETTING THE MODEL, OTHERWISE A NULL HAPPENS!
@@ -1239,7 +1236,6 @@ void CMomentumPlayer::UpdateMaxVelocity()
 
 void CMomentumPlayer::ResetRunStats()
 {
-    SetName(MAKE_STRING(m_pszDefaultEntName)); // Reset name
     // MOM_TODO: Consider any other resets needed (classname, any flags, etc)
 
     m_nPerfectSyncTicks = 0;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1767,6 +1767,8 @@ void CMomentumPlayer::SaveCurrentRunState(bool bFromPractice)
 
     if (bFromPractice || !m_bHasPracticeMode)
     {
+        Q_strncpy(pState->m_pszTargetName, GetEntityName().ToCStr(), sizeof(pState->m_pszTargetName));
+        Q_strncpy(pState->m_pszClassName, GetClassname(), sizeof(pState->m_pszClassName));
         m_iOldTrack = m_Data.m_iCurrentTrack;
         m_iOldZone = m_Data.m_iCurrentZone;
         pState->m_nSavedAccelTicks = m_nAccelTicks;
@@ -1799,6 +1801,8 @@ void CMomentumPlayer::RestoreRunState(bool bFromPractice)
 
     if (bFromPractice || !m_bHasPracticeMode)
     {
+        SetName(MAKE_STRING(pState->m_pszTargetName));
+        SetClassname(pState->m_pszClassName);
         m_Data.m_iCurrentTrack = m_iOldTrack;
         m_Data.m_iCurrentZone = m_iOldZone;
         m_nAccelTicks = pState->m_nSavedAccelTicks;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1686,6 +1686,9 @@ void CMomentumPlayer::SetPracticeModeState()
 
 void CMomentumPlayer::EnablePracticeMode()
 {
+    if (m_bHasPracticeMode)
+        return;
+
     if (g_pMomentumTimer->IsRunning() && mom_practice_safeguard.GetBool())
     {
         const auto safeGuard = (m_nButtons & (IN_FORWARD|IN_MOVELEFT|IN_MOVERIGHT|IN_BACK|IN_JUMP|IN_DUCK|IN_WALK)) != 0;
@@ -1717,6 +1720,9 @@ void CMomentumPlayer::EnablePracticeMode()
 
 void CMomentumPlayer::DisablePracticeMode()
 {
+    if (!m_bHasPracticeMode)
+        return;
+
     m_bHasPracticeMode = false;
     SetPracticeModeState();
 

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -304,8 +304,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     int m_nPrevButtons;
 
-    char m_pszDefaultEntName[128];
-
     // Used by momentum triggers
     Vector m_vecPreviousOrigins[MAX_PREVIOUS_ORIGINS];
 

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -14,6 +14,8 @@ class CMomentumGhostBaseEntity;
 
 struct SavedState_t
 {
+    char m_pszTargetName[128];// Saved player targetname
+    char m_pszClassName[128]; // Saved player classname
     int m_nButtons;           // Saved player buttons being pressed
     Vector m_vecLastPos;      // Saved location before the replay was played or practice mode.
     QAngle m_angLastAng;      // Saved angles before the replay was played or practice mode.

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -389,6 +389,9 @@ CON_COMMAND_F(mom_restart, "Restarts the player to the start trigger. Optionally
         track = Q_atoi(args[1]);
     }
 
+    g_pMomentumTimer->Stop(pPlayer);
+    g_pMomentumTimer->SetCanStart(false);
+
     const auto pStart = g_pMomentumTimer->GetStartTrigger(track);
     if (pStart)
     {


### PR DESCRIPTION
Target and classname are now stored inside SavedState, so when the player exits practicemode, they are reverted back to what they had. Restoring only happens in runs, as well. Closes #367 

Removed setting the default targetname for the player, as if there's ever any problem, it will be a per-map basis of fixing it (clearing the targetname upon stage start).

Also threw in the fix for the timer not stopping/starting after doing `mom_restart`. Closes #388 