### PR TITLE
Added sv_tickrate

### DIFF
--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -154,11 +154,12 @@ static int OnTickRateAutocomplete(const char* partial,
     unsigned suggestionCount = 0;
 
     // Search defined rates for one with a string matching the command argument.
-    for (unsigned rateI = 0; rateI < rateCount; rateI++)
+    for (unsigned rateI = 0; rateI < rateCount && rateI < COMMAND_COMPLETION_MAXITEMS; rateI++)
     {
         if (!strncmp(partial, TickSet::s_DefinedRates[rateI].sType, partialLength))
         {
-            strcpy(commands[suggestionCount], TickSet::s_DefinedRates[rateI].sType);
+            strncpy(commands[suggestionCount], TickSet::s_DefinedRates[rateI].sType,
+                COMMAND_COMPLETION_ITEM_LENGTH);
             ++suggestionCount;
         }
     }

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -7,11 +7,12 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-float* TickSet::interval_per_tick = nullptr;
+static void OnIntervalPerTickChange(IConVar *var, const char *pOldValue, float fOldValue);
 
 MAKE_CONVAR_C(sv_interval_per_tick, "0.015", FCVAR_MAPPING,
     "Changes the interval per tick of the engine. Interval per tick is 1/tickrate, "
     "so 100 tickrate = 0.01.", 0.001f, 0.1f, OnIntervalPerTickChange);
+float *TickSet::interval_per_tick = nullptr;
 const Tickrate TickSet::s_DefinedRates[] = {
     { 0.015f, "66" },
     { 0.01f, "100" }
@@ -100,7 +101,8 @@ bool TickSet::SetTickrate(Tickrate trNew)
     return false;
 }
 
-static void OnTickRateChange(IConVar *var, const char* pOldValue, float fOldValue)
+
+static void OnIntervalPerTickChange(IConVar *var, const char* pOldValue, float fOldValue)
 {
     ConVarRef tr(var);
     float tickrate = tr.GetFloat();

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -8,6 +8,10 @@
 #include "tier0/memdbgon.h"
 
 float* TickSet::interval_per_tick = nullptr;
+
+MAKE_CONVAR_C(sv_interval_per_tick, "0.015", FCVAR_MAPPING,
+    "Changes the interval per tick of the engine. Interval per tick is 1/tickrate, "
+    "so 100 tickrate = 0.01.", 0.001f, 0.1f, OnIntervalPerTickChange);
 const Tickrate TickSet::s_DefinedRates[] = {
     { 0.015f, "66" },
     { 0.01f, "100" }
@@ -112,7 +116,3 @@ static void OnTickRateChange(IConVar *var, const char* pOldValue, float fOldValu
     }*/
     TickSet::SetTickrate(tickrate);
 }
-
-MAKE_CONVAR_C(sv_interval_per_tick, "0.015", FCVAR_MAPPING, 
-              "Changes the interval per tick of the engine. Interval per tick is 1/tickrate, so 100 tickrate = 0.01\n",
-              0.001f, 0.1f, OnTickRateChange);

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -25,8 +25,11 @@ static ConCommand sv_tickrate("sv_tickrate", OnTickRateSet,
 float *TickSet::interval_per_tick = nullptr;
 
 const Tickrate TickSet::s_DefinedRates[] = {
+    { 0.015625f, "64" },
     { 0.015f, "66" },
-    { 0.01f, "100" }
+    { 0.01171875f, "85" },
+    { 0.01f, "100" },
+    { 0.0078125f, "128" }
 };
 Tickrate TickSet::m_trCurrent = s_DefinedRates[TICKRATE_66];
 bool TickSet::m_bInGameUpdate = false;
@@ -74,8 +77,16 @@ bool TickSet::SetTickrate(float tickrate)
     if (!CloseEnough(m_trCurrent.fTickRate, tickrate, FLT_EPSILON))
     {
         Tickrate tr;
-        if (CloseEnough(tickrate, 0.01f, FLT_EPSILON)) tr = s_DefinedRates[TICKRATE_100];
-        else if (CloseEnough(tickrate, 0.015f, FLT_EPSILON)) tr = s_DefinedRates[TICKRATE_66];
+        if (CloseEnough(tickrate, s_DefinedRates[TICKRATE_128].fTickRate, FLT_EPSILON))
+            tr = s_DefinedRates[TICKRATE_128];
+        else if (CloseEnough(tickrate, s_DefinedRates[TICKRATE_100].fTickRate, FLT_EPSILON))
+            tr = s_DefinedRates[TICKRATE_100];
+        else if (CloseEnough(tickrate, s_DefinedRates[TICKRATE_85].fTickRate, FLT_EPSILON))
+            tr = s_DefinedRates[TICKRATE_85];
+        else if (CloseEnough(tickrate, s_DefinedRates[TICKRATE_66].fTickRate, FLT_EPSILON))
+            tr = s_DefinedRates[TICKRATE_66];
+        else if (CloseEnough(tickrate, s_DefinedRates[TICKRATE_64].fTickRate, FLT_EPSILON))
+            tr = s_DefinedRates[TICKRATE_64];
         else
         {
             tr.fTickRate = tickrate;

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -16,7 +16,14 @@ static int OnTickRateAutocomplete(const char *partial,
 MAKE_CONVAR_C(sv_interval_per_tick, "0.015", FCVAR_MAPPING,
     "Changes the interval per tick of the engine. Interval per tick is 1/tickrate, "
     "so 100 tickrate = 0.01.", 0.001f, 0.1f, OnIntervalPerTickChange);
+
+static ConCommand sv_tickrate("sv_tickrate", OnTickRateSet,
+    "Changes the tickrate to one of a defined set of values. "
+    "Custom tickrates can be set using sv_interval_per_tick.",
+    0, OnTickRateAutocomplete);
+
 float *TickSet::interval_per_tick = nullptr;
+
 const Tickrate TickSet::s_DefinedRates[] = {
     { 0.015f, "66" },
     { 0.01f, "100" }

--- a/mp/src/game/server/momentum/tickset.cpp
+++ b/mp/src/game/server/momentum/tickset.cpp
@@ -31,8 +31,8 @@ const Tickrate TickSet::s_DefinedRates[] = {
     { 0.01f, "100" },
     { 0.0078125f, "128" }
 };
+
 Tickrate TickSet::m_trCurrent = s_DefinedRates[TICKRATE_66];
-bool TickSet::m_bInGameUpdate = false;
 
 bool TickSet::TickInit()
 {

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -34,8 +34,11 @@ public:
 
     enum
     {
-        TICKRATE_66 = 0,
-        TICKRATE_100 = 1    
+        TICKRATE_64 = 0,
+        TICKRATE_66 = 1,
+        TICKRATE_85 = 2,
+        TICKRATE_100 = 3,
+        TICKRATE_128 = 4
     };
 
     static bool TickInit();

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -35,10 +35,14 @@ public:
     enum
     {
         TICKRATE_64 = 0,
-        TICKRATE_66 = 1,
-        TICKRATE_85 = 2,
-        TICKRATE_100 = 3,
-        TICKRATE_128 = 4
+        TICKRATE_66,
+        TICKRATE_85,
+        TICKRATE_100,
+        TICKRATE_128,
+
+        TICKRATE_COUNT,
+        TICKRATE_FIRST = TICKRATE_64,
+        TICKRATE_LAST = TICKRATE_128,
     };
 
     static bool TickInit();

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -58,3 +58,5 @@ private:
 
     static Tickrate m_trCurrent;
 };
+
+extern ConVar sv_interval_per_tick;

--- a/mp/src/game/server/momentum/tickset.h
+++ b/mp/src/game/server/momentum/tickset.h
@@ -53,7 +53,4 @@ private:
     static float *interval_per_tick;
 
     static Tickrate m_trCurrent;
-    static bool m_bInGameUpdate;
 };
-
-extern ConVar sv_interval_per_tick;

--- a/mp/src/public/scratchpad3d.h
+++ b/mp/src/public/scratchpad3d.h
@@ -51,7 +51,7 @@ public:
 							m_pCachedRenderData = NULL;
 						}
 
-						~CBaseCommand()
+						virtual ~CBaseCommand()
 						{
 							ReleaseCachedRenderData();
 						}


### PR DESCRIPTION
Closes #482 

Added a ConVar `sv_tickrate` which is synchronized with `sv_interval_per_tick`, equivalent to `1.0 / sv_interval_per_tick`.

Added more defined tickrates as done by bonjorno7 in 8b08aef . As far as I can see, the defined tickrates do nothing more than round within epsilon to these values, and provide an unused interface for aquiring the tickrate as a string. The hard-coded definitions possibly could be removed. If not, tickrates which do not fall into this category perhaps should have a string other than `"CUSTOM"` assigned to them.

I did not implement the suggested feature of 66 being interpreted as 66.6.., as I am not sure of the need for the special case, the default value is already at 66.0, and the repeating value can be assigned to the convar explicitly. I can certainly look into it if need be.

Also did a touch of cleanup.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->