### PR TITLE
Set the shoot position relative to the current position of the player

### DIFF
--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -821,7 +821,7 @@ void CBasePlayer::SetStepSoundTime( stepsoundtimes_t iStepSoundTime, bool bWalki
 //Temp fix.
 Vector CBasePlayer::Weapon_ShootPosition( )
 {
-	return GetViewOffset() + m_vecOldOrigin;
+	return GetViewOffset() + GetAbsOrigin();
 }
 
 void CBasePlayer::SetAnimationExtension( const char *pExtension )


### PR DESCRIPTION
Before it used to shoot rockets relative to a previous position of the player, which ruined rocket jumping at high speeds.