### PR TITLE
Fix crash on resolution change with momentum settings panel open

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
@@ -217,6 +217,13 @@ void AppearanceSettingsPage::ApplySchemeSettings(IScheme* pScheme)
     SetButtonColors();
 }
 
+void AppearanceSettingsPage::OnScreenSizeChanged(int oldwide, int oldtall)
+{
+    BaseClass::OnScreenSizeChanged(oldwide, oldtall);
+
+    DestroyModelPanel();
+}
+
 void AppearanceSettingsPage::UpdateModelSettings()
 {
     MDLCACHE_CRITICAL_SECTION();
@@ -233,4 +240,15 @@ void AppearanceSettingsPage::UpdateModelSettings()
     
     // Player shape
     pModel->SetBodygroup(1, ghost_bodygroup.GetInt());
+}
+
+void AppearanceSettingsPage::DestroyModelPanel()
+{
+    if (m_pModelPreviewFrame)
+    {
+        m_pModelPreviewFrame->DeletePanel();
+    }
+
+    m_pModelPreviewFrame = nullptr;
+    m_pModelPreview = nullptr;
 }

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
@@ -28,10 +28,11 @@ class AppearanceSettingsPage : public SettingsPage
     MESSAGE_FUNC_PARAMS(OnColorSelected, "ColorSelected", pKv);
     void OnCommand(const char* command) OVERRIDE;
     void ApplySchemeSettings(vgui::IScheme* pScheme) OVERRIDE;
+    void OnScreenSizeChanged(int oldwide, int oldtall) override;
 
 private:
     void UpdateModelSettings();
-
+    void DestroyModelPanel();
 
     vgui::Frame *m_pModelPreviewFrame;
     CRenderPanel *m_pModelPreview;

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -165,6 +165,13 @@ void ComparisonsSettingsPage::OnApplyChanges()
     }
 }
 
+void ComparisonsSettingsPage::OnScreenSizeChanged(int oldwide, int oldtall)
+{
+    BaseClass::OnScreenSizeChanged(oldwide, oldtall);
+
+    DestroyBogusComparePanel();
+}
+
 void ComparisonsSettingsPage::LoadSettings()
 {
     if (m_pMaxZones)

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
@@ -23,6 +23,8 @@ class ComparisonsSettingsPage : public SettingsPage
     //Handle custom controls
     void OnApplyChanges() OVERRIDE;
 
+    void OnScreenSizeChanged(int oldwide, int oldtall) override;
+
     //Load the settings for this panel
     void LoadSettings() OVERRIDE;
     void OnPageShow() OVERRIDE;

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -38,6 +38,7 @@ CRenderPanel::CRenderPanel(Panel *parent, const char *pElementName) : BaseClass(
 
 CRenderPanel::~CRenderPanel()
 {
+    DestroyModel();
 }
 
 void CRenderPanel::UpdateRenderPosition()


### PR DESCRIPTION
Closes #527 

Resources weren't properly being disposed of due to the panel getting completely destroyed and recreated on resolution change, so the pinned-sibling frames used to show the preview of your model/comparisons were not properly disposed of, and tried to pin to a panel that was destroyed. This PR disposes of these frames on resolution change, and *not the destructor due to the panels actually getting cleaned up when the game is shutting down*, getting rid of the crash.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->