### PR TITLE
Fix ghosts doing damage

### DIFF
--- a/mp/src/game/shared/momentum/fx_mom_shared.cpp
+++ b/mp/src/game/shared/momentum/fx_mom_shared.cpp
@@ -98,11 +98,8 @@ void FX_FireBullets(int iEntIndex, const Vector &vOrigin, const QAngle &vAngles,
 {
     bool bDoEffects = true;
 
-#ifdef CLIENT_DLL
-    CMomentumPlayer *pPlayer = ToCMOMPlayer(ClientEntityList().GetBaseEntity(iEntIndex));
-#else
-    CMomentumPlayer *pPlayer = ToCMOMPlayer(UTIL_PlayerByIndex(iEntIndex));
-#endif
+    CBaseEntity *pAttacker = CBaseEntity::Instance(iEntIndex);
+    CMomentumPlayer *pPlayer = ToCMOMPlayer(pAttacker);
 
     CWeaponInfo *pWeaponInfo = GetWeaponInfo((CWeaponID)iWeaponID);
 
@@ -193,7 +190,7 @@ void FX_FireBullets(int iEntIndex, const Vector &vOrigin, const QAngle &vAngles,
         iSeed++; // use new seed for next bullet
 
         pPlayer->FireBullet(vOrigin, vAngles, flSpread, flRange, iPenetration, iAmmoType, iDamage, flRangeModifier,
-                            pPlayer, bDoEffects, x, y);
+                            pAttacker, bDoEffects, x, y);
     }
 
 #ifndef CLIENT_DLL

--- a/mp/src/game/shared/momentum/mom_player_shared.cpp
+++ b/mp/src/game/shared/momentum/mom_player_shared.cpp
@@ -274,15 +274,18 @@ void CMomentumPlayer::FireBullet(Vector vecSrc,             // shooting postion
         // add damage to entity that we hit
 
 #ifndef CLIENT_DLL
-        ClearMultiDamage();
+        if (pevAttacker->IsPlayer())
+        {
+            ClearMultiDamage();
 
-        CTakeDamageInfo info(pevAttacker, pevAttacker, fCurrentDamage, iDamageType);
-        CalculateBulletDamageForce(&info, iBulletType, vecDir, tr.endpos);
-        tr.m_pEnt->DispatchTraceAttack(info, vecDir, &tr);
+            CTakeDamageInfo info(pevAttacker, pevAttacker, fCurrentDamage, iDamageType);
+            CalculateBulletDamageForce(&info, iBulletType, vecDir, tr.endpos);
+            tr.m_pEnt->DispatchTraceAttack(info, vecDir, &tr);
 
-        TraceAttackToTriggers(info, tr.startpos, tr.endpos, vecDir);
+            TraceAttackToTriggers(info, tr.startpos, tr.endpos, vecDir);
 
-        ApplyMultiDamage();
+            ApplyMultiDamage();
+        }
 #endif
 
         // check if bullet can penetarte another entity


### PR DESCRIPTION
Closes #445 

Ghosts should not be able to damage things in the local player's game, as some things like buttons rely on the local player to damage them in order to activate them.