### PR TITLE
Disallow pre charged stickies in start zone

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1050,11 +1050,12 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
     case ZONE_TYPE_START:
         if (g_pGameModeSystem->GameModeIs(GAMEMODE_SJ))
         {
-            // Re-enable charge on start zone exit
+            // Re-enable charge on start zone exit and set charge time to 0 to prevent pre-charged stickies
             const auto pLauncher = dynamic_cast<CMomentumStickybombLauncher *>(this->GetActiveWeapon());
             if (pLauncher)
             {
                 pLauncher->SetChargeEnabled(true);
+                pLauncher->SetChargeBeginTime(0.0f);
             }
         }
         // g_pMomentumTimer->CalculateTickIntervalOffset(this, ZONE_TYPE_START, 1);

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -45,6 +45,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
     bool SetChargeEnabled(bool state) { return m_bIsChargeEnabled.Set(state); }
 
     CMomStickybomb *GetStickyByCount(int count) { return m_Stickybombs[count]; }
+    void SetChargeBeginTime(float value) { m_flChargeBeginTime = value; }
     float GetChargeBeginTime() { return m_flChargeBeginTime; }
     float GetChargeMaxTime();
 


### PR DESCRIPTION
This PR fixes a case where the internal sticky charge timer still counts up when trying to charge stickies inside the start zone, thus being able to fire a fully charged sticky upon leaving the start zone.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review