### PR TITLE
Fix players doing damage in practice mode

### DIFF
--- a/mp/src/game/shared/momentum/mom_grenade_projectile.cpp
+++ b/mp/src/game/shared/momentum/mom_grenade_projectile.cpp
@@ -1,8 +1,10 @@
 #include "cbase.h"
 #include "mom_grenade_projectile.h"
+
 #ifndef CLIENT_DLL
 #include "soundent.h"
 #include "te_effect_dispatch.h"
+#include "momentum/mom_player.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -125,8 +127,16 @@ CMomGrenadeProjectile *CMomGrenadeProjectile::Create(const Vector &position, con
     pGrenade->SetFriction(GetGrenadeFriction());
     pGrenade->SetElasticity(GetGrenadeElasticity());
 
-    pGrenade->m_flDamage = 100;
-    pGrenade->m_DmgRadius = pGrenade->m_flDamage * 3.5f;
+    if (pOwner->IsPlayer())
+    {
+        const auto pMomPlayer = static_cast<CMomentumPlayer*>(pOwner);
+        pGrenade->SetDamage(pMomPlayer->m_bHasPracticeMode ? 0.0f : 100.0f);
+    }
+    else
+    {
+        pGrenade->SetDamage(0.0f);
+    }
+    pGrenade->SetDamageRadius(pGrenade->GetDamage() * 3.5f);
     pGrenade->ApplyLocalAngularVelocityImpulse(angVelocity);
 
     // make NPCs afaid of it while in the air

--- a/mp/src/game/shared/momentum/mom_player_shared.cpp
+++ b/mp/src/game/shared/momentum/mom_player_shared.cpp
@@ -276,15 +276,19 @@ void CMomentumPlayer::FireBullet(Vector vecSrc,             // shooting postion
 #ifndef CLIENT_DLL
         if (pevAttacker->IsPlayer())
         {
-            ClearMultiDamage();
+            CMomentumPlayer *pPlayerAttacker = static_cast<CMomentumPlayer*>(pevAttacker);
+            if (!pPlayerAttacker->m_bHasPracticeMode)
+            {
+                ClearMultiDamage();
 
-            CTakeDamageInfo info(pevAttacker, pevAttacker, fCurrentDamage, iDamageType);
-            CalculateBulletDamageForce(&info, iBulletType, vecDir, tr.endpos);
-            tr.m_pEnt->DispatchTraceAttack(info, vecDir, &tr);
+                CTakeDamageInfo info(pevAttacker, pevAttacker, fCurrentDamage, iDamageType);
+                CalculateBulletDamageForce(&info, iBulletType, vecDir, tr.endpos);
+                tr.m_pEnt->DispatchTraceAttack(info, vecDir, &tr);
 
-            TraceAttackToTriggers(info, tr.startpos, tr.endpos, vecDir);
+                TraceAttackToTriggers(info, tr.startpos, tr.endpos, vecDir);
 
-            ApplyMultiDamage();
+                ApplyMultiDamage();
+            }
         }
 #endif
 

--- a/mp/src/game/shared/momentum/mom_rocket.cpp
+++ b/mp/src/game/shared/momentum/mom_rocket.cpp
@@ -5,6 +5,7 @@
 #include "Sprite.h"
 #include "explode.h"
 #include "momentum/mom_triggers.h"
+#include "mom_player_shared.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -276,9 +277,9 @@ void CMomRocket::CreateSmokeTrail()
 //
 // Output : CMomRocket
 //-----------------------------------------------------------------------------
-CMomRocket *CMomRocket::EmitRocket(const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pentOwner /*= nullptr*/)
+CMomRocket *CMomRocket::EmitRocket(const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pOwner)
 {
-    CMomRocket *pRocket = static_cast<CMomRocket *>(CreateNoSpawn("momentum_rocket", vecOrigin, vecAngles, pentOwner));
+    CMomRocket *pRocket = static_cast<CMomRocket *>(CreateNoSpawn("momentum_rocket", vecOrigin, vecAngles, pOwner));
     pRocket->SetModel("models/weapons/w_missile.mdl");
     DispatchSpawn(pRocket);
 
@@ -288,13 +289,22 @@ CMomRocket *CMomRocket::EmitRocket(const Vector &vecOrigin, const QAngle &vecAng
     const Vector velocity = vecForward * MOM_ROCKET_SPEED;
     pRocket->SetAbsVelocity(velocity);
     pRocket->SetupInitialTransmittedGrenadeVelocity(velocity);
-    pRocket->SetThrower(pentOwner);
+    pRocket->SetThrower(pOwner);
 
     QAngle angles;
     VectorAngles(velocity, angles);
     pRocket->SetAbsAngles(angles);
 
-    pRocket->SetDamage(90.0f);
+    if (pOwner->IsPlayer())
+    {
+        const auto pPlayer = static_cast<CMomentumPlayer*>(pOwner);
+        pRocket->SetDamage(pPlayer->m_bHasPracticeMode ? 0.0f : 90.0f);
+    }
+    else
+    {
+        pRocket->SetDamage(0.0f);
+    }
+
     // NOTE: Rocket explosion radius is 146.0f in TF2, but 121.0f is used for self damage (see RadiusDamage in mom_gamerules)
     pRocket->SetRadius(146.0f);
 

--- a/mp/src/game/shared/momentum/mom_rocket.h
+++ b/mp/src/game/shared/momentum/mom_rocket.h
@@ -48,7 +48,7 @@ class CMomRocket : public CBaseProjectile
 
     CHandle<CMomentumRocketLauncher> m_hOwner;
 
-    static CMomRocket *EmitRocket(const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pentOwner = nullptr);
+    static CMomRocket *EmitRocket(const Vector &vecOrigin, const QAngle &vecAngles, CBaseEntity *pOwner);
 
   protected:
     void CreateSmokeTrail();

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -13,6 +13,8 @@
 #include "effect_dispatch_data.h"
 #ifdef CLIENT_DLL
 #include "materialsystem/imaterialvar.h"
+#else
+#include "momentum/mom_player.h"
 #endif
 
 #include "steam/steam_api.h"
@@ -554,36 +556,15 @@ void MomUtil::KnifeTrace(const Vector& vecShootPos, const QAngle& lookAng, bool 
 #ifndef CLIENT_DLL
     else if (pAttacker->IsPlayer())
     {
+        CMomentumPlayer *pPlayer = static_cast<CMomentumPlayer*>(pAttacker);
+        if (pPlayer->m_bHasPracticeMode)
+            return;
+
         CBaseEntity *pHitEntity = trOutput->m_pEnt;
 
         ClearMultiDamage();
 
-        float flDamage = 42.0f;
-
-        if ( bStab )
-        {
-            flDamage = 65.0f;
-
-            if (pHitEntity && pHitEntity->IsPlayer())
-            {
-                Vector vTargetForward;
-
-                AngleVectors(pHitEntity->GetAbsAngles(), &vTargetForward);
-
-                Vector2D vecLOS = (pHitEntity->GetAbsOrigin() - pAttacker->GetAbsOrigin()).AsVector2D();
-                Vector2DNormalize( vecLOS );
-
-                float flDot = vecLOS.Dot( vTargetForward.AsVector2D() );
-
-                //Triple the damage if we are stabbing them in the back.
-                if ( flDot > 0.80f )
-                    flDamage *= 3.0f;
-            }
-        }
-        else
-        {
-            flDamage = 20.0f;
-        }
+        const float flDamage = bStab ? 65.0f : 20.0f;
 
         CTakeDamageInfo info( pAttacker, pAttacker, flDamage, DMG_BULLET | DMG_NEVERGIB );
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.cpp
@@ -39,9 +39,9 @@ PRECACHE_WEAPON_REGISTER(weapon_momentum_grenade);
 #ifndef CLIENT_DLL
 
 void CMomentumGrenade::EmitGrenade(const Vector &vecSrc, const QAngle &vecAngles, const Vector &vecVel,
-                                   AngularImpulse angImpulse, CBasePlayer *pPlayer)
+                                   AngularImpulse angImpulse, CBaseEntity *pOwner)
 {
-    CMomGrenadeProjectile::Create(vecSrc, vecAngles, vecVel, angImpulse, pPlayer, GetWorldModel());
+    CMomGrenadeProjectile::Create(vecSrc, vecAngles, vecVel, angImpulse, pOwner, GetWorldModel());
 }
 
 #endif
@@ -292,7 +292,7 @@ void CMomentumGrenade::StartGrenadeThrow() { m_fThrowTime = gpGlobals->curtime +
 
 void CMomentumGrenade::ThrowGrenade()
 {
-    CBasePlayer *pPlayer = ToBasePlayer(GetOwner());
+    CMomentumPlayer *pPlayer = GetPlayerOwner();
     if (!pPlayer)
     {
         Assert(false);
@@ -335,8 +335,8 @@ void CMomentumGrenade::ThrowGrenade()
     int impulseInt = random->RandomInt(-1200, 1200);
 
 #ifdef GAME_DLL
-    QAngle vecThrowOnline(vecThrow.x, vecThrow.y,
-                          vecThrow.z); // Online uses angles, but we're packing 3 floats so whatever
+    // Online uses angles, but we're packing 3 floats so whatever
+    QAngle vecThrowOnline(vecThrow.x, vecThrow.y, vecThrow.z);
     DecalPacket packet = DecalPacket::Bullet(vecSrc, vecThrowOnline, WEAPON_GRENADE, impulseInt, 0, 0.0f);
     g_pMomentumGhostClient->SendDecalPacket(&packet);
 #endif
@@ -346,15 +346,13 @@ void CMomentumGrenade::ThrowGrenade()
     m_bRedraw = true;
     m_fThrowTime = 0.0f;
 
-    // CMomentumPlayer *pPlayer = ToCMOMPlayer( pPlayer );
-
     // if( pPlayer )
     //	pPlayer->Radio( "Radio.FireInTheHole",   "#Cstrike_TitlesTXT_Fire_in_the_hole" );
 }
 
 void CMomentumGrenade::DropGrenade()
 {
-    CBasePlayer *pPlayer = ToBasePlayer(GetOwner());
+    CMomentumPlayer *pPlayer = GetPlayerOwner();
     if (!pPlayer)
     {
         Assert(false);

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_grenade.h
@@ -44,7 +44,7 @@ class CMomentumGrenade : public CWeaponBase
 
     // Each derived grenade class implements this.
     virtual void EmitGrenade(const Vector &vecSrc, const QAngle &vecAngles, const Vector &vecVel,
-                             AngularImpulse angImpulse, CBasePlayer *pPlayer);
+                             AngularImpulse angImpulse, CBaseEntity *pOwner);
 #endif
 
   protected:


### PR DESCRIPTION
Closes #404 

A player could enter practice mode and fly ahead to shoot/knife/etc buttons on the wall to open door before they had approached the area in the run. While the timer still runs inside practice mode, this would still remove the need for them to react to the buttons, gaining an advantage over others. This PR prevents any damage of any type when in practice mode.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review