### PR TITLE
Fix missing default crosshair

### DIFF
--- a/mp/src/game/client/hud.cpp
+++ b/mp/src/game/client/hud.cpp
@@ -26,6 +26,7 @@
 #include <vgui_controls/AnimationController.h>
 #include <vgui/ISurface.h>
 #include "hud_lcd.h"
+#include "fmtstr.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -57,9 +58,10 @@ struct HudTextureFileRef
 
 void LoadHudTextures(CUtlDict< CHudTexture*>& list, const char *szFilenameWithoutExtension)
 {
+	CFmtStr szFullName("%s.txt", szFilenameWithoutExtension);
 	KeyValuesAD pKeyValuesData("InputFile");
-	
-	if (pKeyValuesData->LoadFromFile(g_pFullFileSystem, szFilenameWithoutExtension, "GAME"))
+
+	if (pKeyValuesData->LoadFromFile(g_pFullFileSystem, szFullName, "GAME"))
 	{
 		LoadHudTextures(list, pKeyValuesData);
 	}


### PR DESCRIPTION
Closes #557

This seems like a regression from cf983e81. The function `LoadHudTextures` was changed and no longer appended the `.txt` to the filenames, so all attempts to load files failed since they were missing the extension.

Fixing this also results in weapon crosshairs having a dot in the middle, since this bug has been around a while I'm not sure if having this is intentional or not.

Example of weapon crosshair:
![Weapon Crosshair](https://i.imgur.com/rbp90My.png)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review