### PR TITLE
Introduce sv_edge_fix (off by default)

### DIFF
--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -77,9 +77,18 @@ class C_MomentumPlayer : public C_BasePlayer, public CMomRunEntity
     // Ladder stuff
     float GetGrabbableLadderTime() const { return m_flGrabbableLadderTime; }
     void SetGrabbableLadderTime(float new_time) { m_flGrabbableLadderTime = new_time; }
+
+    // Last collision
+    void SetLastCollision(const trace_t &tr);
+    int GetLastCollisionTick() const { return m_iLastCollisionTick; }
+    trace_t& GetLastCollisionTrace() { return m_trLastCollisionTrace; }
   private:
     // Ladder stuff
     float m_flGrabbableLadderTime;
+
+    // Last collision
+    int m_iLastCollisionTick; // Tick at which the player last collided with a non-vertical surface
+    trace_t m_trLastCollisionTrace; // (startpos and endpos raised up to player head for ceilings)
 
     float m_flStamina;
 

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -232,6 +232,11 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     float GetGrabbableLadderTime() const { return m_flGrabbableLadderTime; }
     void SetGrabbableLadderTime(float new_time) { m_flGrabbableLadderTime = new_time; }
 
+    // Last collision
+    void SetLastCollision(const trace_t &tr);
+    int GetLastCollisionTick() const { return m_iLastCollisionTick; }
+    trace_t& GetLastCollisionTrace() { return m_trLastCollisionTrace; }
+
     void SetLastEyeAngles(const QAngle &ang) { m_qangLastAngle = ang; }
     const QAngle &LastEyeAngles() const { return m_qangLastAngle; }
 
@@ -292,6 +297,10 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     // Ladder stuff
     float m_flGrabbableLadderTime;
+
+    // Last collision
+    int m_iLastCollisionTick; // Tick at which the player last collided with a non-vertical surface
+    trace_t m_trLastCollisionTrace; // (startpos and endpos raised up to player head for ceilings)
 
     // Trigger stuff
     CUtlVector<CTriggerOnehop*> m_vecOnehops;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1452,8 +1452,22 @@ void CMomentumGameMovement::FullWalkMove()
                 mv->SetAbsOrigin(vecNewOrigin);
         }
 
+        bool bInAirBefore = player->GetGroundEntity() == nullptr;
+
         // Set final flags.
         CategorizePosition();
+
+        bool bInAirAfter = player->GetGroundEntity() == nullptr;
+
+        // Let player bhop after an edgebug
+        trace_t &tr = m_pPlayer->GetLastCollisionTrace();
+        if (sv_edge_fix.GetBool() && !m_pPlayer->m_CurrentSlideTrigger &&
+            bInAirBefore && bInAirAfter && m_pPlayer->GetLastCollisionTick() == gpGlobals->tickcount && // Player edgebugged
+            (m_pPlayer->HasAutoBhop() && (mv->m_nButtons & IN_JUMP)) && // Player wants to bhop
+            tr.plane.normal.z >= 0.7f && mv->m_vecVelocity.z <= NON_JUMP_VELOCITY) // Player can jump on what they edgebugged on
+        {
+            SetGroundEntity(&tr); // Allows the player to jump next tick
+        }
 
         // Make sure velocity is valid.
         CheckVelocity();

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1924,6 +1924,8 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
         //  for contact
         // Add it if it's not already in the list!!!
         MoveHelper()->AddToTouched(pm, mv->m_vecVelocity);
+        if (!CloseEnough(pm.plane.normal[2], 0.0f)) // Filter out staight walls
+            m_pPlayer->SetLastCollision(pm);
 
         // If the plane we hit has a high z component in the normal, then
         //  it's probably a floor
@@ -2121,6 +2123,9 @@ void CMomentumGameMovement::SetGroundEntity(trace_t *pm)
 #endif
 
     BaseClass::SetGroundEntity(pm);
+
+    if (pm && pm->m_pEnt) // if (newGround)
+        m_pPlayer->SetLastCollision(*pm);
 
 #ifdef GAME_DLL
     // Doing this after the BaseClass call in case OnLand wants to use the new ground stuffs

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1244,7 +1244,7 @@ void CMomentumGameMovement::CategorizePosition()
                 Vector vecNextVelocity = mv->m_vecVelocity;
 
                 // Apply half of gravity as that would be done in the next tick before movement code
-                vecNextVelocity -= (player->GetGravity() * GetCurrentGravity() * 0.5 * gpGlobals->frametime);
+                vecNextVelocity.z -= player->GetGravity() * GetCurrentGravity() * 0.5f * gpGlobals->frametime;
 
                 // Try to predict what would happen on the next tick if the player didn't get grounded
                 bool bGrounded = true; // Would the player be grounded next tick?
@@ -1303,7 +1303,7 @@ void CMomentumGameMovement::CategorizePosition()
 
                 // Set ground entity if the player is not going to slide on a ramp next tick and if they will be
                 // grounded (exception if the player wants to bhop)
-                if (vecNextVelocity[2] <= NON_JUMP_VELOCITY && bGrounded)
+                if (vecNextVelocity.z <= NON_JUMP_VELOCITY && bGrounded)
                 {
                     // Make sure we check clip velocity on slopes/surfs before setting the ground entity and nulling out
                     // velocity.z

--- a/mp/src/game/shared/momentum/mom_player_shared.cpp
+++ b/mp/src/game/shared/momentum/mom_player_shared.cpp
@@ -332,3 +332,17 @@ void CMomentumPlayer::KickBack(float up_base, float lateral_base, float up_modif
 
     SetPunchAngle(angle);
 }
+
+void CMomentumPlayer::SetLastCollision(const trace_t &tr)
+{
+    m_iLastCollisionTick = gpGlobals->tickcount;
+    m_trLastCollisionTrace = tr;
+
+    // Raise origin position if it was a ceiling that was hit
+    if (tr.plane.normal.z < 0.0f)
+    {
+        float flOffset = (CollisionProp()->OBBMaxs() - CollisionProp()->OBBMins()).z;
+        m_trLastCollisionTrace.startpos.z += flOffset;
+        m_trLastCollisionTrace.endpos.z   += flOffset;
+    }
+}

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -46,6 +46,7 @@ void CGameModeBase::SetGameModeVars()
     sv_considered_on_ground.SetValue(1);
     sv_duck_collision_fix.SetValue(true);
     sv_ground_trigger_fix.SetValue(true);
+    sv_edge_fix.SetValue(false); // MOM_TODO Let people test the edge fix in 0.8.4 so we can get their opinions
 }
 
 void CGameModeBase::OnPlayerSpawn(CMomentumPlayer *pPlayer)

--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -135,3 +135,4 @@ ConVar r_AirboatViewZHeight( "r_AirboatViewZHeight", "0.0", FCVAR_CHEAT | FCVAR_
 MAKE_CONVAR(sv_considered_on_ground, "1.0", FCVAR_MAPPING, "Amount of units you have to be above the ground to be considered on ground.\n", 0.0f, 5.f);
 MAKE_TOGGLE_CONVAR(sv_duck_collision_fix, "1", FCVAR_MAPPING, "Fixes headbugs by updating the collision box after duck code instead of at the end of the tick. 1 = ON, 0 = OFF.\n");
 MAKE_TOGGLE_CONVAR(sv_ground_trigger_fix, "1", FCVAR_MAPPING, "Fixes being able to jump off the ground if grounded with a trigger under the player (bounces and jumpbugs). 1 = ON, 0 = OFF.\n");
+MAKE_TOGGLE_CONVAR(sv_edge_fix, "1", FCVAR_MAPPING, "Makes edgebugs more consistent and allows for bunnyhopping instead of edgebugging. 1 = ON, 0 = OFF.\n");

--- a/mp/src/game/shared/movevars_shared.h
+++ b/mp/src/game/shared/movevars_shared.h
@@ -56,5 +56,6 @@ extern ConVar r_AirboatViewZHeight;
 extern ConVar sv_considered_on_ground;
 extern ConVar sv_duck_collision_fix;
 extern ConVar sv_ground_trigger_fix;
+extern ConVar sv_edge_fix;
 
 #endif // MOVEVARS_SHARED_H


### PR DESCRIPTION
The fix lets players bunnyhop after edgebugging, but also aims to make edgebugs more consistent. For example if the player is in the air and about to get grounded because they are within sv_considered_on_ground above the ground, then it will check if the player would have edgebugged or missed the edge entirely next tick. If so it will not ground the player (unless they are trying to bunnyhop), allowing for an edgebug (or miss). Another way it tries to make edgebugs more consistent is to always check if they player would have edgebugged if they had gotten a "max distance" edgebug, and if so, allow them to edgebug. Because more consistent edgebugs also means they are more common, this fix will be off by default so people can try it out in the next version. What "max distance" edgebugs are is explained in details here: https://discordapp.com/channels/235111289435717633/602643431453360148/671131070074322955.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review