### PR TITLE
Stop showing default "dots" crosshair with weapon crosshairs and fix custom crosshair files

### DIFF
--- a/mp/src/game/client/hud_crosshair.cpp
+++ b/mp/src/game/client/hud_crosshair.cpp
@@ -327,10 +327,10 @@ void CHudCrosshair::DrawCrosshair( CWeaponBase *weaponBase )
 
     if (cl_crosshair_style.GetInt() != 2)
     {
-        CHudTexture *m_pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
+        CHudTexture *pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
 
-        if (m_pCrosshairTexture)
-            weaponBase->m_iCrosshairTextureID = m_pCrosshairTexture->textureId;
+        if (pCrosshairTexture)
+            weaponBase->m_iCrosshairTextureID = pCrosshairTexture->textureId;
         
         int iLeft = iHalfScreenWidth - (iCrosshairDistance + iBarSize);
         int iRight = iHalfScreenWidth + iCrosshairDistance;
@@ -422,14 +422,14 @@ void CHudCrosshair::DrawCrosshair( CWeaponBase *weaponBase )
     }
     else
     {
-        CHudTexture *m_pCrosshairTexture;
+        CHudTexture *pCrosshairTexture;
         if (FStrEq(cl_crosshair_file.GetString(), "") || FStrEq(cl_crosshair_file.GetString(), "null"))
-            m_pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
+            pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
         else
-            m_pCrosshairTexture = gHUD.GetIcon(cl_crosshair_file.GetString());
+            pCrosshairTexture = gHUD.GetIcon(cl_crosshair_file.GetString());
 
-        if (m_pCrosshairTexture)
-            weaponBase->m_iCrosshairTextureID = m_pCrosshairTexture->textureId;
+        if (pCrosshairTexture)
+            weaponBase->m_iCrosshairTextureID = pCrosshairTexture->textureId;
 
         surface()->DrawSetTexture(weaponBase->m_iCrosshairTextureID);
 

--- a/mp/src/game/client/hud_crosshair.cpp
+++ b/mp/src/game/client/hud_crosshair.cpp
@@ -38,7 +38,7 @@ MAKE_TOGGLE_CONVAR(cl_crosshair_dynamic_fire, "1", FCVAR_ARCHIVE, "Toggle dynami
 
 MAKE_TOGGLE_CONVAR(cl_crosshair_dynamic_move, "1", FCVAR_ARCHIVE, "Toggle dynamic crosshair behaviour with player movement. 0 = OFF, 1 = ON\n");
 
-ConVar cl_crosshair_file("cl_crosshair_file", "", FCVAR_ARCHIVE,
+ConVar cl_crosshair_file("cl_crosshair_file", "crosshair_custom", FCVAR_ARCHIVE,
     "Set the name of the custom VTF texture defined in scripts/hud_textures.txt to be used as a crosshair. Takes effect on cl_crosshair_style 1.\n");
 
 ConVar cl_crosshair_gap("cl_crosshair_gap", "4", FCVAR_ARCHIVE,
@@ -327,10 +327,10 @@ void CHudCrosshair::DrawCrosshair( CWeaponBase *weaponBase )
 
     if (cl_crosshair_style.GetInt() != 2)
     {
-        m_pCrosshair = gHUD.GetIcon("whiteAdditive");
+        CHudTexture *m_pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
 
-        if (m_pCrosshair)
-            weaponBase->m_iCrosshairTextureID = m_pCrosshair->textureId;
+        if (m_pCrosshairTexture)
+            weaponBase->m_iCrosshairTextureID = m_pCrosshairTexture->textureId;
         
         int iLeft = iHalfScreenWidth - (iCrosshairDistance + iBarSize);
         int iRight = iHalfScreenWidth + iCrosshairDistance;
@@ -372,7 +372,7 @@ void CHudCrosshair::DrawCrosshair( CWeaponBase *weaponBase )
             if (!cl_crosshair_t.GetBool())
                 surface()->DrawTexturedRect(iHalfLefter, iTop, iHalfRighter, iFarTop);
             surface()->DrawTexturedRect(iHalfLefter, iBottom, iHalfRighter, iFarBottom);
-            
+		
             if (cl_crosshair_dot.GetBool())
             {
                 if (cl_crosshair_outline_enable.GetBool())
@@ -422,15 +422,14 @@ void CHudCrosshair::DrawCrosshair( CWeaponBase *weaponBase )
     }
     else
     {
-        m_pCrosshair = nullptr;
-
+        CHudTexture *m_pCrosshairTexture;
         if (FStrEq(cl_crosshair_file.GetString(), "") || FStrEq(cl_crosshair_file.GetString(), "null"))
-            m_pCrosshair = gHUD.GetIcon("whiteAdditive");
+            m_pCrosshairTexture = gHUD.GetIcon("whiteAdditive");
         else
-            m_pCrosshair = gHUD.GetIcon(cl_crosshair_file.GetString());
+            m_pCrosshairTexture = gHUD.GetIcon(cl_crosshair_file.GetString());
 
-        if (m_pCrosshair)
-            weaponBase->m_iCrosshairTextureID = m_pCrosshair->textureId;
+        if (m_pCrosshairTexture)
+            weaponBase->m_iCrosshairTextureID = m_pCrosshairTexture->textureId;
 
         surface()->DrawSetTexture(weaponBase->m_iCrosshairTextureID);
 


### PR DESCRIPTION
Custom crosshair files were maybe fixed with #561, though odd issues with the crosshair having alpha and only showing when the run comparisons panel did sometimes occurred? This might need more testing to ensure this is no longer the case.

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->