### PR TITLE
Introduce sv_bounce_fix to either remove randomness of bounces or remove them entirely

### DIFF
--- a/mp/src/game/client/momentum/c_mom_player.cpp
+++ b/mp/src/game/client/momentum/c_mom_player.cpp
@@ -15,6 +15,7 @@ RecvPropInt(RECVINFO(m_iLastZoomFOV), SPROP_UNSIGNED),
 RecvPropInt(RECVINFO(m_afButtonDisabled)),
 RecvPropEHandle(RECVINFO(m_CurrentSlideTrigger)),
 RecvPropBool(RECVINFO(m_bAutoBhop)),
+RecvPropBool(RECVINFO(m_bCanBounce)),
 RecvPropArray3(RECVINFO_ARRAY(m_iZoneCount), RecvPropInt(RECVINFO(m_iZoneCount[0]), SPROP_UNSIGNED)),
 RecvPropArray3(RECVINFO_ARRAY(m_iLinearTracks), RecvPropInt(RECVINFO(m_iLinearTracks[0]), SPROP_UNSIGNED)),
 RecvPropDataTable(RECVINFO_DT(m_Data), SPROP_PROXY_ALWAYS_YES | SPROP_CHANGES_OFTEN, &REFERENCE_RECV_TABLE(DT_MomRunEntityData)),
@@ -150,4 +151,9 @@ float C_MomentumPlayer::GetCurrentRunTime()
         iTotalTicks = m_Data.m_iRunTime;
 
     return float(iTotalTicks) * m_Data.m_flTickRate;
+}
+
+void C_MomentumPlayer::AllowBounce(bool bAllow)
+{
+    m_bCanBounce = bAllow;
 }

--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -31,6 +31,9 @@ class C_MomentumPlayer : public C_BasePlayer, public CMomRunEntity
 
     bool HasAutoBhop() { return m_bAutoBhop; }
     // void ResetStrafeSync();
+    
+    void AllowBounce(bool bAllow);
+    bool CanBounce() const { return m_bCanBounce; }
 
     // Returns the replay entity that the player is watching (first person only)
     int GetSpecEntIndex() const;
@@ -53,6 +56,7 @@ class C_MomentumPlayer : public C_BasePlayer, public CMomRunEntity
 
     int m_afButtonDisabled;
     CNetworkVar(bool, m_bAutoBhop);
+    CNetworkVar(bool, m_bCanBounce); // Is the player allowed to perform a bounce?
 
     // CMomRunEnt stuff
     RUN_ENT_TYPE GetEntType() OVERRIDE { return RUN_ENT_PLAYER; }

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -572,10 +572,7 @@ void CMomentumPlayer::SetAutoBhopEnabled(bool bEnable)
 }
 
 void CMomentumPlayer::AllowBounce(bool bAllow)
-{
-    if (bAllow != m_bCanBounce)
-        DevMsg("bounce:%d\n", bAllow);
-    
+{ 
     m_bCanBounce = bAllow;
 }
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -127,6 +127,7 @@ SendPropInt(SENDINFO(m_iLastZoomFOV), 8, SPROP_UNSIGNED),
 SendPropInt(SENDINFO(m_afButtonDisabled)),
 SendPropEHandle(SENDINFO(m_CurrentSlideTrigger)),
 SendPropBool(SENDINFO(m_bAutoBhop)),
+SendPropBool(SENDINFO(m_bCanBounce)),
 SendPropArray3(SENDINFO_ARRAY3(m_iZoneCount), SendPropInt(SENDINFO_ARRAY(m_iZoneCount), 7, SPROP_UNSIGNED)),
 SendPropArray3(SENDINFO_ARRAY3(m_iLinearTracks), SendPropInt(SENDINFO_ARRAY(m_iLinearTracks), 1, SPROP_UNSIGNED)),
 SendPropDataTable(SENDINFO_DT(m_Data), &REFERENCE_SEND_TABLE(DT_MomRunEntityData)),
@@ -568,6 +569,14 @@ void CMomentumPlayer::SetAutoBhopEnabled(bool bEnable)
 {
     m_bAutoBhop = bEnable;
     DevLog("%s autobhop\n", bEnable ? "Enabled" : "Disabled");
+}
+
+void CMomentumPlayer::AllowBounce(bool bAllow)
+{
+    if (bAllow != m_bCanBounce)
+        DevMsg("bounce:%d\n", bAllow);
+    
+    m_bCanBounce = bAllow;
 }
 
 void CMomentumPlayer::OnJump()
@@ -2023,6 +2032,8 @@ void CMomentumPlayer::ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &v
     float force = Min(info.GetDamage() * flScale, 1000.0f);
     Vector vecForce = -vecDir * force;
     ApplyAbsVelocityImpulse(vecForce);
+    
+    AllowBounce(false);
 }
 
 bool CMomentumPlayer::CanPaint() { return m_flNextPaintTime <= gpGlobals->curtime; }

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -86,6 +86,9 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     bool HasAutoBhop() const { return m_bAutoBhop; }
     bool DidPlayerBhop() const { return m_bDidPlayerBhop; }
     void ResetRunStats();
+    
+    void AllowBounce(bool bAllow);
+    bool CanBounce() const { return m_bCanBounce; }
 
     void LimitSpeed(float flSpeedLimit, bool bSaveZ);
 
@@ -124,6 +127,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     int m_iLimitSpeedType;    // Limit speed only when touching ground?
     int m_iSuccessiveBhops;   // How many successive bhops this player has
     CNetworkVar(bool, m_bAutoBhop); // Is the player using auto bhop?
+    CNetworkVar(bool, m_bCanBounce); // Is the player allowed to perform a bounce?
 
 
     void GetBulletTypeParameters(int iBulletType, float &fPenetrationPower, float &flPenetrationDistance, bool &bPaint);

--- a/mp/src/game/server/player_command.cpp
+++ b/mp/src/game/server/player_command.cpp
@@ -6,6 +6,7 @@
 
 #include "cbase.h"
 #include "player.h"
+#include "momentum/mom_player.h"
 #include "usercmd.h"
 #include "igamemovement.h"
 #include "mathlib/mathlib.h"
@@ -455,7 +456,8 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	// If the player is grounded, there is the possibility that they are bit above the ground and therefore might be
 	// above a trigger. The player could avoid this trigger by doing a jump, so to prevent this we extend the player
 	// collision by how much they are above the ground when checking for triggers
-	if (sv_bounce_fix.GetInt() == 2 && player->GetGroundEntity() != nullptr)
+	if (((sv_bounce_fix.GetInt() == 1 && !static_cast<CMomentumPlayer*>(player)->CanBounce()) || sv_bounce_fix.GetInt() == 2) &&
+        player->GetGroundEntity() != nullptr)
     {
         Vector mins = player->CollisionProp()->OBBMins();
         Vector maxs = player->CollisionProp()->OBBMaxs();

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2428,8 +2428,7 @@ void CMomentumGameMovement::SetGroundEntity(trace_t *pm)
         mv->m_vecVelocity.z = 0.0f;
         
         // Check if player is actually on the ground for bounce fix
-        if (sv_bounce_fix.GetInt() == 1 && !CloseEnough(fabs(pm->plane.normal.z), 0.0f, FLT_EPSILON)
-            && pm->fraction == 0.0f)
+        if (sv_bounce_fix.GetInt() == 1 && pm->fraction == 0.0f)
         {
             // Allow the player to perform a bounce if they hit a floor or ceiling, and disallow if they hit someting
             // angled

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2426,6 +2426,15 @@ void CMomentumGameMovement::SetGroundEntity(trace_t *pm)
         }
 
         mv->m_vecVelocity.z = 0.0f;
+        
+        // Check if player is actually on the ground for bounce fix
+        if (sv_bounce_fix.GetInt() == 1 && !CloseEnough(fabs(pm->plane.normal.z), 0.0f, FLT_EPSILON)
+            && pm->fraction == 0.0f)
+        {
+            // Allow the player to perform a bounce if they hit a floor or ceiling, and disallow if they hit someting
+            // angled
+            m_pPlayer->AllowBounce(CloseEnough(fabs(pm->plane.normal.z), 1.0f, FLT_EPSILON));
+        }
     }
 }
 
@@ -2590,6 +2599,12 @@ int CMomentumGameMovement::ClipVelocity(Vector in, Vector &normal, Vector &out, 
             out.y = in.y;
             out.z = 0.0f;
         }
+    }
+    
+    if (sv_bounce_fix.GetInt() == 1 && !CloseEnough(fabs(normal.z), 0.0f, FLT_EPSILON))
+    {
+        // Allow the player to perform a bounce if they hit a floor or ceiling, and disallow if they hit someting angled
+        m_pPlayer->AllowBounce(CloseEnough(fabs(normal.z), 1.0f, FLT_EPSILON));
     }
 
     // Return blocking flags.

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -42,6 +42,7 @@ void CGameModeBase::SetGameModeVars()
     sv_maxspeed.SetValue(260);
     sv_stopspeed.SetValue(75);
     sv_considered_on_ground.SetValue(1);
+    sv_bounce_fix.SetValue(2);
 }
 
 void CGameModeBase::OnPlayerSpawn(CMomentumPlayer *pPlayer)
@@ -79,6 +80,7 @@ void CGameMode_RJ::SetGameModeVars()
     sv_maxspeed.SetValue(240);
     sv_stopspeed.SetValue(100);
     sv_considered_on_ground.SetValue(2);
+    sv_bounce_fix.SetValue(0);
 }
 
 void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -80,7 +80,7 @@ void CGameMode_RJ::SetGameModeVars()
     sv_maxspeed.SetValue(240);
     sv_stopspeed.SetValue(100);
     sv_considered_on_ground.SetValue(2);
-    sv_bounce_fix.SetValue(0);
+    sv_bounce_fix.SetValue(1);
 }
 
 void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)

--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -132,3 +132,4 @@ ConVar r_AirboatViewZHeight( "r_AirboatViewZHeight", "0.0", FCVAR_CHEAT | FCVAR_
 
 // Momentum convars
 ConVar sv_considered_on_ground("sv_considered_on_ground", "1.0", 0, "Amount of units you have to be above the ground to be considered on ground", true, 0.0f, true, 5.f);
+ConVar sv_bounce_fix("sv_bounce_fix", "0", 0, "Modify behaviour of bounces, 0 for default behaviour, 1 for no random bounces and knockback setups, 2 for no bounces at all", true, 0, true, 2);

--- a/mp/src/game/shared/movevars_shared.h
+++ b/mp/src/game/shared/movevars_shared.h
@@ -54,5 +54,6 @@ extern ConVar r_AirboatViewZHeight;
 
 // Momentum convars
 extern ConVar sv_considered_on_ground;
+extern ConVar sv_bounce_fix;
 
 #endif // MOVEVARS_SHARED_H


### PR DESCRIPTION
The convar sv_bounce_fix will do nothing if set to 0. If it is set to 2 it will make it impossible to avoid triggers that are placed on the ground by jumping or knockback (caused by getting grounded by being within sv_considered_on_ground, but still being above the trigger). Setting the convar to 1 will remove random bounces, that is, if you get knockback or if you hit a surface that isn't a floor, a ceiling, or a wall, you will be unable to bounce again until you hit a floor or a ceiling.