### PR TITLE
Validate Online Packets

### DIFF
--- a/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
@@ -19,6 +19,7 @@
 #include "vgui_avatarimage.h"
 
 #include "mom_modulecomms.h"
+#include "mom_ghostdefs.h"
 
 #include "fmtstr.h"
 #include "ilocalize.h"
@@ -350,7 +351,7 @@ void LobbyMembersPanel::OnContextReqSavelocs(uint64 target)
     ShowPanel(false);
     KeyValues *pReq = new KeyValues("req_savelocs");
     // Stage 1 is request the count, make the other player make a copy of their savelocs for us
-    pReq->SetInt("stage", 1);
+    pReq->SetInt("stage", SAVELOC_REQ_STAGE_COUNT_REQ);
     pReq->SetUint64("target", target);
     g_pModuleComms->FireEvent(pReq);
 

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -724,7 +724,8 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
             case PACKET_TYPE_SPEC_UPDATE:
                 {
                     SpecUpdatePacket update(buf);
-                    uint64 fromWhoID = fromWho.ConvertToUint64(), specTargetID = update.specTarget;
+                    if (update.spec_type == SPEC_UPDATE_INVALID)
+                        break;
 
                     CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
                     if (pEntity)
@@ -733,8 +734,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                         update.specTarget != 0 ? pEntity->HideGhost() : pEntity->UnHideGhost();
                     }
 
-                    // Write it out to the Hud Chat
-                    WriteSpecMessage(update.spec_type, fromWhoID, specTargetID);
+                    WriteSpecMessage(update.spec_type, fromWho.ConvertToUint64(), update.specTarget);
                 }
                 break;
             case PACKET_TYPE_SAVELOC_REQ:

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -683,162 +683,153 @@ bool CMomentumLobbySystem::TryJoinLobbyFromString(const char* pString)
 
 void CMomentumLobbySystem::SendAndReceiveP2PPackets()
 {
-    if (m_mapLobbyGhosts.Count() > 0)
+    if (m_mapLobbyGhosts.Count() == 0)
+        return;
+
+    uint32 size;
+    while (SteamNetworking()->IsP2PPacketAvailable(&size))
     {
-        // Read data
-        uint32 size;
-        while (SteamNetworking()->IsP2PPacketAvailable(&size))
+        uint8 *bytes = new uint8[size];
+        uint32 bytesRead;
+        CSteamID fromWho;
+        SteamNetworking()->ReadP2PPacket(bytes, size, &bytesRead, &fromWho);
+
+        CUtlBuffer buf(bytes, size, CUtlBuffer::READ_ONLY);
+        buf.SetBigEndian(false);
+
+        const auto type = buf.GetUnsignedChar();
+        switch (type)
         {
-            // Read the packet's data
-            uint8 *bytes = new uint8[size];
-            uint32 bytesRead;
-            CSteamID fromWho;
-            SteamNetworking()->ReadP2PPacket(bytes, size, &bytesRead, &fromWho);
-
-            // Throw the data into a manageable reader
-            CUtlBuffer buf(bytes, size, CUtlBuffer::READ_ONLY);
-            buf.SetBigEndian(false);
-
-            // Determine what type it is
-            uint8 type = buf.GetUnsignedChar();
-            switch (type)
+        case PACKET_TYPE_POSITION:
             {
-            case PACKET_TYPE_POSITION:
-                {
-                    PositionPacket frame(buf);
-                    CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
-                    if (pEntity)
-                        pEntity->AddPositionFrame(frame);
-                }
-                break;
-            case PACKET_TYPE_DECAL:
-                {
-                    DecalPacket decals(buf);
-                    if (decals.decal_type == DECAL_INVALID)
-                        break;
+                PositionPacket frame(buf);
+                CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
+                if (pEntity)
+                    pEntity->AddPositionFrame(frame);
+            }
+            break;
+        case PACKET_TYPE_DECAL:
+            {
+                DecalPacket decals(buf);
+                if (decals.decal_type == DECAL_INVALID)
+                    break;
 
-                    const auto pEntity = GetLobbyMemberEntity(fromWho);
-                    if (pEntity)
+                const auto pEntity = GetLobbyMemberEntity(fromWho);
+                if (pEntity)
+                {
+                    pEntity->AddDecalFrame(decals);
+                }
+            }
+            break;
+        case PACKET_TYPE_SPEC_UPDATE:
+            {
+                SpecUpdatePacket update(buf);
+                if (update.spec_type == SPEC_UPDATE_INVALID)
+                    break;
+
+                const auto pEntity = GetLobbyMemberEntity(fromWho);
+                if (pEntity)
+                {
+                    pEntity->m_bSpectating = update.specTarget != 0;
+                    update.specTarget != 0 ? pEntity->HideGhost() : pEntity->UnHideGhost();
+                }
+
+                WriteSpecMessage(update.spec_type, fromWho.ConvertToUint64(), update.specTarget);
+            }
+            break;
+        case PACKET_TYPE_SAVELOC_REQ:
+            {
+                SavelocReqPacket saveloc(buf);
+
+                // Done/fail states:
+                // 1. They hit "cancel" (most common)
+                // 2. They leave the map (same as 1, just accidental maybe)
+                // 3. They leave the lobby/server (manually, due to power outage, etc)
+                // 4. We leave the map
+                // 5. We leave the lobby/server
+                // 6. They get the savelocs they need
+
+                // Of the above, 1 and 6 are the ones that are manually sent.
+                // 2<->5 can be automatically detected with lobby/server hooks
+
+                // Fail requirements:
+                // Requester: set "requesting" to false, close the request UI
+                // Requestee: remove requester from requesters vector
+
+                DevLog(2, "Received a stage %i saveloc request packet!\n", saveloc.stage);
+
+                switch (saveloc.stage)
+                {
+                case SAVELOC_REQ_STAGE_COUNT_REQ:
                     {
-                        pEntity->AddDecalFrame(decals);
+                        if (!g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64()))
+                            break;
+
+                        SavelocReqPacket response;
+                        response.stage = SAVELOC_REQ_STAGE_COUNT_ACK;
+                        response.saveloc_count = g_pMOMSavelocSystem->GetSavelocCount();
+
+                        SendPacket(&response, &fromWho, k_EP2PSendReliable);
                     }
-                }
-                break;
-            case PACKET_TYPE_SPEC_UPDATE:
-                {
-                    SpecUpdatePacket update(buf);
-                    if (update.spec_type == SPEC_UPDATE_INVALID)
-                        break;
-
-                    const auto pEntity = GetLobbyMemberEntity(fromWho);
-                    if (pEntity)
+                    break;
+                case SAVELOC_REQ_STAGE_COUNT_ACK:
                     {
-                        pEntity->m_bSpectating = update.specTarget != 0;
-                        update.specTarget != 0 ? pEntity->HideGhost() : pEntity->UnHideGhost();
+                        KeyValues *pKV = new KeyValues("req_savelocs");
+                        pKV->SetInt("stage", SAVELOC_REQ_STAGE_COUNT_ACK);
+                        pKV->SetInt("count", saveloc.saveloc_count);
+                        g_pModuleComms->FireEvent(pKV);
                     }
-
-                    WriteSpecMessage(update.spec_type, fromWho.ConvertToUint64(), update.specTarget);
-                }
-                break;
-            case PACKET_TYPE_SAVELOC_REQ:
-                {
-                    SavelocReqPacket saveloc(buf);
-
-                    // Done/fail states:
-                    // 1. They hit "cancel" (most common)
-                    // 2. They leave the map (same as 1, just accidental maybe)
-                    // 3. They leave the lobby/server (manually, due to power outage, etc)
-                    // 4. We leave the map
-                    // 5. We leave the lobby/server
-                    // 6. They get the savelocs they need
-
-                    // Of the above, 1 and 6 are the ones that are manually sent.
-                    // 2<->5 can be automatically detected with lobby/server hooks
-
-                    // Fail requirements:
-                    // Requester: set "requesting" to false, close the request UI
-                    // Requestee: remove requester from requesters vector
-
-                    DevLog(2, "Received a stage %i saveloc request packet!\n", saveloc.stage);
-
-                    switch (saveloc.stage)
+                    break;
+                case SAVELOC_REQ_STAGE_SAVELOC_REQ:
                     {
-                    case SAVELOC_REQ_STAGE_COUNT_REQ:
-                        {
-                            if (!g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64()))
-                                break;
+                        SavelocReqPacket response;
+                        response.stage = SAVELOC_REQ_STAGE_SAVELOC_ACK;
 
-                            SavelocReqPacket response;
-                            response.stage = SAVELOC_REQ_STAGE_COUNT_ACK;
-                            response.saveloc_count = g_pMOMSavelocSystem->GetSavelocCount();
-
+                        if (g_pMOMSavelocSystem->WriteRequestedSavelocs(&saveloc, &response, fromWho.ConvertToUint64()))
                             SendPacket(&response, &fromWho, k_EP2PSendReliable);
-                        }
-                        break;
-                    case SAVELOC_REQ_STAGE_COUNT_ACK:
-                        {
-                            KeyValues *pKV = new KeyValues("req_savelocs");
-                            pKV->SetInt("stage", SAVELOC_REQ_STAGE_COUNT_ACK);
-                            pKV->SetInt("count", saveloc.saveloc_count);
-                            g_pModuleComms->FireEvent(pKV);
-                        }
-                        break;
-                    case SAVELOC_REQ_STAGE_SAVELOC_REQ:
+                    }
+                    break;
+                case SAVELOC_REQ_STAGE_SAVELOC_ACK:
+                    {
+                        if (g_pMOMSavelocSystem->ReadReceivedSavelocs(&saveloc, fromWho.ConvertToUint64()))
                         {
                             SavelocReqPacket response;
-                            response.stage = SAVELOC_REQ_STAGE_SAVELOC_ACK;
-
-                            if (g_pMOMSavelocSystem->WriteRequestedSavelocs(&saveloc, &response, fromWho.ConvertToUint64()))
-                                SendPacket(&response, &fromWho, k_EP2PSendReliable);
-                        }
-                        break;
-                    case SAVELOC_REQ_STAGE_SAVELOC_ACK:
-                        {
-                            // We got their savelocs, add it to the player's list of savelocs
-                            if (g_pMOMSavelocSystem->ReadReceivedSavelocs(&saveloc, fromWho.ConvertToUint64()))
+                            response.stage = SAVELOC_REQ_STAGE_DONE;
+                            if (SendPacket(&response, &fromWho, k_EP2PSendReliable))
                             {
-                                // Send them a packet that we're all good
-                                SavelocReqPacket response;
-                                response.stage = SAVELOC_REQ_STAGE_DONE;
-                                if (SendPacket(&response, &fromWho, k_EP2PSendReliable))
-                                {
-                                    // Send ourselves an event saying we're all good
-                                    KeyValues *pKv = new KeyValues("req_savelocs");
-                                    pKv->SetInt("stage", SAVELOC_REQ_STAGE_DONE);
-                                    g_pModuleComms->FireEvent(pKv);
-                                }
+                                KeyValues *pKv = new KeyValues("req_savelocs");
+                                pKv->SetInt("stage", SAVELOC_REQ_STAGE_DONE);
+                                g_pModuleComms->FireEvent(pKv);
                             }
                         }
-                        break;
-                    case SAVELOC_REQ_STAGE_DONE:
-                        {
-                            g_pMOMSavelocSystem->RequesterLeft(fromWho.ConvertToUint64());
-                        }
-                        break;
-                    case SAVELOC_REQ_STAGE_INVALID:
-                    default:
-                        DevWarning(2, "Invalid stage for the saveloc request packet!\n");
-                        break;
                     }
+                    break;
+                case SAVELOC_REQ_STAGE_DONE:
+                    {
+                        g_pMOMSavelocSystem->RequesterLeft(fromWho.ConvertToUint64());
+                    }
+                    break;
+                case SAVELOC_REQ_STAGE_INVALID:
+                default:
+                    DevWarning(2, "Invalid stage for the saveloc request packet!\n");
+                    break;
                 }
-                break;
-            default:
-                break;
             }
-
-            // Clear the buffer and free the memory
-            buf.Purge();
-            delete[] bytes;
+            break;
+        default:
+            break;
         }
 
-        // Send position data
-        if (m_flNextUpdateTime > 0.0f && gpGlobals->curtime > m_flNextUpdateTime)
+        buf.Purge();
+        delete[] bytes;
+    }
+
+    if (m_flNextUpdateTime > 0.0f && gpGlobals->curtime > m_flNextUpdateTime)
+    {
+        PositionPacket frame;
+        if (g_pMomentumGhostClient->CreateNewNetFrame(frame) && SendPacket(&frame))
         {
-            PositionPacket frame;
-            if (g_pMomentumGhostClient->CreateNewNetFrame(frame) && SendPacket(&frame))
-            {
-                m_flNextUpdateTime = gpGlobals->curtime + (1.0f / mm_updaterate.GetFloat());
-            }
+            m_flNextUpdateTime = gpGlobals->curtime + (1.0f / mm_updaterate.GetFloat());
         }
     }
 }

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -765,7 +765,8 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                     {
                     case SAVELOC_REQ_STAGE_COUNT_REQ:
                         {
-                            g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64());
+                            if (!g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64()))
+                                break;
 
                             SavelocReqPacket response;
                             response.stage = SAVELOC_REQ_STAGE_COUNT_ACK;

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -787,14 +787,14 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                             SavelocReqPacket response;
                             response.stage = SAVELOC_REQ_STAGE_SAVELOC_ACK;
 
-                            if (g_pMOMSavelocSystem->FillSavelocReq(true, &saveloc, &response))
+                            if (g_pMOMSavelocSystem->WriteRequestedSavelocs(&saveloc, &response, fromWho.ConvertToUint64()))
                                 SendPacket(&response, &fromWho, k_EP2PSendReliable);
                         }
                         break;
                     case SAVELOC_REQ_STAGE_SAVELOC_ACK:
                         {
                             // We got their savelocs, add it to the player's list of savelocs
-                            if (g_pMOMSavelocSystem->FillSavelocReq(false, &saveloc, nullptr))
+                            if (g_pMOMSavelocSystem->ReadReceivedSavelocs(&saveloc, fromWho.ConvertToUint64()))
                             {
                                 // Send them a packet that we're all good
                                 SavelocReqPacket response;

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -714,7 +714,10 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
             case PACKET_TYPE_DECAL:
                 {
                     DecalPacket decals(buf);
-                    CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
+                    if (decals.decal_type == DECAL_INVALID)
+                        break;
+
+                    const auto pEntity = GetLobbyMemberEntity(fromWho);
                     if (pEntity)
                     {
                         pEntity->AddDecalFrame(decals);
@@ -727,7 +730,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                     if (update.spec_type == SPEC_UPDATE_INVALID)
                         break;
 
-                    CMomentumOnlineGhostEntity *pEntity = GetLobbyMemberEntity(fromWho);
+                    const auto pEntity = GetLobbyMemberEntity(fromWho);
                     if (pEntity)
                     {
                         pEntity->m_bSpectating = update.specTarget != 0;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -215,13 +215,13 @@ void CMOMSaveLocSystem::LevelShutdownPreEntity()
 
 void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
 {
-    int stage = pKv->GetInt("stage");
+    int stage = pKv->GetInt("stage", SAVELOC_REQ_STAGE_INVALID);
     CSteamID target(pKv->GetUint64("target"));
-    if (stage == 1)
+    if (stage == SAVELOC_REQ_STAGE_COUNT_REQ)
     {
         // They clicked "request savelocs" from a player, UI just opened, get the count to send back
         SavelocReqPacket packet;
-        packet.stage = 1;
+        packet.stage = SAVELOC_REQ_STAGE_COUNT_REQ;
         if (g_pMomentumGhostClient->SendSavelocReqPacket(target, &packet))
         {
             // Also keep track of this in the saveloc system
@@ -229,23 +229,21 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
         }
 
     }
-    else if (stage == 3)
+    else if (stage == SAVELOC_REQ_STAGE_SAVELOC_REQ)
     {
-        // They clicked on the # of savelocs to request, build a request packet and get these bad boys
         SavelocReqPacket packet;
-        packet.stage = 3;
+        packet.stage = SAVELOC_REQ_STAGE_SAVELOC_REQ;
         packet.saveloc_count = pKv->GetInt("count");
         packet.dataBuf.CopyBuffer(pKv->GetPtr("nums"), sizeof(int) * packet.saveloc_count);
         g_pMomentumGhostClient->SendSavelocReqPacket(target, &packet);
     }
-    else if (stage == -3)
+    else if (stage == SAVELOC_REQ_STAGE_CLICKED_CANCEL)
     {
-        // The player clicked cancel
         SetRequestingSavelocsFrom(0);
 
         // Let our requestee know
         SavelocReqPacket packet;
-        packet.stage = -1;
+        packet.stage = SAVELOC_REQ_STAGE_DONE;
         g_pMomentumGhostClient->SendSavelocReqPacket(target, &packet);
     }
 }
@@ -261,9 +259,9 @@ void CMOMSaveLocSystem::RequesterLeft(const uint64& requester)
     // The person we are requesting savelocs from just left
     if (requester == m_iRequesting)
     {
-        // Fire event for client, 
+        // Fire event for client
         KeyValues *pKv = new KeyValues("req_savelocs");
-        pKv->SetInt("stage", -2);
+        pKv->SetInt("stage", SAVELOC_REQ_STAGE_REQUESTER_LEFT);
         g_pModuleComms->FireEvent(pKv);
 
         m_iRequesting = 0;
@@ -482,7 +480,7 @@ void CMOMSaveLocSystem::UpdateRequesters()
 
     // Send them our saveloc count
     SavelocReqPacket response;
-    response.stage = 2;
+    response.stage = SAVELOC_REQ_STAGE_COUNT_ACK;
     response.saveloc_count = m_rcSavelocs.Count();
 
     FOR_EACH_VEC(m_vecRequesters, i)

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -89,20 +89,23 @@ void SavedLocation_t::Teleport(CMomentumPlayer* pPlayer)
     g_EventQueue.RestoreForTarget(pPlayer, entEventsState);
 }
 
-void SavedLocation_t::Read(CUtlBuffer& mem)
+bool SavedLocation_t::Read(CUtlBuffer &mem)
 {
-    KeyValues *read = new KeyValues("From Someone");
-    read->ReadAsBinary(mem);
-    Load(read);
-    read->deleteThis();
+    KeyValuesAD read("From Someone");
+    if (read->ReadAsBinary(mem))
+    {
+        Load(read);
+        return true;
+    }
+
+    return false;
 }
 
-void SavedLocation_t::Write(CUtlBuffer& mem)
+bool SavedLocation_t::Write(CUtlBuffer &mem)
 {
-    KeyValues *test = new KeyValues("To Someone");
-    Save(test);
-    test->WriteAsBinary(mem);
-    test->deleteThis();
+    KeyValuesAD write("To Someone");
+    Save(write);
+    return write->WriteAsBinary(mem);
 }
 
 CMOMSaveLocSystem::CMOMSaveLocSystem(const char* pName): CAutoGameSystem(pName)
@@ -248,10 +251,13 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
     }
 }
 
-void CMOMSaveLocSystem::AddSavelocRequester(const uint64& newReq)
+bool CMOMSaveLocSystem::AddSavelocRequester(const uint64& newReq)
 {
-    if (!m_vecRequesters.HasElement(newReq))
-        m_vecRequesters.AddToTail(newReq);
+    if (m_vecRequesters.HasElement(newReq))
+        return false;
+
+    m_vecRequesters.AddToTail(newReq);
+    return true;
 }
 
 void CMOMSaveLocSystem::RequesterLeft(const uint64& requester)

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -288,50 +288,64 @@ void CMOMSaveLocSystem::SetRequestingSavelocsFrom(const uint64& from)
     m_iRequesting = from;
 }
 
-bool CMOMSaveLocSystem::FillSavelocReq(const bool sending, SavelocReqPacket *input, SavelocReqPacket *outputBuf)
+bool CMOMSaveLocSystem::WriteRequestedSavelocs(SavelocReqPacket *input, SavelocReqPacket *output, const uint64 &requester)
 {
-    if (sending)
+    if (!m_vecRequesters.HasElement(requester))
+        return false;
+
+    int count = 0;
+    for (int i = 0; i < input->saveloc_count && input->dataBuf.IsValid(); i++)
     {
-        int count = 0;
-        // Go through each requested saveloc and copy the binary into outputBuf
-        for (int i = 0; i < input->saveloc_count; i++)
+        const auto requestedIndex = input->dataBuf.GetInt();
+
+        const auto savedLoc = GetSaveloc(requestedIndex);
+        if (savedLoc)
         {
-            int requested = input->dataBuf.GetInt();
+            if (!savedLoc->Write(output->dataBuf))
+                return false;
 
-            SavedLocation_t *savedLoc = GetSaveloc(requested);
-            if (savedLoc)
-            {
-                savedLoc->Write(outputBuf->dataBuf);
-                count++;
-            }
-        }
-
-        if (!count) // If we didn't have any savelocs to give, get outta here
-            return false;
-
-        // We set the count here because we may have a different number of savelocs than requested
-        // (eg. when we delete some savelocs while the packet to request the original amount/indicies is still live)
-        outputBuf->saveloc_count = count;
-    }
-    else // receiving savelocs
-    {
-        // They gave us their savelocs, read them and add them to the player
-        if (input->saveloc_count)
-        {
-            for (int i = 0; i < input->saveloc_count; i++)
-            {
-                // Memory managed by the player, when they exit the level
-                SavedLocation_t *newSavedLoc = new SavedLocation_t;
-                newSavedLoc->Read(input->dataBuf);
-                m_rcSavelocs.AddToTail(newSavedLoc);
-            }
-
-            FireUpdateEvent();
-            UpdateRequesters();
+            count++;
         }
     }
+
+    if (count == 0)
+        return false;
+
+    // We set the count here because we may have a different number of savelocs than requested
+    // (eg. when we delete some savelocs while the packet to request the original amount/indicies is still live)
+    output->saveloc_count = count;
 
     return true;
+}
+
+bool CMOMSaveLocSystem::ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender)
+{
+    if (sender != m_iRequesting)
+        return false;
+
+    if (input->saveloc_count > 0)
+    {
+        for (int i = 0; i < input->saveloc_count && input->dataBuf.IsValid(); i++)
+        {
+            auto newSavedLoc = new SavedLocation_t;
+            if (newSavedLoc->Read(input->dataBuf))
+            {
+                m_rcSavelocs.AddToTail(newSavedLoc);
+            }
+            else
+            {
+                delete newSavedLoc;
+                return false;
+            }
+        }
+
+        FireUpdateEvent();
+        UpdateRequesters();
+
+        return true;
+    }
+
+    return false;
 }
 
 SavedLocation_t* CMOMSaveLocSystem::CreateSaveloc()

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -32,8 +32,8 @@ struct SavedLocation_t
     // Called when the player wants to teleport to this checkpoint 
     void Teleport(CMomentumPlayer* pPlayer);
 
-    void Read(CUtlBuffer &mem);
-    void Write(CUtlBuffer &mem);
+    bool Read(CUtlBuffer &mem);
+    bool Write(CUtlBuffer &mem);
 };
 
 class CMOMSaveLocSystem : public CAutoGameSystem
@@ -49,7 +49,7 @@ public:
     // Called when the UI wants to request savelocs
     void OnSavelocRequestEvent(KeyValues *pKv);
     // Called when somebody requests our savelocs, keep track of them
-    void AddSavelocRequester(const uint64 &newReq);
+    bool AddSavelocRequester(const uint64 &newReq);
     // Called when a potential requester leaves the lobby/map
     void RequesterLeft(const uint64 &requester);
     // Called when we are requesting savelocs from someone

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -54,10 +54,10 @@ public:
     void RequesterLeft(const uint64 &requester);
     // Called when we are requesting savelocs from someone
     void SetRequestingSavelocsFrom(const uint64 &from);
-    // Called when a saveloc request is completed.
-    // When sending (our savelocs to them), input = the nums, output = binary savelocs
-    // When !sending (recv savelocs from them), input = the savelocs, output = not needed
-    bool FillSavelocReq(bool sending, SavelocReqPacket *input, SavelocReqPacket *outputBuf);
+    uint64 GetRequestingSavelocsFrom() const { return m_iRequesting; }
+
+    bool WriteRequestedSavelocs(SavelocReqPacket *input, SavelocReqPacket *output, const uint64 &requester);
+    bool ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender);
 
     // Local
     // Gets the current menu Saveloc index

--- a/mp/src/game/shared/baseentity_shared.cpp
+++ b/mp/src/game/shared/baseentity_shared.cpp
@@ -19,6 +19,7 @@
 #include "debugoverlay_shared.h"
 #include "coordsize.h"
 #include "vphysics/performance.h"
+#include "movevars_shared.h"
 
 #ifdef CLIENT_DLL
 	#include "c_te_effect_dispatch.h"
@@ -66,9 +67,8 @@ ConVar hl2_episodic( "hl2_episodic", "0", FCVAR_REPLICATED );
 
 bool CBaseEntity::m_bAllowPrecache = false;
 
-// Set default max values for entities based on the existing constants from elsewhere
-float k_flMaxEntityPosCoord = MAX_COORD_FLOAT;
 float k_flMaxEntityEulerAngle = 360.0 * 1000.0f; // really should be restricted to +/-180, but some code doesn't adhere to this.  let's just trap NANs, etc
+
 // Sometimes the resulting computed speeds are legitimately above the original
 // constants; use bumped up versions for the downstream validation logic to
 // account for this.
@@ -1107,6 +1107,25 @@ int	CBaseEntity::GetNextThinkTick( int nContextIndex ) const
 	return m_aThinkFunctions[nContextIndex].m_nNextThinkTick; 
 }
 
+bool IsEntityCoordinateReasonable(const vec_t coord)
+{
+    return coord > -MAX_COORD_FLOAT && coord < MAX_COORD_FLOAT;
+}
+
+bool IsEntityPositionReasonable(const Vector &pos)
+{
+    Vector posAbs;
+    VectorAbs(pos, posAbs);
+    return posAbs.x < MAX_COORD_FLOAT && posAbs.y < MAX_COORD_FLOAT && posAbs.z < MAX_COORD_FLOAT;
+}
+
+bool IsEntityVelocityReasonable(const Vector &vel)
+{
+    const float max = sv_maxvelocity.GetFloat();
+    Vector velAbs;
+    VectorAbs(vel, velAbs);
+    return velAbs.x < max && velAbs.y < max && velAbs.z < max;
+}
 
 int CheckEntityVelocity( Vector &v )
 {

--- a/mp/src/game/shared/baseentity_shared.h
+++ b/mp/src/game/shared/baseentity_shared.h
@@ -254,31 +254,19 @@ inline bool CBaseEntity::IsEffectActive( int nEffects ) const
 // Shared EntityMessage between game and client .dlls
 #define BASEENTITY_MSG_REMOVE_DECALS	1
 
-extern float k_flMaxEntityPosCoord;
 extern float k_flMaxEntityEulerAngle;
 extern float k_flMaxEntitySpeed;
 extern float k_flMaxEntitySpinRate;
 
-inline bool IsEntityCoordinateReasonable ( const vec_t c )
-{
-	float r = k_flMaxEntityPosCoord;
-	return c > -r && c < r;
-}
-
-inline bool IsEntityPositionReasonable( const Vector &v )
-{
-	float r = k_flMaxEntityPosCoord;
-	return
-		v.x > -r && v.x < r &&
-		v.y > -r && v.y < r &&
-		v.z > -r && v.z < r;
-}
+bool IsEntityCoordinateReasonable(const vec_t coord);
+bool IsEntityPositionReasonable(const Vector &pos);
+bool IsEntityVelocityReasonable(const Vector &vel);
 
 // Returns:
 //   -1 - velocity is really, REALLY bad and probably should be rejected.
 //   0  - velocity was suspicious and clamped.
 //   1  - velocity was OK and not modified
-extern int CheckEntityVelocity( Vector &v );
+int CheckEntityVelocity( Vector &v );
 
 inline bool IsEntityQAngleReasonable( const QAngle &q )
 {

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -93,10 +93,15 @@ public:
 
         Buttons = buttons;
         ViewOffset = viewOffsetZ;
+
+        Validate();
     }
 
     PositionPacket(): Buttons(0), ViewOffset(0)
     {
+        EyeAngle.Init();
+        Position.Init();
+        Velocity.Init();
     }
 
     PositionPacket(CUtlBuffer &buf)
@@ -106,6 +111,8 @@ public:
         buf.Get(&Velocity, sizeof(Vector));
         Buttons = buf.GetInt();
         ViewOffset = buf.GetFloat();
+
+        Validate();
     }
 
     PacketType GetType() const OVERRIDE { return PACKET_TYPE_POSITION; }
@@ -120,6 +127,20 @@ public:
         buf.PutFloat(ViewOffset);
     }
 
+    void Validate()
+    {
+        if (!EyeAngle.IsValid() || !IsEntityQAngleReasonable(EyeAngle))
+            EyeAngle = vec3_angle;
+
+        if (!Position.IsValid() || !IsEntityPositionReasonable(Position))
+            Position = vec3_origin;
+
+        if (!Velocity.IsValid() || !IsEntityVelocityReasonable(Velocity))
+            Velocity = vec3_origin;
+
+        ViewOffset = Clamp(ViewOffset, VEC_DUCK_VIEW.z, VEC_VIEW.z);
+    }
+
     PositionPacket& operator=(const PositionPacket &other)
     {
         Buttons = other.Buttons;
@@ -127,6 +148,7 @@ public:
         EyeAngle = other.EyeAngle;
         Position = other.Position;
         Velocity = other.Velocity;
+        Validate();
         return *this;
     }
 

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -193,7 +193,12 @@ class SpecUpdatePacket : public MomentumPacket
     SpecUpdatePacket(CUtlBuffer &buf)
     {
         specTarget = static_cast<uint64>(buf.GetInt64());
-        spec_type = static_cast<SpectateMessageType_t>(buf.GetInt());
+
+        auto iSpecType = buf.GetInt();
+        if (iSpecType < SPEC_UPDATE_FIRST || iSpecType > SPEC_UPDATE_LAST)
+            iSpecType = SPEC_UPDATE_INVALID;
+
+        spec_type = static_cast<SpectateMessageType_t>(iSpecType);
     }
 
     PacketType GetType() const OVERRIDE { return PACKET_TYPE_SPEC_UPDATE; }

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -5,21 +5,12 @@
 
 enum PacketType
 {
-    PT_CONN_REQ = 0,
-    PT_CONN_ACK,
-    PT_APPR_DATA,
-    PT_APPR_ACK,
-    PT_POS_DATA,
-    PT_POS_ACK,
-    PT_CHAT_DATA,
-    PT_MAP_CHANGE,
-    PT_DISC_REQ,
+    PACKET_TYPE_POSITION = 0,
+    PACKET_TYPE_DECAL,
+    PACKET_TYPE_SPEC_UPDATE,
+    PACKET_TYPE_SAVELOC_REQ,
 
-    PT_DECAL_DATA,
-    PT_SPEC_UPDATE,
-    PT_SAVELOC_REQ,
-
-    PT_COUNT
+    PACKET_TYPE_COUNT
 };
 
 #define APPEARANCE_BODYGROUP_MIN 0
@@ -87,12 +78,13 @@ class MomentumPacket
 // Based on CReplayFrame, describes data needed for ghost's physical properties 
 class PositionPacket : public MomentumPacket
 {
-  public:
+public:
     int Buttons;
     float ViewOffset;
     QAngle EyeAngle;
     Vector Position;
     Vector Velocity;
+
     PositionPacket(const QAngle eyeAngle, const Vector position, const Vector velocity, const float viewOffsetZ, const int buttons)
     {
         EyeAngle = eyeAngle;
@@ -106,6 +98,7 @@ class PositionPacket : public MomentumPacket
     PositionPacket(): Buttons(0), ViewOffset(0)
     {
     }
+
     PositionPacket(CUtlBuffer &buf)
     {
         buf.Get(&EyeAngle, sizeof(QAngle));
@@ -115,7 +108,7 @@ class PositionPacket : public MomentumPacket
         ViewOffset = buf.GetFloat();
     }
 
-    PacketType GetType() const OVERRIDE { return PT_POS_DATA; }
+    PacketType GetType() const OVERRIDE { return PACKET_TYPE_POSITION; }
 
     void Write(CUtlBuffer& buf) OVERRIDE
     {
@@ -181,7 +174,7 @@ class SpecUpdatePacket : public MomentumPacket
         spec_type = static_cast<SpectateMessageType_t>(buf.GetInt());
     }
 
-    PacketType GetType() const OVERRIDE { return PT_SPEC_UPDATE; }
+    PacketType GetType() const OVERRIDE { return PACKET_TYPE_SPEC_UPDATE; }
 
     void Write(CUtlBuffer& buf) OVERRIDE
     {
@@ -294,7 +287,7 @@ class DecalPacket : public MomentumPacket
         return *this;
     }
 
-    PacketType GetType() const OVERRIDE { return PT_DECAL_DATA; }
+    PacketType GetType() const OVERRIDE { return PACKET_TYPE_DECAL; }
 
     void Write(CUtlBuffer& buf) OVERRIDE
     {
@@ -340,7 +333,7 @@ class SavelocReqPacket : public MomentumPacket
         }
     }
 
-    PacketType GetType() const OVERRIDE { return PT_SAVELOC_REQ; }
+    PacketType GetType() const OVERRIDE { return PACKET_TYPE_SAVELOC_REQ; }
 
     void Write(CUtlBuffer& buf) OVERRIDE
     {

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -386,6 +386,10 @@ class SavelocReqPacket : public MomentumPacket
     SavelocReqPacket(CUtlBuffer &buf)
     {
         stage = buf.GetInt();
+
+        if (stage < SAVELOC_REQ_STAGE_FIRST || stage > SAVELOC_REQ_STAGE_LAST)
+            stage = SAVELOC_REQ_STAGE_INVALID;
+
         if (stage > SAVELOC_REQ_STAGE_COUNT_REQ)
         {
             saveloc_count = buf.GetInt();
@@ -393,6 +397,7 @@ class SavelocReqPacket : public MomentumPacket
             if (stage > SAVELOC_REQ_STAGE_COUNT_ACK && buf.IsValid())
             {
                 dataBuf.Clear();
+                dataBuf.SetBigEndian(false);
                 dataBuf.Put(buf.PeekGet(), buf.GetBytesRemaining());
             }
         }

--- a/mp/src/game/shared/momentum/mom_shareddefs.h
+++ b/mp/src/game/shared/momentum/mom_shareddefs.h
@@ -182,7 +182,11 @@ enum SpectateMessageType_t
     SPEC_UPDATE_JOIN = 0,           // Started spectating
     SPEC_UPDATE_CHANGETARGET,    // Is now spectating someone else
     SPEC_UPDATE_STOP,           // Stopped spectating; respawned
-    SPEC_UPDATE_LEAVE       // This player left the map/lobby
+    SPEC_UPDATE_LEAVE,       // This player left the map/lobby
+
+    SPEC_UPDATE_FIRST = SPEC_UPDATE_JOIN,
+    SPEC_UPDATE_LAST = SPEC_UPDATE_LEAVE,
+    SPEC_UPDATE_INVALID = -1,
 };
 
 #define PANEL_TIMES "times"


### PR DESCRIPTION
Closes #462 

This PR is the second half that #525 started. This PR validates the packets used in online lobbies to help prevent garbage data from causing unforeseen consequences. For example, the saveloc request flow was actually pretty insecure as people can be added multiple times as requesters, and stages sent out of order would be obeyed and potentially cause crashes/undefined behavior. Every packet has its core data validated to be reasonable, and clamps values to invalid/default values to be properly rejected by the code. Code will never be 100% fool proof, but this is much better than it was.

As for spam prevention, Steam handles it for the most part, but could be a valid concern. Spam can be counteracted by changing the privacy settings for lobbies, though it will get properly revisited when we tackle #258 .

Needs proper testing before merge.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->