### PR TITLE
Move zone files to zones-folder

### DIFF
--- a/mp/src/creategameprojects.ps1
+++ b/mp/src/creategameprojects.ps1
@@ -8,7 +8,7 @@ if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference= 'silentlycontinue'
 # This is the path to your steamworks dev folder (depo). This should be the folder with hl2.exe inside of it.
 # Your local momentum folder will be sym linked INSIDE this folder as momentum
-$path = "C:\Users\eelih\Documents\Koodit\Momentum\MomentumDev"
+$path = "E:\Steamworks\dev\Momentum"
 
 # Boot arguments
 $hl2exe = Join-Path $path hl2.exe 

--- a/mp/src/creategameprojects.ps1
+++ b/mp/src/creategameprojects.ps1
@@ -8,7 +8,7 @@ if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference= 'silentlycontinue'
 # This is the path to your steamworks dev folder (depo). This should be the folder with hl2.exe inside of it.
 # Your local momentum folder will be sym linked INSIDE this folder as momentum
-$path = "E:\Steamworks\dev\Momentum"
+$path = "C:\Users\eelih\Documents\Koodit\Momentum\MomentumDev"
 
 # Boot arguments
 $hl2exe = Join-Path $path hl2.exe 

--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -117,6 +117,12 @@ void CMapZoneSystem::FrameUpdatePostEntityThink()
     m_Editor.FrameUpdate();
 }
 
+void PostInit()
+{
+    // Creates a folder for zonefiles if it doesn't exist yet
+    filesystem->CreateDirHierarchy(ZONE_FOLDER, "MOD");
+}
+
 bool CMapZoneSystem::ZoneTypeToClass(int type, char *dest, int maxlen)
 {
     switch (type)

--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -117,7 +117,7 @@ void CMapZoneSystem::FrameUpdatePostEntityThink()
     m_Editor.FrameUpdate();
 }
 
-void PostInit()
+void CMapZoneSystem::PostInit()
 {
     // Creates a folder for zonefiles if it doesn't exist yet
     filesystem->CreateDirHierarchy(ZONE_FOLDER, "MOD");

--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -119,7 +119,6 @@ void CMapZoneSystem::FrameUpdatePostEntityThink()
 
 void CMapZoneSystem::PostInit()
 {
-    // Creates a folder for zonefiles if it doesn't exist yet
     filesystem->CreateDirHierarchy(ZONE_FOLDER, "MOD");
 }
 

--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -161,7 +161,7 @@ void CMapZoneSystem::LoadZonesFromFile()
 {
     m_bLoadedFromSite = false;
     char zoneFilePath[MAX_PATH];
-    V_ComposeFileName(MAP_FOLDER, gpGlobals->mapname.ToCStr(), zoneFilePath, MAX_PATH);
+    V_ComposeFileName(ZONE_FOLDER, gpGlobals->mapname.ToCStr(), zoneFilePath, MAX_PATH);
     V_SetExtension(zoneFilePath, EXT_ZONE_FILE, MAX_PATH);
     DevLog("Looking for zone file: %s \n", zoneFilePath);
 
@@ -417,7 +417,7 @@ void CMapZoneSystem::SaveZonesToFile()
         if (!zoneKV->IsEmpty() && gpGlobals->mapname.ToCStr())
         {
             char zoneFilePath[MAX_PATH];
-            V_ComposeFileName(MAP_FOLDER, gpGlobals->mapname.ToCStr(), zoneFilePath, MAX_PATH);
+            V_ComposeFileName(ZONE_FOLDER, gpGlobals->mapname.ToCStr(), zoneFilePath, MAX_PATH);
             V_SetExtension(zoneFilePath, EXT_ZONE_FILE, MAX_PATH);
             zoneKV->SaveToFile(filesystem, zoneFilePath, "MOD");
         }

--- a/mp/src/game/server/momentum/mapzones.h
+++ b/mp/src/game/server/momentum/mapzones.h
@@ -17,6 +17,8 @@ public:
     void LevelShutdownPostEntity() OVERRIDE;
     void FrameUpdatePostEntityThink() OVERRIDE;
 
+    void PostInit() OVERRIDE;
+
     bool ZoneTypeToClass(int type, char *dest, int maxlen);
 
     void ClearMapZones();

--- a/mp/src/game/shared/momentum/mom_shareddefs.h
+++ b/mp/src/game/shared/momentum/mom_shareddefs.h
@@ -262,6 +262,7 @@ enum SpectateMessageType_t
 #define CHECK_STEAM_API(steam_interface) ____CHECK_STEAM_API(steam_interface, return)
 
 #define MAP_FOLDER "maps"
+#define ZONE_FOLDER "zones"
 #define RECORDING_PATH "replays"
 #define RECORDING_ONLINE_PATH "online"
 #define EXT_ZONE_FILE ".zon"


### PR DESCRIPTION
Closes #447

Saves and loads .zon files from zones/ rather than maps/. Problem: won't work if zones-folder doesn't exists.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->