### PR TITLE
Default mom_sj_stickybomb_drawdelay to 0

### DIFF
--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -56,7 +56,7 @@ LINK_ENTITY_TO_CLASS(momentum_stickybomb, CMomStickybomb);
 PRECACHE_WEAPON_REGISTER(momentum_stickybomb);
 
 #ifdef CLIENT_DLL
-static MAKE_CONVAR(mom_sj_stickybomb_drawdelay, "0.1", FCVAR_ARCHIVE,
+static MAKE_CONVAR(mom_sj_stickybomb_drawdelay, "0", FCVAR_ARCHIVE,
                    "Determines how long it takes for stickies to start being drawn upon spawning.\n", 0, 1);
 #endif
 


### PR DESCRIPTION
As this setting gives an objective advantage for things like airpogos, this is being set to 0 by default and anyone who wishes to change it can do so.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review