### PR TITLE
Fix Rocket Abusing Scenarios

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -255,12 +255,22 @@ CMomentumPlayer::CMomentumPlayer()
     {
         m_pStartZoneMarks[i] = nullptr;
     }
+
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
+    {
+        gEntList.AddListenerEntity(this);
+    }
 }
 
 CMomentumPlayer::~CMomentumPlayer()
 {
     if (this == s_pPlayer)
         s_pPlayer = nullptr;
+
+    if (g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
+    {
+        gEntList.RemoveListenerEntity(this);
+    }
 
     RemoveTrail();
     RemoveAllOnehops();
@@ -1116,6 +1126,14 @@ void CMomentumPlayer::Touch(CBaseEntity *pOther)
 
     if (g_MOMBlockFixer->IsBhopBlock(pOther->entindex()))
         g_MOMBlockFixer->PlayerTouch(this, pOther);
+}
+
+void CMomentumPlayer::OnEntitySpawned(CBaseEntity *pEntity)
+{
+}
+
+void CMomentumPlayer::OnEntityDeleted(CBaseEntity *pEntity)
+{
 }
 
 void CMomentumPlayer::PlayerThink()

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -158,6 +158,10 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     void StopSpectating();
 
+    // Timer commands
+    void TimerCommand_Restart(int track);
+    void TimerCommand_Reset(); // To the current stage, if any
+
     // Practice mode
     void TogglePracticeMode();
     void EnablePracticeMode();

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -32,7 +32,7 @@ struct SavedState_t
 #define NUM_TICKS_TO_BHOP 10 // The number of ticks a player can be on a ground before considered "not bunnyhopping"
 #define MAX_PREVIOUS_ORIGINS 3 // The number of previous origins saved
 
-class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CMomRunEntity
+class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CMomRunEntity, public IEntityListener
 {
   public:
     DECLARE_CLASS(CMomentumPlayer, CBasePlayer);
@@ -243,6 +243,10 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     bool IsInAirDueToJump() const { return m_bInAirDueToJump; }
 
     SavedState_t *GetSavedRunState() { return &m_SavedRunState; }
+
+    // IEntityListener
+    void OnEntitySpawned(CBaseEntity *pEntity) override;
+    void OnEntityDeleted(CBaseEntity *pEntity) override;
 
   private:
     // Player think function called every tick

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -11,6 +11,7 @@ class CTriggerOnehop;
 class CTriggerProgress;
 class CTriggerSlide;
 class CMomentumGhostBaseEntity;
+class CMomRocket;
 
 struct SavedState_t
 {
@@ -271,7 +272,8 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     bool SelectSpawnSpot(const char *pEntClassName, CBaseEntity *&pSpot);
     void SetPracticeModeState();
 
-  private:
+    void DestroyRockets();
+
     CSteamID m_sSpecTargetSteamID;
 
     bool m_bInAirDueToJump;
@@ -326,4 +328,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     SavedState_t m_SavedRunState; // Used when either entering practice mode or spectating while in a run
     SavedState_t m_PracticeModeState; // Only used when the path is (in a run) -> (enters Practice) -> (spectates)
+
+    CUtlVector<CMomRocket*> m_vecRockets;
 };

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -380,44 +380,15 @@ CON_COMMAND_F(mom_restart, "Restarts the player to the start trigger. Optionally
               FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_SERVER_CAN_EXECUTE)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    if (!pPlayer || !pPlayer->AllowUserTeleports())
-        return;
-
-    int track = pPlayer->m_Data.m_iCurrentTrack;
-    if (args.ArgC() > 1)
+    if (pPlayer)
     {
-        track = Q_atoi(args[1]);
-    }
-
-    g_pMomentumTimer->Stop(pPlayer);
-    g_pMomentumTimer->SetCanStart(false);
-
-    const auto pStart = g_pMomentumTimer->GetStartTrigger(track);
-    if (pStart)
-    {
-        const auto pStartMark = pPlayer->GetStartMark(track);
-        if (pStartMark)
+        int track = pPlayer->m_Data.m_iCurrentTrack;
+        if (args.ArgC() > 1)
         {
-            pStartMark->Teleport(pPlayer);
-        }
-        else
-        {
-            // Don't set angles if still in start zone.
-            QAngle ang = pStart->GetLookAngles();
-            pPlayer->Teleport(&pStart->WorldSpaceCenter(), (pStart->HasLookAngles() ? &ang : nullptr), &vec3_origin);
+            track = Q_atoi(args[1]);
         }
 
-        pPlayer->m_Data.m_iCurrentTrack = track;
-        pPlayer->ResetRunStats();
-    }
-    else
-    {
-        const auto pStartPoint = pPlayer->EntSelectSpawnPoint();
-        if (pStartPoint)
-        {
-            pPlayer->Teleport(&pStartPoint->GetAbsOrigin(), &pStartPoint->GetAbsAngles(), &vec3_origin);
-            pPlayer->ResetRunStats();
-        }
+        pPlayer->TimerCommand_Restart(track);
     }
 }
 
@@ -425,14 +396,9 @@ CON_COMMAND_F(mom_reset, "Teleports the player back to the start of the current 
               FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_SERVER_CAN_EXECUTE)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    if (pPlayer && pPlayer->AllowUserTeleports())
+    if (pPlayer)
     {
-        const auto pCurrentZone = pPlayer->GetCurrentZoneTrigger();
-        // MOM_TODO do a trace downwards from the top of the trigger's center to touchable land, teleport the player there
-        if (pCurrentZone)
-            pPlayer->Teleport(&pCurrentZone->WorldSpaceCenter(), nullptr, &vec3_origin);
-        else
-            Warning("Cannot reset, you have no current zone!\n");
+        pPlayer->TimerCommand_Reset();
     }
 }
 


### PR DESCRIPTION
#347 

Makes the player a listener for rockets and destroys rockets on:
 * Using mom_restart
 * Using mom_reset
 * Exiting practice mode in a run
 * Entering the start zone