### PR TITLE
Don't default to local player in player_speedmod

### DIFF
--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -7693,10 +7693,6 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 	{
 		pPlayer = (CBasePlayer *)data.pActivator;
 	}
-	else if ( !g_pGameRules->IsDeathmatch() )
-	{
-		pPlayer = UTIL_GetLocalPlayer();
-	}
 
 	if ( pPlayer )
 	{


### PR DESCRIPTION
Closes #489 

Since pretty much every map is made with multiplayer servers in mind, there's no reason for player_speedmod to default to the local player; the activator will never be a non-player entity.

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->