### PR TITLE
Fix weapons being able to instantly fire exiting practice mode

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1899,6 +1899,7 @@ void CMomentumPlayer::SaveCurrentRunState(bool bFromPractice)
     pState->m_angLastAng = GetAbsAngles();
     pState->m_vecLastVelocity = GetAbsVelocity();
     pState->m_fLastViewOffset = GetViewOffset().z;
+    pState->m_fNextPrimaryAttack = GetActiveWeapon() ? GetActiveWeapon()->m_flNextPrimaryAttack - gpGlobals->curtime : 0.0f;
 
     if (bFromPractice || !m_bHasPracticeMode)
     {
@@ -1933,6 +1934,8 @@ void CMomentumPlayer::RestoreRunState(bool bFromPractice)
     Teleport(&pState->m_vecLastPos, &pState->m_angLastAng, &pState->m_vecLastVelocity);
     SetViewOffset(Vector(0, 0, pState->m_fLastViewOffset));
     SetLastEyeAngles(pState->m_angLastAng);
+    if (GetActiveWeapon())
+        GetActiveWeapon()->m_flNextPrimaryAttack = gpGlobals->curtime + pState->m_fNextPrimaryAttack;
 
     if (bFromPractice || !m_bHasPracticeMode)
     {

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -21,7 +21,8 @@ struct SavedState_t
     Vector m_vecLastPos;      // Saved location before the replay was played or practice mode.
     QAngle m_angLastAng;      // Saved angles before the replay was played or practice mode.
     Vector m_vecLastVelocity; // Saved velocity before the replay was played or practice mode.
-    float m_fLastViewOffset;  // Saved viewoffset before the replay was played or practice mode.    
+    float m_fLastViewOffset;  // Saved viewoffset before the replay was played or practice mode.
+    float m_fNextPrimaryAttack; // Saved next weapon shoot time
     // Stats-related
     int m_nSavedPerfectSyncTicks;
     int m_nSavedStrafeTicks;


### PR DESCRIPTION
Closes #486 

After delaying a bit in practice mode, the player was able to fire a rocket immediately as the weapon's next primary attack had already arrived. So upon exiting practice mode we now reset the primary attack to what it should be as if they never entered practice.

As for if the player changes weapon and exits practice mode, the 0.5 sec weapon switch delay effectively blocks instantly firing which should provide ample time to mess up any tricks they are setting up with this.