### PR TITLE
Network Rockets through Online Lobbies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: gocnak/steam-runtime-i386:momentum
       
     working_directory: ~/mom_build
-    resource_class: large
+    resource_class: medium
     environment:
       USING_DOCKER: h*ckyeahIam
     

--- a/mp/src/game/server/momentum/mom_online_ghost.cpp
+++ b/mp/src/game/server/momentum/mom_online_ghost.cpp
@@ -201,19 +201,14 @@ void CMomentumOnlineGhostEntity::ThrowGrenade(const DecalPacket& packet)
         Vector vecThrow(packet.vAngle.x, packet.vAngle.y, packet.vAngle.z);
         auto grenade = CMomGrenadeProjectile::Create(packet.vOrigin, vec3_angle, vecThrow, AngularImpulse(600, packet.data.bullet.iMode, 0), this, pGrenadeInfo->szWorldModel);
         grenade->SetDamage(0.0f); // These grenades should not do damage
-
     }
 }
 
 void CMomentumOnlineGhostEntity::FireRocket(const DecalPacket &packet)
 {
-    /*const auto pRocket =*/ CMomRocket::EmitRocket(packet.vOrigin, packet.vAngle, this);
-    /*if (pRocket)
-    {
-        pRocket->SetDamage(0.0f)
-    }*/
+    const auto pRocket = CMomRocket::EmitRocket(packet.vOrigin, packet.vAngle, this);
+    pRocket->SetDamage(0.0f); // Rockets do no damage unless... MOM_TODO: set this per map/gamemode flag?
 }
-
 
 void CMomentumOnlineGhostEntity::Precache(void)
 {

--- a/mp/src/game/server/momentum/mom_online_ghost.cpp
+++ b/mp/src/game/server/momentum/mom_online_ghost.cpp
@@ -7,6 +7,7 @@
 #include "util/mom_util.h"
 #include "weapon/mom_weapon_parse.h"
 #include "mom_grenade_projectile.h"
+#include "mom_rocket.h"
 #include "te_effect_dispatch.h"
 #include "weapon/weapon_base.h"
 #include "ghost_client.h"
@@ -102,6 +103,9 @@ void CMomentumOnlineGhostEntity::FireDecal(const DecalPacket &decal)
         break;
     case DECAL_KNIFE:
         DoKnifeSlash(decal);
+        break;
+    case DECAL_ROCKET:
+        FireRocket(decal);
     default:
         break;
     }
@@ -200,6 +204,16 @@ void CMomentumOnlineGhostEntity::ThrowGrenade(const DecalPacket& packet)
 
     }
 }
+
+void CMomentumOnlineGhostEntity::FireRocket(const DecalPacket &packet)
+{
+    /*const auto pRocket =*/ CMomRocket::EmitRocket(packet.vOrigin, packet.vAngle, this);
+    /*if (pRocket)
+    {
+        pRocket->SetDamage(0.0f)
+    }*/
+}
+
 
 void CMomentumOnlineGhostEntity::Precache(void)
 {

--- a/mp/src/game/server/momentum/mom_online_ghost.h
+++ b/mp/src/game/server/momentum/mom_online_ghost.h
@@ -62,6 +62,7 @@ private:
     void DoPaint(const DecalPacket &packet);
     void DoKnifeSlash(const DecalPacket &packet);
     void ThrowGrenade(const DecalPacket &packet);
+    void FireRocket(const DecalPacket &packet);
 
     CUtlQueue<ReceivedFrame_t<PositionPacket>*> m_vecPositionPackets;
     ReceivedFrame_t<PositionPacket>* m_pCurrentFrame;

--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -137,16 +137,19 @@ bool CMomentumGameRules::ShouldCollide(int collisionGroup0, int collisionGroup1)
         V_swap(collisionGroup0, collisionGroup1);
     }
 
-    // Don't stand on COLLISION_GROUP_WEAPONs
-    if (collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT && collisionGroup1 == COLLISION_GROUP_WEAPON)
+    if ((collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT))
     {
-        return false;
-    }
+        // Don't stand on COLLISION_GROUP_WEAPONs
+        if (collisionGroup1 == COLLISION_GROUP_WEAPON)
+            return false;
 
-    if ((collisionGroup0 == COLLISION_GROUP_PLAYER || collisionGroup0 == COLLISION_GROUP_PLAYER_MOVEMENT) &&
-        collisionGroup1 == COLLISION_GROUP_PUSHAWAY)
-    {
-        return false;
+        // We get pushed away from pushaways
+        if (collisionGroup1 == COLLISION_GROUP_PUSHAWAY)
+            return false;
+
+        // Do not stand on projectiles
+        if (collisionGroup1 == COLLISION_GROUP_PROJECTILE)
+            return false;
     }
 
     if (collisionGroup0 == COLLISION_GROUP_DEBRIS && collisionGroup1 == COLLISION_GROUP_PUSHAWAY)

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -213,7 +213,8 @@ enum DecalType
 {
     DECAL_BULLET = 0,
     DECAL_PAINT,
-    DECAL_KNIFE
+    DECAL_KNIFE,
+    DECAL_ROCKET,
     // etc
 };
 
@@ -286,6 +287,12 @@ class DecalPacket : public MomentumPacket
         DecalPacket packet(DECAL_KNIFE, origin, angle);
         packet.data.knife.bStab = bStab;
         return packet;
+    }
+
+    static DecalPacket Rocket(Vector origin, QAngle angle)
+    {
+        DecalPacket pack(DECAL_ROCKET, origin, angle);
+        return pack;
     }
 
     DecalPacket(CUtlBuffer &buf)

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -74,7 +74,7 @@ void CMomentumRocketLauncher::GetProjectileFireSetup(CMomentumPlayer *pPlayer, V
     trace_t tr;
 
     CTraceFilterSimple filter(pPlayer, COLLISION_GROUP_NONE);
-    UTIL_TraceLine(vecShootPos, endPos, MASK_SOLID, &filter, &tr);
+    UTIL_TraceLine(vecShootPos, endPos, MASK_SOLID_BRUSHONLY, &filter, &tr);
 
     // Offset actual start point
     *vecSrc = vecShootPos + (vecForward * vecOffset.x) + (vecRight * vecOffset.y) + (vecUp * vecOffset.z);

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -4,6 +4,10 @@
 #include "mom_system_gamemode.h"
 #include "weapon_mom_rocketlauncher.h"
 
+#ifdef GAME_DLL
+#include "momentum/ghost_client.h"
+#endif
+
 #include "tier0/memdbgon.h"
 
 IMPLEMENT_NETWORKCLASS_ALIASED(MomentumRocketLauncher, DT_MomentumRocketLauncher)
@@ -130,6 +134,9 @@ void CMomentumRocketLauncher::RocketLauncherFire()
     UTIL_TraceLine(pPlayer->EyePosition(), vecSrc, MASK_SOLID_BRUSHONLY, &traceFilter, &trace);
 
     CMomRocket::EmitRocket(trace.endpos, angForward, pPlayer);
+
+    DecalPacket rocket = DecalPacket::Rocket(trace.endpos, angForward);
+    g_pMomentumGhostClient->SendDecalPacket(&rocket);
 #endif
 }
 


### PR DESCRIPTION
Firing rockets when in lobbies will now show up in game for others. They currently do not boost other players in the lobby, nor should they do damage to anything on their instance.