### PR TITLE
Add ConVar mom_hud_sj_chargemeter_units to show stickybomb speed when charged

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -1,5 +1,8 @@
 #include "cbase.h"
 
+#include <vgui/ILocalize.h>
+#include <vgui/ISurface.h>
+#include <vgui/IVGui.h>
 #include <vgui_controls/EditablePanel.h>
 #include <vgui_controls/ProgressBar.h>
 #include <vgui_controls/Label.h>
@@ -8,6 +11,8 @@
 #include "hud.h"
 #include "hudelement.h"
 #include "iclientmode.h"
+#include "ienginevgui.h"
+
 #include "mom_system_gamemode.h"
 #include "weapon/weapon_mom_stickybomblauncher.h"
 
@@ -16,6 +21,12 @@
 using namespace vgui;
 
 static MAKE_TOGGLE_CONVAR(mom_hud_sj_chargemeter_enable, "1", FCVAR_ARCHIVE, "Toggles the charge meter on or off.\n");
+static MAKE_CONVAR(mom_hud_sj_chargemeter_units, "0", FCVAR_ARCHIVE,
+                   "If above 0, shows the speed at which a sticky will be launched when charged.\n"
+                   " 0 = OFF\n"
+                   " 1 = Speed in Hammer units (900-2400u/s)\n"
+                   " 2 = Speed in percent (0% = 900u/s, 100% = 2400u/s)",
+                   0, 2);
 
 class CHudStickyCharge : public CHudElement, public EditablePanel
 {
@@ -89,11 +100,19 @@ void CHudStickyCharge::OnThink()
     if (!m_pLauncher)
         return;
 
+    // Reset the charge label when player stops charging
+    if (mom_hud_sj_chargemeter_units.GetInt() >= 0 && m_pLauncher->GetChargeBeginTime() == 0)
+    {
+        m_pChargeLabel->SetText("CHARGE");
+    }
+
     // Turn charge meter red while inside start zone to indicate that stickies can't be charged
     if (!m_pLauncher->IsChargeEnabled())
     {
         m_pChargeMeter->SetFgColor(Color(192, 28, 0, 140));
         m_pChargeMeter->SetProgress(1.0f);
+
+        m_pChargeLabel->SetVisible(false);
     }
     else
     {
@@ -110,6 +129,21 @@ void CHudStickyCharge::OnThink()
                 float flPercentCharged = min(1.0, flTimeCharged / flChargeMaxTime);
 
                 m_pChargeMeter->SetProgress(flPercentCharged);
+
+                if (mom_hud_sj_chargemeter_units.GetInt() == 1)
+                {
+                    char buf[64];
+                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) RemapValClamped(flTimeCharged, 0.0f, 4.0f, 900.0f, 2400.0f));
+
+                    m_pChargeLabel->SetText(buf);
+                }
+                else if (mom_hud_sj_chargemeter_units.GetInt() == 2)
+                {
+                    char buf[64];
+                    Q_snprintf(buf, sizeof(buf), "%d%%", (int) (flPercentCharged * 100));
+
+                    m_pChargeLabel->SetText(buf);
+                }
             }
             else
             {

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -101,7 +101,7 @@ void CHudStickyCharge::OnThink()
         return;
 
     // Reset the charge label when player stops charging
-    if (mom_hud_sj_chargemeter_units.GetInt() >= 0 && m_pLauncher->GetChargeBeginTime() == 0)
+    if (m_pLauncher->GetChargeBeginTime() == 0)
     {
         m_pChargeLabel->SetText("CHARGE");
     }
@@ -116,6 +116,10 @@ void CHudStickyCharge::OnThink()
     }
     else
     {
+        // If charge label was disabled by start zone, enable it again
+        if (!m_pChargeLabel->IsVisible())
+            m_pChargeLabel->SetVisible(true);
+
         m_pChargeMeter->SetFgColor(Color(235, 235, 235, 255));
         float flChargeMaxTime = m_pLauncher->GetChargeMaxTime();
 
@@ -133,7 +137,7 @@ void CHudStickyCharge::OnThink()
                 if (mom_hud_sj_chargemeter_units.GetInt() == 1)
                 {
                     char buf[64];
-                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) RemapValClamped(flTimeCharged, 0.0f, 4.0f, 900.0f, 2400.0f));
+                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) m_pLauncher->CalculateProjectileSpeed(flTimeCharged));
 
                     m_pChargeLabel->SetText(buf);
                 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -101,7 +101,7 @@ void CHudStickyCharge::OnThink()
         return;
 
     // Reset the charge label when player stops charging
-    if (m_pLauncher->GetChargeBeginTime() == 0)
+    if (m_pLauncher->GetChargeBeginTime() <= 0.0f)
     {
         m_pChargeLabel->SetText("CHARGE");
     }

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -253,6 +253,12 @@ void CMomentumStickybombLauncher::SecondaryAttack()
     }
 }
 
+float CMomentumStickybombLauncher::CalculateProjectileSpeed(float flProgress)
+{
+    return RemapValClamped(flProgress, 0.0f, MOM_STICKYBOMB_MAX_CHARGE_TIME,
+                           MOM_STICKYBOMB_MIN_CHARGE_VEL, MOM_STICKYBOMB_MAX_CHARGE_VEL);
+}
+
 float CMomentumStickybombLauncher::GetProjectileSpeed()
 {
 #ifdef CLIENT_DLL
@@ -262,10 +268,7 @@ float CMomentumStickybombLauncher::GetProjectileSpeed()
     if (!mom_sj_charge_enable.GetBool())
         return 900.0f;
 
-    return RemapValClamped((gpGlobals->curtime - m_flChargeBeginTime), 0.0f, 
-                           MOM_STICKYBOMB_MAX_CHARGE_TIME, 
-                           MOM_STICKYBOMB_MIN_CHARGE_VEL, 
-                           MOM_STICKYBOMB_MAX_CHARGE_VEL);
+    return CalculateProjectileSpeed(gpGlobals->curtime - m_flChargeBeginTime);
 }
 
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -39,6 +39,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
     void DeathNotice(CBaseEntity *pVictim);
     int GetStickybombCount() { return m_iStickybombCount.Get(); }
     float GetProjectileSpeed();
+    float CalculateProjectileSpeed(float flProgress);
 
     bool IsChargeEnabled() { return m_bIsChargeEnabled.Get(); }
     bool SetChargeEnabled(bool state) { return m_bIsChargeEnabled.Set(state); }


### PR DESCRIPTION
This PR adds a ConVar `mom_hud_sj_chargemeter_units` to allow players to see the speed at which a stickybomb will be fired when charged.

Setting it to 1 will show the speed in Hammer units:
![20200226010732_1](https://user-images.githubusercontent.com/6624576/75299118-86b87280-5834-11ea-834e-d1f98aeb3ca1.jpg)

Setting it to 2 will show the speed in percent:
![20200226010720_1](https://user-images.githubusercontent.com/6624576/75299154-9932ac00-5834-11ea-959d-35af5964d58c.jpg)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review