### PR TITLE
Actually enforce disabled buttons in non-overlapping keys logic

### DIFF
--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -402,6 +402,8 @@ bool ClientModeMOMNormal::CreateMove(float flInputSampleTime, CUserCmd *cmd)
 
     if (!mom_enable_overlapping_keys.GetBool())
     {
+        cmd->buttons &= ~local_player->m_afButtonDisabled;
+
         // Holding both forward and backwards, which one was the last pressed of these?
         if ((cmd->buttons & (IN_FORWARD | IN_BACK)) == (IN_FORWARD | IN_BACK))
         {
@@ -447,8 +449,6 @@ bool ClientModeMOMNormal::CreateMove(float flInputSampleTime, CUserCmd *cmd)
         {
             dominant_buttons &= ~(IN_MOVELEFT | IN_MOVERIGHT);
         }
-
-        cmd->buttons &= ~local_player->m_afButtonDisabled;
     }
 
     prev_flags = local_player->GetFlags();


### PR DESCRIPTION
The buttons need to be updated before the sidemove is added in

Turns out I was testing with `mom_enable_overlapping_keys 1` before 🤦‍♂ 

Closes #469 