### PR TITLE
Prevent changing righthand / centerfire when in a run

### DIFF
--- a/mp/src/game/client/c_baseviewmodel.cpp
+++ b/mp/src/game/client/c_baseviewmodel.cpp
@@ -8,19 +8,15 @@
 #include "cbase.h"
 #include "c_baseviewmodel.h"
 #include "model_types.h"
-#include "hud.h"
 #include "view_shared.h"
 #include "iviewrender.h"
 #include "view.h"
-#include "mathlib/vmatrix.h"
 #include "cl_animevent.h"
 #include "eventlist.h"
 #include "tools/bonelist.h"
-#include <KeyValues.h>
 #include "hltvcamera.h"
-#ifdef TF_CLIENT_DLL
-	#include "tf_weaponbase.h"
-#endif
+#include "mom_shareddefs.h"
+#include "c_mom_player.h"
 
 #if defined( REPLAY_ENABLED )
 #include "replay/replaycamera.h"
@@ -31,11 +27,23 @@
 // NVNT haptics system interface
 #include "haptics/ihaptics.h"
 
-
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Use right-handed view models." );
+MAKE_TOGGLE_CONVAR_CV(cl_righthand, "1", FCVAR_ARCHIVE, "Use right-handed view models. 1 = ON, 0 = OFF.\n", nullptr, [](IConVar *pVar, const char *pVal)
+{
+    const auto pPlayer = C_MomentumPlayer::GetLocalMomPlayer();
+    if (pPlayer)
+    {
+        if (pPlayer->m_Data.m_bTimerRunning)
+        {
+            Warning("Cannot change cl_righthand while in a run! Stop the timer to be able to change it.\n");
+            return false;
+        }
+    }
+
+    return true;
+});
 
 #ifdef TF_CLIENT_DLL
 	ConVar cl_flipviewmodels( "cl_flipviewmodels", "0", FCVAR_USERINFO | FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Flip view models." );

--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -8,7 +8,7 @@
 
 #include "tier0/memdbgon.h"
 
-CON_COMMAND(mom_zone_generate, "Generates the .zon file for map zones.")
+CON_COMMAND_F(mom_zone_generate, "Generates the .zon file for map zones.", FCVAR_MAPPING)
 {
     g_MapZoneSystem.SaveZonesToFile();
 }

--- a/mp/src/game/server/momentum/mapzones_build.cpp
+++ b/mp/src/game/server/momentum/mapzones_build.cpp
@@ -779,9 +779,9 @@ void CMomPointZoneBuilder::DrawDebugLines(CMomHulls_t &hulls) const
 {
     // Draw the hulls
     // Very useful for debugging
-    ConVarRef mom_zone_debug("mom_zone_debug");
+    ConVarRef mom_zone_debug("mom_zone_debug", true);
 
-    if (mom_zone_debug.GetInt() == 0)
+    if (!mom_zone_debug.IsValid() || mom_zone_debug.GetInt() == 0)
         return;
 
 

--- a/mp/src/game/server/momentum/mapzones_edit.cpp
+++ b/mp/src/game/server/momentum/mapzones_edit.cpp
@@ -35,17 +35,17 @@ static ConVar mom_zone_debug("mom_zone_debug", "0", FCVAR_MAPPING);
 static MAKE_TOGGLE_CONVAR_C(mom_zone_usenewmethod, "0", FCVAR_MAPPING, "If 1, use a new point-based zoning method (by Mehis).\n", OnZoningMethodChanged);
 static MAKE_TOGGLE_CONVAR(mom_zone_crosshair, "1", FCVAR_MAPPING, "Toggles the drawing of the zoning crosshair/reticle.");
 
-CON_COMMAND_F(mom_zone_zoomin, "Decrease reticle maximum distance.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_zoomin, "Decrease reticle maximum distance.\n", FCVAR_MAPPING)
 {
     g_MapZoneSystem.GetZoneEditor()->DecreaseZoom(mom_zone_grid.GetFloat());
 }
 
-CON_COMMAND_F(mom_zone_zoomout, "Increase reticle maximum distance.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_zoomout, "Increase reticle maximum distance.\n", FCVAR_MAPPING)
 {
     g_MapZoneSystem.GetZoneEditor()->IncreaseZoom(mom_zone_grid.GetFloat());
 }
 
-CON_COMMAND_F(mom_zone_delete, "Delete zone types. Accepts start/stop/stage or an entity index.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_delete, "Delete zone types. Accepts start/stop/stage or an entity index.\n", FCVAR_MAPPING)
 {
     // MOM_TODO: Deleting a zone while a player is inside it causes some weird issues, need to investigate
     if (!mom_zone_edit.GetBool())
@@ -88,7 +88,7 @@ CON_COMMAND_F(mom_zone_delete, "Delete zone types. Accepts start/stop/stage or a
     }
 }
 
-CON_COMMAND_F(mom_zone_edit_existing, "Edit an existing zone. Requires entity index.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_edit_existing, "Edit an existing zone. Requires entity index.\n", FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -124,7 +124,7 @@ CON_COMMAND_F(mom_zone_edit_existing, "Edit an existing zone. Requires entity in
 CON_COMMAND_F(
     mom_zone_start_setlook,
     "Sets start zone teleport look angles. Will take yaw in degrees or use your angles if no arguments given.\n",
-    FCVAR_CHEAT)
+    FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -163,7 +163,7 @@ CON_COMMAND_F(
     }
 }
 
-CON_COMMAND_F(mom_zone_mark, "Starts building a zone.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_mark, "Starts building a zone.\n", FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -171,7 +171,7 @@ CON_COMMAND_F(mom_zone_mark, "Starts building a zone.\n", FCVAR_CHEAT)
     g_MapZoneSystem.GetZoneEditor()->OnMark();
 }
 
-CON_COMMAND_F(mom_zone_cancel, "Cancel the building of the current zone.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_cancel, "Cancel the building of the current zone.\n", FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -179,7 +179,7 @@ CON_COMMAND_F(mom_zone_cancel, "Cancel the building of the current zone.\n", FCV
     g_MapZoneSystem.GetZoneEditor()->OnCancel();
 }
 
-CON_COMMAND_F(mom_zone_back, "Go back a step when zone building.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_back, "Go back a step when zone building.\n", FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -187,7 +187,7 @@ CON_COMMAND_F(mom_zone_back, "Go back a step when zone building.\n", FCVAR_CHEAT
     g_MapZoneSystem.GetZoneEditor()->OnRemove();
 }
 
-CON_COMMAND_F(mom_zone_create, "Create the zone.\n", FCVAR_CHEAT)
+CON_COMMAND_F(mom_zone_create, "Create the zone.\n", FCVAR_MAPPING)
 {
     if (!mom_zone_edit.GetBool())
         return;
@@ -197,7 +197,7 @@ CON_COMMAND_F(mom_zone_create, "Create the zone.\n", FCVAR_CHEAT)
 
 CON_COMMAND_F(mom_zone_info,
               "Sends info about the trigger that is being looked at (if one exists). Internal usage only.\n",
-              FCVAR_HIDDEN)
+              FCVAR_HIDDEN | FCVAR_MAPPING)
 {
     class CZoneTriggerTraceEnum : public IEntityEnumerator
     {

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -82,8 +82,8 @@ bool CMomentumTimer::Start(CMomentumPlayer *pPlayer)
         Warning("Cannot start timer while using save loc menu!\n");
         return false;
     }
-    static ConVarRef mom_zone_edit("mom_zone_edit");
-    if (mom_zone_edit.GetBool())
+    static ConVarRef mom_zone_edit("mom_zone_edit", true);
+    if (mom_zone_edit.IsValid() && mom_zone_edit.GetBool())
     {
         Warning("Cannot start timer while editing zones!\n");
         return false;

--- a/mp/src/game/shared/momentum/mom_shareddefs.h
+++ b/mp/src/game/shared/momentum/mom_shareddefs.h
@@ -223,6 +223,11 @@ enum SpectateMessageType_t
     if (eventServer && eventClient) \
     { gameeventmanager->FireEvent(eventServer, true); gameeventmanager->FireEventClientSide(eventClient); }
 
+
+// Creates a convar with a callback and validator function
+#define MAKE_CONVAR_CV(name, defaultval, flags, desc, minVal, maxVal, callback, validator)                                    \
+    ConVar_Validated name(#name, defaultval, flags, desc, true, minVal, true, maxVal, callback, validator)
+
 // Creates a convar with a callback function
 #define MAKE_CONVAR_C(name, defaultval, flags, desc, minVal, maxVal, callback)                                                \
     ConVar name(#name, defaultval, flags, desc, true, minVal, true, maxVal, callback)
@@ -234,7 +239,12 @@ enum SpectateMessageType_t
 //Creates a CONVAR with 0 as the minimum value, and 1 as the max value. Useful for toggle variables.
 #define MAKE_TOGGLE_CONVAR(name, defaultval, flags, desc) MAKE_CONVAR(name, defaultval, flags, desc, 0, 1)
 
+// Creates a toggle convar with a callback function
 #define MAKE_TOGGLE_CONVAR_C(name, defaultval, flags, desc, callback) MAKE_CONVAR_C(name, defaultval, flags, desc, 0, 1, callback)
+
+// Creates a toggle convar with a callback and validator function
+#define MAKE_TOGGLE_CONVAR_CV(name, defaultval, flags, desc, callback, validator) \
+    MAKE_CONVAR_CV(name, defaultval, flags, desc, 0, 1, callback, validator)
 
 //Flags for a HUD cvar (usually)
 #define FLAG_HUD_CVAR (FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_REPLICATED)

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -6,6 +6,7 @@
 
 #ifdef GAME_DLL
 #include "momentum/ghost_client.h"
+#include "momentum/mom_timer.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -33,8 +34,18 @@ LINK_ENTITY_TO_CLASS(weapon_momentum_rocketlauncher, CMomentumRocketLauncher);
 PRECACHE_WEAPON_REGISTER(weapon_momentum_rocketlauncher);
 
 #ifdef GAME_DLL
-static MAKE_TOGGLE_CONVAR(mom_rj_center_fire, "0", FCVAR_ARCHIVE,
-                          "If enabled, all rockets will be fired from the center of the screen. 0 = OFF, 1 = ON\n");
+static MAKE_TOGGLE_CONVAR_CV(mom_rj_center_fire, "0", FCVAR_ARCHIVE, "If enabled, all rockets will be fired from the center of the screen. 0 = OFF, 1 = ON\n", nullptr,
+    [](IConVar *pVar, const char *pNewVal)
+    {
+        if (g_pMomentumTimer->IsRunning())
+        {
+            Warning("Cannot change rocket firing mode while in a run! Stop your timer to be able to change it.\n");
+            return false;
+        }
+
+        return true;
+    }
+);
 static MAKE_TOGGLE_CONVAR(mom_rj_use_tf_viewmodel, "0", FCVAR_ARCHIVE,
                           "Toggles between the TF2 Rocket Launcher model and the Momentum one. 0 = Momentum, 1 = TF2\n");
 static MAKE_CONVAR(mom_rj_sounds, "1", FCVAR_ARCHIVE,

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -100,7 +100,7 @@ void CMomentumRocketLauncher::GetProjectileFireSetup(CMomentumPlayer *pPlayer, V
 #ifdef GAME_DLL
     static ConVarRef cl_righthand("cl_righthand");
 #else
-    extern ConVar cl_righthand;
+    extern ConVar_Validated cl_righthand;
     static ConVarRef mom_rj_center_fire("mom_rj_center_fire");
 #endif
 

--- a/mp/src/public/tier1/convar.h
+++ b/mp/src/public/tier1/convar.h
@@ -379,6 +379,8 @@ private:
 	// Called by CCvar when the value of a var is changing.
 	virtual void				InternalSetValue(const char *value);
 	// For CVARs marked FCVAR_NEVER_AS_STRING
+	// These are pointless but cannot be removed due to not having engine license... fun...
+	// MOM_TODO remove these if we get engine!
 	virtual void				InternalSetFloatValue( float fNewValue );
 	virtual void				InternalSetIntValue( int nValue );
 

--- a/mp/src/public/tier1/iconvar.h
+++ b/mp/src/public/tier1/iconvar.h
@@ -95,6 +95,8 @@ class CCommand;
 //-----------------------------------------------------------------------------
 typedef void ( *FnChangeCallback_t )( IConVar *var, const char *pOldValue, float flOldValue );
 
+// Called BEFORE a ConVar can change value. Return true for the new value to be accepted, else false to reject.
+typedef bool ( *FnValidatorFunc_t )( IConVar *var, const char *pNewValue );
 
 //-----------------------------------------------------------------------------
 // Abstract interface for ConVars


### PR DESCRIPTION
Closes #520 

This PR introduces a new type of ConVar called ConVar_Validated, that takes in a bool func pointer that validates the new value to be set for a convar, returning true to accept and false to reject it. We cannot merge it into the base class as it ruins the vtable of ConVars already defined in engine/matsys/etc. If we get engine license, we can merge them.

`cl_righthand` and `mom_rj_center_fire` are now validated to check for if the player is in a run, and if so, to reject the change.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->