### PR TITLE
Increase Momentum Shotgun range: 3000 -> 8192

### DIFF
--- a/mp/game/momentum/scripts/weapon_momentum_shotgun.txt
+++ b/mp/game/momentum/scripts/weapon_momentum_shotgun.txt
@@ -7,7 +7,7 @@ WeaponData
     // Weapon characteristics:
     "Penetration"       "1"
     "Damage"            "22"
-    "Range"             "3000"
+    "Range"             "8192"
     "RangeModifier"     "0.70"
     "Bullets"           "6"
     "CycleTime"         "0.25"


### PR DESCRIPTION
Some buttons were not reachable with the shotgun, so the range is now 8192, hitting a wall up to 8191 HU away.
Visual difference in range:

![](https://i.imgur.com/hkFA3dL.png)

Should Close #416 👀 