### PR TITLE
Add timestamps to chat messages

### DIFF
--- a/mp/src/game/client/hud_chat.cpp
+++ b/mp/src/game/client/hud_chat.cpp
@@ -83,9 +83,8 @@ void CHudChat::OnLobbyMessage(LobbyChatMsg_t *pParam)
     const char *spectatingText = SteamMatchmaking()->GetLobbyMemberData(m_LobbyID, msgSender, LOBBY_DATA_IS_SPEC);
     const bool isSpectating = spectatingText != nullptr && Q_strlen(spectatingText) > 0;
 
-    char timestamp[16] = "";
-    if (mom_chat_timestamps_enable.GetBool())
-        GetTimestamp(timestamp, 16);
+    char timestamp[16];
+    GetTimestamp(timestamp, 16);
 
     char message[4096];
     // MOM_TODO: This won't be just text in the future, if we capitalize on being able to send binary data. Wrap this is
@@ -174,6 +173,12 @@ void CHudChat::MsgFunc_LobbyUpdateMsg(bf_read &msg)
 
 void CHudChat::GetTimestamp(char *pBuffer, int maxLen)
 {
+    if (!mom_chat_timestamps_enable.GetBool())
+    {
+        Q_snprintf(pBuffer, maxLen, "");
+        return;
+    }
+
     time_t now = time(nullptr);
     struct tm *tm = localtime(&now);
     Q_snprintf(pBuffer, maxLen, "%c%s[%02d:%02d] ", COLOR_HEXCODE, "CCCCCC", tm->tm_hour, tm->tm_min);
@@ -188,9 +193,8 @@ void CHudChat::Printf(int iFilter, const char *fmt, ...)
     Q_vsnprintf(msg, sizeof(msg), fmt, marker);
     va_end(marker);
 
-    char timestamp[16] = "";
-    if (mom_chat_timestamps_enable.GetBool())
-        GetTimestamp(timestamp, 16);
+    char timestamp[16];
+    GetTimestamp(timestamp, 16);
 
     ChatPrintf(0, iFilter, "%s%c%s", timestamp, COLOR_NORMAL, msg);
 }

--- a/mp/src/game/client/hud_chat.h
+++ b/mp/src/game/client/hud_chat.h
@@ -23,6 +23,9 @@ class CHudChat : public CBaseHudChat
     STEAM_CALLBACK(CHudChat, OnLobbyMessage, LobbyChatMsg_t);
     STEAM_CALLBACK(CHudChat, OnLobbyDataUpdate, LobbyDataUpdate_t);
 
+    void GetTimestamp(char *pOut, int maxLen);
+    void Printf(int iFilter, const char *fmt, ...) OVERRIDE;
+
     void StartMessageMode(int) OVERRIDE;
     void StopMessageMode() OVERRIDE;
     void FireGameEvent(IGameEvent *event) OVERRIDE;

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -301,7 +301,7 @@ void CMomentumLobbySystem::HandleLobbyChatMsg(LobbyChatMsg_t* pParam)
     time_t now = time(nullptr);
     struct tm *tm = localtime(&now);
     DevLog("SERVER: Got a chat message! Wrote %i byte(s) into buffer.\n", written);
-    Msg("SERVER: Chat message [%02d:%02d]: %s\n", tm->tm_min, tm->tm_sec, message);
+    Msg("SERVER: Chat message [%02d:%02d]: %s\n", tm->tm_hour, tm->tm_min, message);
     delete[] message;
 }
 void CMomentumLobbySystem::SetAppearanceInMemberData(GhostAppearance_t app)

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -298,8 +298,10 @@ void CMomentumLobbySystem::HandleLobbyChatMsg(LobbyChatMsg_t* pParam)
 
     char *message = new char[4096];
     int written = SteamMatchmaking()->GetLobbyChatEntry(CSteamID(pParam->m_ulSteamIDLobby), pParam->m_iChatID, nullptr, message, 4096, nullptr);
+    time_t now = time(nullptr);
+    struct tm *tm = localtime(&now);
     DevLog("SERVER: Got a chat message! Wrote %i byte(s) into buffer.\n", written);
-    Msg("SERVER: Chat message: %s\n", message);
+    Msg("SERVER: Chat message [%02d:%02d]: %s\n", tm->tm_min, tm->tm_sec, message);
     delete[] message;
 }
 void CMomentumLobbySystem::SetAppearanceInMemberData(GhostAppearance_t app)


### PR DESCRIPTION
Added timestamps for chat messages printed in the console.
Added timestamps for the in-game chat messages.
Added a `ConVar` to toggle timestamps.
Closes #321 