### PR TITLE
Stop TF2 materials from going pitch black

### DIFF
--- a/mp/src/game/client/client_momentum.vpc
+++ b/mp/src/game/client/client_momentum.vpc
@@ -337,6 +337,7 @@ $Project "Client (Momentum)"
             $File   "momentum\clientmode_mom_normal.cpp"
             $File   "momentum\c_mom_ghost_base.h"
             $File   "momentum\c_mom_ghost_base.cpp"
+            $File   "momentum\tf2proxy.cpp"
 
             // RTT Shadows
             $File "momentum\worldlight.h"

--- a/mp/src/game/client/momentum/tf2proxy.cpp
+++ b/mp/src/game/client/momentum/tf2proxy.cpp
@@ -1,0 +1,126 @@
+//================================================================================================================//
+// Purpose: Fakes material proxies from TF2 to stop models from turning pitch black and remove console error spew
+//================================================================================================================//
+#include "cbase.h"
+
+#include <KeyValues.h>
+
+#include "baseanimatedtextureproxy.h"
+#include "functionproxy.h"
+
+#include "tier0/memdbgon.h"
+
+class CYellowLevelProxy : public CResultProxy
+{
+  public:
+    void OnBind(void *pC_BaseEntity)
+    {
+        Assert(m_pResult);
+
+        if (!pC_BaseEntity)
+            return;
+
+        C_BaseEntity *pEntity = BindArgToEntity(pC_BaseEntity);
+        if (!pEntity)
+            return;
+
+        // stop stuff from going black
+        m_pResult->SetVecValue(1.0f, 1.0f, 1.0f);
+    }
+};
+
+EXPOSE_INTERFACE(CYellowLevelProxy, IMaterialProxy, "YellowLevel" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CBurnLevelProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CBurnLevelProxy, IMaterialProxy, "BurnLevel" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CInvulnLevelProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CInvulnLevelProxy, IMaterialProxy, "InvulnLevel" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CSpyInvisProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CSpyInvisProxy, IMaterialProxy, "spy_invis" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CWeaponInvisProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CWeaponInvisProxy, IMaterialProxy, "weapon_invis" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CInvisProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CInvisProxy, IMaterialProxy, "invis" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CModelGlowColorProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CModelGlowColorProxy, IMaterialProxy, "ModelGlowColor" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CItemTintColorProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CItemTintColorProxy, IMaterialProxy, "ItemTintColor" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CStickybombGlowColorProxy : public CResultProxy
+{
+  public:
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CStickybombGlowColorProxy, IMaterialProxy, "StickybombGlowColor" IMATERIAL_PROXY_INTERFACE_VERSION);
+
+class CAnimatedWeaponSheenProxy : public CBaseAnimatedTextureProxy
+{
+  public:
+    CAnimatedWeaponSheenProxy() {}
+    ~CAnimatedWeaponSheenProxy() {}
+
+    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
+    void OnBind(void *pC_BaseEntity) {}
+    float GetAnimationStartTime(void *pBaseEntity) { return 0; }
+    IMaterial *GetMaterial() { return nullptr; }
+};
+
+EXPOSE_INTERFACE(CAnimatedWeaponSheenProxy, IMaterialProxy, "AnimatedWeaponSheen" IMATERIAL_PROXY_INTERFACE_VERSION);


### PR DESCRIPTION
This PR fixes an issue with materials from live TF2 which use custom material proxies that are not in Momentum, turning models black.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review