### PR TITLE
Fix AllowingJump property of slide triggers

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2339,9 +2339,7 @@ void CMomentumGameMovement::SetGroundEntity(trace_t *pm)
 {
     // We check jump button because the player might want jumping while sliding
     // And it's more fun like this
-    if (m_pPlayer->m_CurrentSlideTrigger &&
-        (!((mv->m_nButtons & IN_JUMP) && m_pPlayer->m_CurrentSlideTrigger->m_bStuckOnGround) ||
-         m_pPlayer->m_CurrentSlideTrigger->m_bStuckOnGround))
+    if (m_pPlayer->m_CurrentSlideTrigger && !((mv->m_nButtons & IN_JUMP) && m_pPlayer->m_CurrentSlideTrigger->m_bAllowingJump))
         pm = nullptr;
 
     CBaseEntity *newGround = pm ? pm->m_pEnt : nullptr;


### PR DESCRIPTION
The way the sliding mechanic works for slide triggers is that it blocks the player's ground entity from being set. This makes the game think that the player isn't standing on anything and moves the player in a way that feels like sliding. 

It also blocks mechanics like walking/jumping, so to allow jumping we check if the player intends to jump and if the AllowingJump property is set, and if so we lift the set ground entity block temporarily.

Closes #430