### PR TITLE
Limit appveyor to only build when mp/src/ files change

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,12 @@ branches:
     - master
     - develop
 
+# We only want to build if actual source files changed, and not game resource / misc files.
+only_commits:
+  files:
+    - mp/src/
+    - appveyor.yml
+
 # Don't build when tags are made
 skip_tags: true
 


### PR DESCRIPTION
This PR aims to lower the amount of unnecessary Appveyor builds by checking if only source folder (`mp/src/`) file changes are made. While the majority of the time source file changes are what's happening, there are cases where only res or texture or map files are added and don't warrant a full build.