### PR TITLE
Fix Saveloc Gravity Exploit

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1131,6 +1131,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
 void CMomentumPlayer::ResetMovementProperties()
 {
     SetLaggedMovementValue(1.0f);
+    SetGravity(1.0f);
 }
 
 void CMomentumPlayer::Touch(CBaseEntity *pOther)

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -952,7 +952,7 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
         {
         case ZONE_TYPE_START:
         {
-            ResetProps();
+            ResetMovementProperties();
 
             const auto pStartTrigger = static_cast<CTriggerTimerStart*>(pTrigger);
 
@@ -1092,7 +1092,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
         case ZONE_TYPE_STOP:
             m_Data.m_iCurrentTrack = m_iOldTrack;
             m_Data.m_iCurrentZone = m_iOldZone;
-            ResetProps();
+            ResetMovementProperties();
             break;
         case ZONE_TYPE_CHECKPOINT:
             break;
@@ -1128,7 +1128,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
     }
 }
 
-void CMomentumPlayer::ResetProps()
+void CMomentumPlayer::ResetMovementProperties()
 {
     SetLaggedMovementValue(1.0f);
 }

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -274,8 +274,8 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     void DestroyRockets();
     
-    // Resets all player properties to their default state
-    void ResetProps();
+    // Resets all player movement properties to their default state
+    void ResetMovementProperties();
 
     CSteamID m_sSpecTargetSteamID;
 


### PR DESCRIPTION
Closes #468 

Savelocs are able to be edited in the savelocs.txt file to modify their gravity. Walking into a start zone, making a saveloc, quitting the map, opening the file and editing the gravity scale, saving it, reloading the map, and loading the saveloc gave the player their gravity scale, and could be abused for a run since it was not reset inside the start zone.