### PR TITLE
Hotfix for setting correct rocket self-damage radius

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamerules.cpp
+++ b/mp/src/game/shared/momentum/mom_gamerules.cpp
@@ -288,7 +288,7 @@ void CMomentumGameRules::RadiusDamage(const CTakeDamageInfo &info, const Vector 
 
     if (pAttacker && g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
     {
-        if (FClassnameIs(pAttacker, "momentum_rocket"))
+        if (FClassnameIs(info.GetInflictor(), "momentum_rocket"))
         {
             flRadius = 121.0f; // Rocket self-damage radius is 121.0f
         }


### PR DESCRIPTION
During one of the changes in the generic bomb branch, the check for setting the rocket self-damage radius was changed to using `pAttacker` instead of the inflictor which meant that rockets would have a higher radius during push force calculations and thus make jumps like last on jump_concept trivial.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review