### PR TITLE
Fix Replay Date Bug + Some Cleanup of Replay System

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -221,22 +221,12 @@ void CHudMapFinishedDialog::SetRunUploaded(bool bState)
     m_pLevelGain->SetVisible(false);
 }
 
-static const char * const szSubmitStates[] = {
-    "#MOM_MF_RunSubmitFail_Unknown", // RUN_SUBMIT_UNKNOWN
-    "#MOM_MF_RunSubmitted", // RUN_SUBMIT_SUCCESS
-    "#MOM_MF_RunSubmitFail_InMapping", // RUN_SUBMIT_FAIL_IN_MAPPING_MODE
-    "#MOM_MF_RunSubmitFail_InvalidMapStatus", // RUN_SUBMIT_FAIL_MAP_STATUS_INVALID
-    "#MOM_MF_RunSubmitFail_InvalidSession", // RUN_SUBMIT_FAIL_SESSION_ID_INVALID
-    "#MOM_MF_RunSubmitFail_APIFail", // RUN_SUBMIT_FAIL_API_FAIL
-    "#MOM_MF_RunSubmitFail_IOFail", // RUN_SUBMIT_FAIL_IO_FAIL
-};
-
 void CHudMapFinishedDialog::SetRunSubmitted(RunSubmitState_t state)
 {
     if (state <= RUN_SUBMIT_UNKNOWN || state >= RUN_SUBMIT_COUNT)
         return;
 
-    m_pRunUploadStatus->SetText(szSubmitStates[state]);
+    m_pRunUploadStatus->SetText(g_szSubmitStates[state]);
     m_pRunUploadStatus->SetFgColor(state == RUN_SUBMIT_SUCCESS ? COLOR_ORANGE : COLOR_RED);
 
     // Visibility for these will be determined by the run_upload event

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
@@ -37,10 +37,14 @@ public:
     void SetRunUploaded(bool bState);
     void SetRunSubmitted(RunSubmitState_t state);
 
+    bool ClosePanel();
+
 protected:
     CPanelAnimationVar(vgui::HFont, m_hTextFont, "TextFont", "Default");
 
 private:
+    void FirePanelClosedEvent(bool bRestartingMap);
+
     wchar_t m_pwCurrentPageOverall[BUFSIZELOCL];
     wchar_t m_pwCurrentPageZoneNum[BUFSIZELOCL];
     wchar_t m_pwOverallTime[BUFSIZELOCL];
@@ -87,6 +91,7 @@ private:
     C_MomRunEntityData *m_pRunData;
 
     bool m_bIsGhost;
+    bool m_bCanClose;
 
     int m_iCurrentPage, m_iVelocityType;
 };

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -225,6 +225,7 @@ CMomentumPlayer::CMomentumPlayer()
       m_flLastVelocity(0.0f), m_nPerfectSyncTicks(0), m_nStrafeTicks(0), m_nAccelTicks(0),
       m_nPrevButtons(0), m_flTweenVelValue(1.0f), m_bInAirDueToJump(false), m_iProgressNumber(-1)
 {
+    m_bAllowUserTeleports = true;
     m_flPunishTime = -1;
     m_iLastBlock = -1;
     m_iOldTrack = 0;
@@ -846,6 +847,9 @@ void CMomentumPlayer::CheckChatText(char *p, int bufsize) { g_pMomentumGhostClie
 // Overrides Teleport() so we can take care of the trail
 void CMomentumPlayer::Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
 {
+    if (!m_bAllowUserTeleports)
+        return;
+
     // No need to remove the trail here, CreateTrail() already does it for us
     BaseClass::Teleport(newPosition, newAngles, newVelocity);
     PhysicsCheckForEntityUntouch();

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -847,7 +847,7 @@ void CMomentumPlayer::CheckChatText(char *p, int bufsize) { g_pMomentumGhostClie
 // Overrides Teleport() so we can take care of the trail
 void CMomentumPlayer::Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
 {
-    if (!m_bAllowUserTeleports)
+    if (!m_bAllowUserTeleports || m_Data.m_bMapFinished)
         return;
 
     // No need to remove the trail here, CreateTrail() already does it for us

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -56,6 +56,14 @@ void CMomentumReplayGhostEntity::FireGameEvent(IGameEvent *pEvent)
     }
 }
 
+void CMomentumReplayGhostEntity::Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
+{
+    if (m_Data.m_bMapFinished)
+        return;
+
+    BaseClass::Teleport(newPosition, newAngles, newVelocity);
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Sets up the entity's initial state
 //-----------------------------------------------------------------------------
@@ -630,7 +638,7 @@ void CMomentumReplayGhostEntity::OnZoneExit(CTriggerZone *pTrigger)
     case ZONE_TYPE_START:
         break;
     case ZONE_TYPE_STOP:
-
+        m_Data.m_bMapFinished = false;
         break;
     case ZONE_TYPE_CHECKPOINT:
         break;

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -151,6 +151,19 @@ void CMomentumReplayGhostEntity::UpdateStep(int Skip)
     m_iCurrentTick = clamp<int>(m_iCurrentTick, 0, m_iTotalTicks);
 }
 
+void CMomentumReplayGhostEntity::LoadFromReplayBase(CMomReplayBase *pReplay)
+{
+    m_pPlaybackReplay = pReplay;
+
+    m_RunStats.FullyCopyFrom(*m_pPlaybackReplay->GetRunStats());
+    m_Data.m_iRunTime = m_pPlaybackReplay->GetStopTick() - m_pPlaybackReplay->GetStartTick();
+    m_Data.m_iRunFlags = m_pPlaybackReplay->GetRunFlags();
+    m_Data.m_flTickRate = m_pPlaybackReplay->GetTickInterval();
+    m_Data.m_iStartTick = m_pPlaybackReplay->GetStartTick();
+
+    m_pPlaybackReplay->SetRunEntity(this);
+}
+
 void CMomentumReplayGhostEntity::Think()
 {
     BaseClass::Think();

--- a/mp/src/game/server/momentum/mom_replay_entity.h
+++ b/mp/src/game/server/momentum/mom_replay_entity.h
@@ -55,6 +55,7 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
     void Spawn(void) OVERRIDE;
     void Precache(void) OVERRIDE;
     void FireGameEvent(IGameEvent *pEvent) OVERRIDE;
+    void Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity) override;
 
     void CreateTrail() OVERRIDE;
 

--- a/mp/src/game/server/momentum/mom_replay_entity.h
+++ b/mp/src/game/server/momentum/mom_replay_entity.h
@@ -20,8 +20,10 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
     // Increments the steps intelligently.
     void UpdateStep(int Skip);
 
-    void EndRun();
+    void LoadFromReplayBase(CMomReplayBase *pReplay);
+
     void StartRun(bool firstPerson = false);
+    void EndRun();
 
     void HandleGhost() OVERRIDE;
     void HandleGhostFirstPerson() OVERRIDE;
@@ -30,18 +32,12 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
 
     void GoToTick(int tick);
 
-    inline void SetTickRate(float rate) { m_Data.m_flTickRate = rate; }
-    inline void SetRunFlags(uint32 flags) { m_Data.m_iRunFlags = flags; }
-    void SetPlaybackReplay(CMomReplayBase *pPlayback) { m_pPlaybackReplay = pPlayback; }
-
     CReplayFrame* GetCurrentStep();
     CReplayFrame *GetNextStep();
     CReplayFrame *GetPreviousStep();
 
     bool IsReplayEnt() { return true; }
 
-    bool m_bIsActive;
-    bool m_bReplayFirstPerson;
 
     RUN_ENT_TYPE GetEntType() OVERRIDE { return RUN_ENT_REPLAY; }
     virtual void OnZoneEnter(CTriggerZone *pTrigger) OVERRIDE;
@@ -66,6 +62,8 @@ class CMomentumReplayGhostEntity : public CMomentumGhostBaseEntity, public CGame
     CMomReplayBase *m_pPlaybackReplay;
 
     bool m_bHasJumped;
+    bool m_bIsActive;
+    bool m_bReplayFirstPerson;
 
     // for faking strafe sync calculations
     QAngle m_angLastEyeAngle;

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -1,5 +1,6 @@
 #include "cbase.h"
 
+#include "time.h"
 #include "mom_timer.h"
 #include "mom_player_shared.h"
 #include "mom_replay_entity.h"
@@ -277,7 +278,7 @@ void CMomentumReplaySystem::SetReplayInfo()
     m_pRecordingReplay->SetPlayerSteamID(pUser ? pUser->GetSteamID().ConvertToUint64() : 0);
     m_pRecordingReplay->SetTickInterval(gpGlobals->interval_per_tick);
     m_pRecordingReplay->SetRunFlags(pPlayer->m_Data.m_iRunFlags);
-    m_pRecordingReplay->SetRunDate(g_pMomentumTimer->GetLastRunDate());
+    m_pRecordingReplay->SetRunDate(time(nullptr));
     m_pRecordingReplay->SetStartTick(m_iStartTimerTick - m_iStartRecordingTick);
     m_pRecordingReplay->SetStopTick(m_iStopTimerTick - m_iStartRecordingTick);
     m_pRecordingReplay->SetTrackNumber(g_pMomentumTimer->GetTrackNumber());

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -304,7 +304,12 @@ void CMomentumReplaySystem::StartPlayback(bool firstperson)
         CMomentumReplayGhostEntity *pGhost = m_pPlaybackReplay->GetRunEntity();
 
         if (pGhost)
+        {
+            mom_replay_timescale.SetValue(1.0f);
+            mom_replay_selection.SetValue(0);
+
             pGhost->StartRun(firstperson);
+        }
 
         m_bPlayingBack = true;
     }
@@ -336,11 +341,11 @@ void CMomentumReplaySystem::LoadReplayGhost()
 
 void CMomentumReplaySystem::StopPlayback()
 {
-    if (!g_ReplaySystem.m_bPlayingBack)
+    if (!m_bPlayingBack)
         return;
 
     Log("Stopping replay playback.\n");
-    g_ReplaySystem.UnloadPlayback();
+    UnloadPlayback();
 }
 
 class CMOMReplayCommands
@@ -370,8 +375,6 @@ class CMOMReplayCommands
                 if (!Q_strcmp(STRING(gpGlobals->mapname), pLoaded->GetMapName()))
                 {
                     g_ReplaySystem.StartPlayback(firstperson);
-                    mom_replay_timescale.SetValue(1.0f);
-                    mom_replay_selection.SetValue(0);
                 }
                 else
                 {
@@ -394,7 +397,6 @@ CON_COMMAND(mom_replay_play_loaded, "Begins playing back a loaded replay (in fir
     if (g_ReplaySystem.GetPlaybackReplay() && !g_ReplaySystem.IsPlayingBack())
     {
         g_ReplaySystem.StartPlayback(true);
-        mom_replay_timescale.SetValue(1.0f);
     }
 }
 

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -336,13 +336,7 @@ void CMomentumReplaySystem::LoadReplayGhost()
         return;
 
     auto pGhost = static_cast<CMomentumReplayGhostEntity *>(CreateEntityByName("mom_replay_ghost"));
-    pGhost->m_RunStats.FullyCopyFrom(*m_pPlaybackReplay->GetRunStats());
-    pGhost->m_Data.m_iRunTime = m_pPlaybackReplay->GetStopTick() - m_pPlaybackReplay->GetStartTick();
-    pGhost->m_Data.m_iRunFlags = m_pPlaybackReplay->GetRunFlags();
-    pGhost->m_Data.m_flTickRate = m_pPlaybackReplay->GetTickInterval();
-    pGhost->SetPlaybackReplay(m_pPlaybackReplay);
-    pGhost->m_Data.m_iStartTick = m_pPlaybackReplay->GetStartTick();
-    m_pPlaybackReplay->SetRunEntity(pGhost);
+    pGhost->LoadFromReplayBase(m_pPlaybackReplay);
 }
 
 void CMomentumReplaySystem::StopPlayback()

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -124,10 +124,6 @@ void CMomentumReplaySystem::StopRecording(bool throwaway, bool delay)
     DevLog("Before trimming: %i\n", m_iTickCount);
     TrimReplay();
 
-    // Store the replay in a file and stop recording. Let's Trim before doing this, for our start recorded tick.
-    SetReplayInfo();
-    SetRunStats();
-
     int postTrimTickCount = m_pRecordingReplay->GetFrameCount();
     DevLog("After trimming: %i\n", postTrimTickCount);
     char newRecordingPath[MAX_PATH];
@@ -268,13 +264,15 @@ CMomReplayBase *CMomentumReplaySystem::LoadPlayback(const char *pFileName, bool 
     return m_pPlaybackReplay;
 }
 
-void CMomentumReplaySystem::SetReplayInfo()
+void CMomentumReplaySystem::SetReplayHeaderAndStats()
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
+    ISteamUser *pUser = SteamUser();
+
+    // Header
     m_pRecordingReplay->SetMapName(gpGlobals->mapname.ToCStr());
     m_pRecordingReplay->SetMapHash(m_szMapHash);
     m_pRecordingReplay->SetPlayerName(pPlayer->GetPlayerName());
-    ISteamUser *pUser = SteamUser();
     m_pRecordingReplay->SetPlayerSteamID(pUser ? pUser->GetSteamID().ConvertToUint64() : 0);
     m_pRecordingReplay->SetTickInterval(gpGlobals->interval_per_tick);
     m_pRecordingReplay->SetRunFlags(pPlayer->m_Data.m_iRunFlags);
@@ -283,12 +281,9 @@ void CMomentumReplaySystem::SetReplayInfo()
     m_pRecordingReplay->SetStopTick(m_iStopTimerTick - m_iStartRecordingTick);
     m_pRecordingReplay->SetTrackNumber(g_pMomentumTimer->GetTrackNumber());
     m_pRecordingReplay->SetZoneNumber(0); // MOM_TODO (0.9.0) allow individual zone runs
-}
 
-void CMomentumReplaySystem::SetRunStats()
-{
-    const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    CMomRunStats* stats = m_pRecordingReplay->CreateRunStats(pPlayer->m_RunStats.GetTotalZones());
+    // Stats
+    CMomRunStats *stats = m_pRecordingReplay->CreateRunStats(pPlayer->m_RunStats.GetTotalZones());
     stats->FullyCopyFrom(pPlayer->m_RunStats);
     // MOM_TODO uncomment: stats->SetZoneTime(0, m_pRecordingReplay->GetRunTime());
 }

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -29,7 +29,6 @@ CMomentumReplaySystem::CMomentumReplaySystem(const char* pName):
     m_fRecEndTime(-1.0f)
 {
     m_szMapHash[0] = '\0';
-    m_pRecordingReplay = g_ReplayFactory.CreateEmptyReplay(0);
 }
 
 CMomentumReplaySystem::~CMomentumReplaySystem()
@@ -77,15 +76,17 @@ void CMomentumReplaySystem::PostInit()
 
 void CMomentumReplaySystem::BeginRecording()
 {
+    if (m_bRecording || m_pRecordingReplay)
+        return;
+
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    // don't record if we're watching a preexisting replay
-    if (pPlayer && pPlayer->GetObserverMode() == OBS_MODE_NONE)
-    {
-        m_bRecording = true;
-        m_iTickCount = 1; // recording begins at 1 ;)
-        m_iStartRecordingTick = gpGlobals->tickcount;
-        m_pRecordingReplay = g_ReplayFactory.CreateEmptyReplay(0);
-    }
+    if (!pPlayer || pPlayer->GetObserverMode() != OBS_MODE_NONE)
+        return;
+
+    m_bRecording = true;
+    m_iTickCount = 1; // recording begins at 1 ;)
+    m_iStartRecordingTick = gpGlobals->tickcount;
+    m_pRecordingReplay = g_ReplayFactory.CreateEmptyReplay(0);
 }
 
 void CMomentumReplaySystem::CancelRecording()

--- a/mp/src/game/server/momentum/mom_replay_system.h
+++ b/mp/src/game/server/momentum/mom_replay_system.h
@@ -25,7 +25,8 @@ public:
     void SetTimerStopTick(uint32 tick) { m_iStopTimerTick = tick; }
 
     void BeginRecording();
-    void StopRecording(bool throwaway, bool delay);
+    void CancelRecording();
+    void StopRecording();  // Called when the timer stops, calls FinishRecording after delay
     bool IsRecording() const { return m_bRecording; }
     bool IsPlayingBack() const { return m_bPlayingBack; }
     void TrimReplay(); // Trims a replay's start down to only include a defined amount of time in the start trigger
@@ -45,6 +46,7 @@ public:
     //CMomRunStats *SavedRunStats() { return &m_SavedRunStats; }
 
   private:
+    void FinishRecording();       // Called when the end recording delay is over, writes replay file
     void UpdateRecordingParams(); // called every game frame after entities think and update
     void SetReplayHeaderAndStats();
     bool StoreReplay(char *pPathOut, size_t outSize);

--- a/mp/src/game/server/momentum/mom_replay_system.h
+++ b/mp/src/game/server/momentum/mom_replay_system.h
@@ -46,11 +46,9 @@ public:
 
   private:
     void UpdateRecordingParams(); // called every game frame after entities think and update
-    void SetReplayInfo();
-    void SetRunStats();
+    void SetReplayHeaderAndStats();
     bool StoreReplay(char *pPathOut, size_t outSize);
 
-  private:
     bool m_bRecording;
     bool m_bPlayingBack;
     CMomReplayBase *m_pRecordingReplay;

--- a/mp/src/game/server/momentum/mom_replay_system.h
+++ b/mp/src/game/server/momentum/mom_replay_system.h
@@ -57,7 +57,6 @@ public:
     CMomReplayBase *m_pPlaybackReplay;
 
     bool m_bShouldStopRec;
-    int m_iTickCount;          // MOM_TODO: Maybe remove me?
     uint32 m_iStartRecordingTick; // The tick that the replay started, used for trimming.
     uint32 m_iStartTimerTick;     // The tick that the player's timer starts, used for trimming.
     uint32 m_iStopTimerTick;      // The tick that the player's timer stopped, used for the hud

--- a/mp/src/game/server/momentum/mom_replay_system.h
+++ b/mp/src/game/server/momentum/mom_replay_system.h
@@ -21,8 +21,8 @@ public:
     void PostInit() OVERRIDE;
 
     // Sets the start timer tick, this is used for trimming later on
-    void SetTimerStartTick(uint32 tick) { m_iStartTimerTick = tick; }
-    void SetTimerStopTick(uint32 tick) { m_iStopTimerTick = tick; }
+    void SetTimerStartTick(int tick) { m_iStartTimerTick = tick; }
+    void SetTimerStopTick(int tick) { m_iStopTimerTick = tick; }
 
     void BeginRecording();
     void CancelRecording();
@@ -57,9 +57,9 @@ public:
     CMomReplayBase *m_pPlaybackReplay;
 
     bool m_bShouldStopRec;
-    uint32 m_iStartRecordingTick; // The tick that the replay started, used for trimming.
-    uint32 m_iStartTimerTick;     // The tick that the player's timer starts, used for trimming.
-    uint32 m_iStopTimerTick;      // The tick that the player's timer stopped, used for the hud
+    int m_iStartRecordingTick; // The tick that the replay started, used for trimming.
+    int m_iStartTimerTick;     // The tick that the player's timer starts, used for trimming.
+    int m_iStopTimerTick;      // The tick that the player's timer stopped, used for the hud
     float m_fRecEndTime;       // The time to end the recording, if delay was passed as true to StopRecording()
     //CMomRunStats m_SavedRunStats;
     // Map SHA1 hash for version purposes

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -136,7 +136,16 @@ void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */
     }
 
     if (g_ReplaySystem.IsRecording() && bStopRecording)
-        g_ReplaySystem.StopRecording(!bFinished, bFinished);
+    {
+        if (bFinished)
+        {
+            g_ReplaySystem.StopRecording();
+        }
+        else
+        {
+            g_ReplaySystem.CancelRecording();
+        }
+    }
 }
 
 void CMomentumTimer::Reset(CMomentumPlayer *pPlayer)
@@ -159,7 +168,7 @@ void CMomentumTimer::Reset(CMomentumPlayer *pPlayer)
 
         // Handle the replay recordings
         if (g_ReplaySystem.IsRecording())
-            g_ReplaySystem.StopRecording(true, false);
+            g_ReplaySystem.CancelRecording();
 
         g_ReplaySystem.BeginRecording();
     }

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -28,19 +28,17 @@ CMomentumTimer::CMomentumTimer() : CAutoGameSystemPerFrame("CMomentumTimer"),
     m_iStartTick(0), m_iEndTick(0), m_bIsRunning(false),
     m_bCanStart(false), m_bWasCheatsMsgShown(false), m_iTrackNumber(0), m_bShouldUseStartZoneOffset(false)
 {
-
 }
 
-void CMomentumTimer::LevelInitPostEntity()
-{
-    m_bWasCheatsMsgShown = false;
-}
+void CMomentumTimer::LevelInitPostEntity() { m_bWasCheatsMsgShown = false; }
 
 void CMomentumTimer::LevelShutdownPreEntity()
 {
-    if (IsRunning())
+    if (m_bIsRunning)
         Stop(nullptr);
+
     m_bWasCheatsMsgShown = false;
+
     for (int i = 0; i < MAX_TRACKS; i++)
     {
         m_hStartTriggers[i] = nullptr;
@@ -120,11 +118,8 @@ bool CMomentumTimer::Start(CMomentumPlayer *pPlayer)
 
 void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */, bool bStopRecording /* = true*/)
 {
-    // Only stop timer if it's currently running
-    if (!IsRunning())
-    {
+    if (!m_bIsRunning)
         return;
-    }
 
     SetRunning(pPlayer, false);
 
@@ -140,7 +135,6 @@ void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */
         DispatchTimerEventMessage(pPlayer, pPlayer->entindex(), bFinished ? TIMER_EVENT_FINISHED : TIMER_EVENT_STOPPED);
     }
 
-    // Stop replay recording, if there was any
     if (g_ReplaySystem.IsRecording() && bStopRecording)
         g_ReplaySystem.StopRecording(!bFinished, bFinished);
 }
@@ -341,8 +335,7 @@ void CMomentumTimer::DisablePractice(CMomentumPlayer *pPlayer)
 
 //--------- Commands --------------------------------
 
-CON_COMMAND(mom_start_mark_create,
-            "Marks a starting point inside the start trigger for a more customized starting location.\n")
+CON_COMMAND(mom_start_mark_create, "Marks a starting point inside the start trigger for a more customized starting location.\n")
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
     if (pPlayer)
@@ -351,9 +344,9 @@ CON_COMMAND(mom_start_mark_create,
     }
 }
 
-CON_COMMAND(mom_start_mark_clear,
-            "Clears the saved start location for your current track, if there is one.\n"
-            "You may also specify the track number to clear as the parameter; \"mom_start_mark_clear 2\" clears track 2's start mark.")
+CON_COMMAND(mom_start_mark_clear, "Clears the saved start location for your current track, if there is one.\n"
+                                  "You may also specify the track number to clear as the parameter; "
+                                  "\"mom_start_mark_clear 2\" clears track 2's start mark.")
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
     if (pPlayer)
@@ -377,7 +370,9 @@ CON_COMMAND_F(mom_timer_stop, "Stops the timer if it is currently running.", FCV
     }
 }
 
-CON_COMMAND_F(mom_restart, "Restarts the player to the start trigger. Optionally takes a track number to restart to (default is main track).\n",
+CON_COMMAND_F(mom_restart,
+              "Restarts the player to the start trigger. Optionally takes a track number to restart to (default is "
+              "main track).\n",
               FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_SERVER_CAN_EXECUTE)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
@@ -403,7 +398,8 @@ CON_COMMAND_F(mom_reset, "Teleports the player back to the start of the current 
     }
 }
 
-CON_COMMAND_F(mom_stage_tele, "Teleports the player to the desired stage. Stops the timer (Useful for mappers)\n"
+CON_COMMAND_F(mom_stage_tele,
+              "Teleports the player to the desired stage. Stops the timer (Useful for mappers)\n"
               "Usage: mom_stage_tele <stage> [track]\nThe default track is the current track the player is on.",
               FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_SERVER_CAN_EXECUTE)
 {

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -2,8 +2,6 @@
 
 #include "mom_timer.h"
 
-#include <ctime>
-#include "in_buttons.h"
 #include "mom_player_shared.h"
 #include "mom_replay_system.h"
 #include "mom_system_saveloc.h"
@@ -26,10 +24,9 @@ class CTimeTriggerTraceEnum : public IEntityEnumerator
     Ray_t *m_pRay;
 };
 
-CMomentumTimer::CMomentumTimer() : CAutoGameSystemPerFrame("CMomentumTimer"), 
-      m_iStartTick(0), m_iEndTick(0),
-      m_iLastRunDate(0), m_bIsRunning(false), m_bCanStart(false),
-      m_bWasCheatsMsgShown(false), m_iTrackNumber(0), m_bShouldUseStartZoneOffset(false)
+CMomentumTimer::CMomentumTimer() : CAutoGameSystemPerFrame("CMomentumTimer"),
+    m_iStartTick(0), m_iEndTick(0), m_bIsRunning(false),
+    m_bCanStart(false), m_bWasCheatsMsgShown(false), m_iTrackNumber(0), m_bShouldUseStartZoneOffset(false)
 {
 
 }
@@ -112,7 +109,6 @@ bool CMomentumTimer::Start(CMomentumPlayer *pPlayer)
 
     m_iStartTick = gpGlobals->tickcount;
     m_iEndTick = 0;
-    m_iLastRunDate = 0;
     m_iTrackNumber = pPlayer->m_Data.m_iCurrentTrack;
     SetRunning(pPlayer, true);
 
@@ -139,7 +135,6 @@ void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */
         {
             m_iEndTick = gpGlobals->tickcount;
             g_ReplaySystem.SetTimerStopTick(m_iEndTick);
-            time(&m_iLastRunDate); // Set the last run date for the replay
         }
 
         DispatchTimerEventMessage(pPlayer, pPlayer->entindex(), bFinished ? TIMER_EVENT_FINISHED : TIMER_EVENT_STOPPED);

--- a/mp/src/game/server/momentum/mom_timer.h
+++ b/mp/src/game/server/momentum/mom_timer.h
@@ -14,7 +14,7 @@ class CMomentumTimer : public CAutoGameSystemPerFrame
     // CAutoGameSystemPerFrame
     void LevelInitPostEntity() OVERRIDE;
     void LevelShutdownPreEntity() OVERRIDE;
-    virtual void FrameUpdatePreEntityThink() OVERRIDE;
+    void FrameUpdatePreEntityThink() OVERRIDE;
 
     // HUD messages
     void DispatchCheatsMessage(CMomentumPlayer *pPlayer);
@@ -50,8 +50,6 @@ class CMomentumTimer : public CAutoGameSystemPerFrame
     int GetCurrentTime() const { return gpGlobals->tickcount - m_iStartTick; }
     // Gets the time for the last run, if there was one
     int GetLastRunTime() const;
-    // Gets the date achieved for the last run.
-    time_t GetLastRunDate() const { return m_iLastRunDate; }
 
     // Practice mode- noclip mode that stops timer
     void EnablePractice(CMomentumPlayer *pPlayer);
@@ -69,11 +67,9 @@ class CMomentumTimer : public CAutoGameSystemPerFrame
 
     // tries to start timer, if successful also sets all the player vars and starts replay
     void TryStart(CMomentumPlayer *pPlayer, bool bUseStartZoneOffset);
+
   private:
-
-
     int m_iStartTick, m_iEndTick;
-    time_t m_iLastRunDate;
     bool m_bIsRunning;
     bool m_bCanStart;
     bool m_bWasCheatsMsgShown;

--- a/mp/src/game/shared/momentum/mom_shareddefs.h
+++ b/mp/src/game/shared/momentum/mom_shareddefs.h
@@ -47,6 +47,16 @@ enum RunSubmitState_t
     RUN_SUBMIT_COUNT
 };
 
+static const char *const g_szSubmitStates[] = {
+    "#MOM_MF_RunSubmitFail_Unknown",          // RUN_SUBMIT_UNKNOWN
+    "#MOM_MF_RunSubmitted",                   // RUN_SUBMIT_SUCCESS
+    "#MOM_MF_RunSubmitFail_InMapping",        // RUN_SUBMIT_FAIL_IN_MAPPING_MODE
+    "#MOM_MF_RunSubmitFail_InvalidMapStatus", // RUN_SUBMIT_FAIL_MAP_STATUS_INVALID
+    "#MOM_MF_RunSubmitFail_InvalidSession",   // RUN_SUBMIT_FAIL_SESSION_ID_INVALID
+    "#MOM_MF_RunSubmitFail_APIFail",          // RUN_SUBMIT_FAIL_API_FAIL
+    "#MOM_MF_RunSubmitFail_IOFail",           // RUN_SUBMIT_FAIL_IO_FAIL
+};
+
 // Gamemode for momentum
 enum GameMode_t
 {


### PR DESCRIPTION
Closes #439 

Fixed the date bug by preventing user teleporting at all while the AllowUserTeleport flag is false.
Cleaned up the replay system and probably got rid of some memory leaks.
Separated the process of ending a replay into Cancel / Stop / Finish, where Cancel is throwing it away, Stop is called when the timer stops (begin the delay) and Finish is called after the delay for the replay is over.