### PR TITLE
Convar fix for headbugs

### DIFF
--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -4616,6 +4616,18 @@ void CGameMovement::PlayerMove( void )
 
 	UpdateDuckJumpEyeOffset();
 	Duck();
+    
+    if (sv_duck_collision_fix.GetBool())
+    {
+        if ( player->GetFlags() & FL_DUCKING )
+        {
+            player->SetCollisionBounds( VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX );
+        }
+        else
+        {
+            player->SetCollisionBounds( VEC_HULL_MIN, VEC_HULL_MAX );
+        }
+    }
 
 	// Don't run ladder code if dead on on a train
 	if ( !player->pl.deadflag && !(player->GetFlags() & FL_ONTRAIN) )

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -43,6 +43,7 @@ void CGameModeBase::SetGameModeVars()
     sv_maxspeed.SetValue(260);
     sv_stopspeed.SetValue(75);
     sv_considered_on_ground.SetValue(1);
+    sv_duck_collision_fix.SetValue(true);
 }
 
 void CGameModeBase::OnPlayerSpawn(CMomentumPlayer *pPlayer)
@@ -90,6 +91,7 @@ void CGameMode_RJ::SetGameModeVars()
     sv_maxspeed.SetValue(240);
     sv_stopspeed.SetValue(100);
     sv_considered_on_ground.SetValue(2);
+    sv_duck_collision_fix.SetValue(false);
 }
 
 void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)

--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -132,3 +132,4 @@ ConVar r_AirboatViewZHeight( "r_AirboatViewZHeight", "0.0", FCVAR_CHEAT | FCVAR_
 
 // Momentum convars
 ConVar sv_considered_on_ground("sv_considered_on_ground", "1.0", 0, "Amount of units you have to be above the ground to be considered on ground", true, 0.0f, true, 5.f);
+ConVar sv_duck_collision_fix("sv_duck_collision_fix", "1", 0, "Fixes headbugs by updating the collision box after duck code instead of at the end of the tick", true, 0, true, 1);

--- a/mp/src/game/shared/movevars_shared.h
+++ b/mp/src/game/shared/movevars_shared.h
@@ -54,5 +54,6 @@ extern ConVar r_AirboatViewZHeight;
 
 // Momentum convars
 extern ConVar sv_considered_on_ground;
+extern ConVar sv_duck_collision_fix;
 
 #endif // MOVEVARS_SHARED_H


### PR DESCRIPTION
Adds convar sv_duck_collision_fix. The rocket jump gamemode will not use this fix as it is undesired and unwanted headbugs will instead be fixed manually in the map. The duck code already checks if the player would be stuck when ducking/unducking and this fix only affects the tick you duck/unduck by using the correct bbox for movement checks.