### PR TITLE
Fixed incorrect sound when landing on slope

### DIFF
--- a/mp/src/game/client/c_baseplayer.h
+++ b/mp/src/game/client/c_baseplayer.h
@@ -341,7 +341,7 @@ public:
 	virtual void PlayPlayerJingle();
 
 	virtual void UpdateStepSound( surfacedata_t *psurface, const Vector &vecOrigin, const Vector &vecVelocity  );
-	virtual void PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force );
+	virtual void PlayStepSound( const Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force);
 	virtual surfacedata_t * GetFootstepSurface( const Vector &origin, const char *surfaceName );
 	virtual void GetStepSoundVelocities( float *velwalk, float *velrun );
 	virtual void SetStepSoundTime( stepsoundtimes_t iStepSoundTime, bool bWalking );

--- a/mp/src/game/server/player.h
+++ b/mp/src/game/server/player.h
@@ -435,7 +435,7 @@ public:
 	
 	void					UpdatePlayerSound ( void );
 	virtual void			UpdateStepSound( surfacedata_t *psurface, const Vector &vecOrigin, const Vector &vecVelocity );
-	virtual void			PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force );
+	virtual void			PlayStepSound( const Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force );
 	virtual const char	   *GetOverrideStepSound( const char *pszBaseStepSoundName ) { return pszBaseStepSoundName; }
 	virtual void			GetStepSoundVelocities( float *velwalk, float *velrun );
 	virtual void			SetStepSoundTime( stepsoundtimes_t iStepSoundTime, bool bWalking );

--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -640,7 +640,7 @@ void CBasePlayer::UpdateStepSound( surfacedata_t *psurface, const Vector &vecOri
 //			fvol - 
 //			force - force sound to play
 //-----------------------------------------------------------------------------
-void CBasePlayer::PlayStepSound( Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force )
+void CBasePlayer::PlayStepSound( const Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force )
 {
     if (!sv_footsteps.GetFloat())
         return;

--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -2399,7 +2399,7 @@ bool CGameMovement::CheckJumpButton( void )
 	// In the air now.
     SetGroundEntity( NULL );
 	
-	player->PlayStepSound( (Vector &)mv->GetAbsOrigin(), player->m_pSurfaceData, 1.0, true );
+	player->PlayStepSound( mv->GetAbsOrigin(), player->m_pSurfaceData, 1.0, true );
 	
 	MoveHelper()->PlayerSetAnimation( PLAYER_JUMP );
 
@@ -3948,7 +3948,7 @@ void CGameMovement::PlayerRoughLandingEffects(float fvol, short surfacePropsInde
 			pSurfaceData = player->m_pSurfaceData;
 		}
 
-		player->PlayStepSound((Vector&)mv->GetAbsOrigin(), pSurfaceData, fvol, true);
+		player->PlayStepSound(mv->GetAbsOrigin(), pSurfaceData, fvol, true);
 	}
 }
 

--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -3931,26 +3931,24 @@ void CGameMovement::CheckFalling( void )
 	player->m_Local.m_flFallVelocity = 0.0f;
 }
 
-void CGameMovement::PlayerRoughLandingEffects( float fvol )
+void CGameMovement::PlayerRoughLandingEffects(float fvol, short surfacePropsIndexOverride /* = -1 */)
 {
 	if ( fvol > 0.0 )
 	{
-		//
-		// Play landing sound right away.
 		player->m_flStepSoundTime = 400;
 
-		// Play step sound for current texture.
-		player->PlayStepSound( (Vector &)mv->GetAbsOrigin(), player->m_pSurfaceData, fvol, true );
-
-		//
-		// Knock the screen around a little bit, temporary effect.
-		//
-		player->m_Local.m_vecPunchAngle.Set( ROLL, player->m_Local.m_flFallVelocity * 0.013 );
-
-		if ( player->m_Local.m_vecPunchAngle[PITCH] > 8 )
+		surfacedata_t* pSurfaceData = nullptr;
+		if (surfacePropsIndexOverride != -1)
 		{
-			player->m_Local.m_vecPunchAngle.Set( PITCH, 8 );
+			pSurfaceData = MoveHelper()->GetSurfaceProps()->GetSurfaceData(surfacePropsIndexOverride);
 		}
+
+		if (!pSurfaceData)
+		{
+			pSurfaceData = player->m_pSurfaceData;
+		}
+
+		player->PlayStepSound((Vector&)mv->GetAbsOrigin(), pSurfaceData, fvol, true);
 	}
 }
 

--- a/mp/src/game/shared/gamemovement.h
+++ b/mp/src/game/shared/gamemovement.h
@@ -209,7 +209,7 @@ protected:
 
 	virtual void	CheckFalling( void );
 
-	virtual void	PlayerRoughLandingEffects( float fvol );
+	virtual void PlayerRoughLandingEffects(float fvol, short surfacePropsIndexOverride = -1);
 
 	void			PlayerWaterSounds( void );
 

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1033,7 +1033,7 @@ bool CMomentumGameMovement::CheckJumpButton()
     // Set the last jump time
     m_pPlayer->m_Data.m_flLastJumpTime = gpGlobals->curtime;
 
-    player->PlayStepSound(const_cast<Vector &>(mv->GetAbsOrigin()), player->m_pSurfaceData, 1.0, true);
+    player->PlayStepSound(mv->GetAbsOrigin(), player->m_pSurfaceData, 1.0, true);
 
     // MoveHelper()->PlayerSetAnimation( PLAYER_JUMP );
     // player->DoAnimationEvent(PLAYERANIMEVENT_JUMP);

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2115,20 +2115,14 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
             VectorCopy(vec3_origin, mv->m_vecVelocity);
     }
 
-    // Check if they slammed into a wall
-    float fSlamVol = 0.0f;
-
     float fLateralStoppingAmount = primal_velocity.Length2D() - mv->m_vecVelocity.Length2D();
-    if (fLateralStoppingAmount > PLAYER_MAX_SAFE_FALL_SPEED * 2.0f)
+    if (fLateralStoppingAmount > PLAYER_MAX_SAFE_FALL_SPEED)
     {
-        fSlamVol = 1.0f;
+        float fSlamVol = (fLateralStoppingAmount > PLAYER_MAX_SAFE_FALL_SPEED * 2.0f) ? 1.0f : 0.85f;
+        
+        // Play rough landing sound with last traced surface.
+        PlayerRoughLandingEffects(fSlamVol, pm.surface.surfaceProps);
     }
-    else if (fLateralStoppingAmount > PLAYER_MAX_SAFE_FALL_SPEED)
-    {
-        fSlamVol = 0.85f;
-    }
-
-    PlayerRoughLandingEffects(fSlamVol);
 
     return blocked;
 }

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -52,8 +52,6 @@ ConVar sv_ladder_angle("sv_ladder_angle", "-0.707", FCVAR_REPLICATED,
 #ifndef CLIENT_DLL
 #include "env_player_surface_trigger.h"
 static ConVar dispcoll_drawplane("dispcoll_drawplane", "0");
-static MAKE_TOGGLE_CONVAR(mom_punchangle_enable, "0", FCVAR_ARCHIVE | FCVAR_REPLICATED,
-                          "Toggle landing punchangle. 0 = OFF, 1 = ON\n");
 #endif
 
 CMomentumGameMovement::CMomentumGameMovement() : m_pPlayer(nullptr) {}
@@ -64,35 +62,6 @@ void CMomentumGameMovement::ProcessMovement(CBasePlayer *pPlayer, CMoveData *dat
     Assert(m_pPlayer);
 
     BaseClass::ProcessMovement(pPlayer, data);
-}
-
-void CMomentumGameMovement::PlayerRoughLandingEffects(float fvol)
-{
-    if (fvol > 0.0)
-    {
-        //
-        // Play landing sound right away.
-        player->m_flStepSoundTime = 400;
-
-        // Play step sound for current texture.
-        player->PlayStepSound(const_cast<Vector &>(mv->GetAbsOrigin()), player->m_pSurfaceData, fvol, true);
-
-#ifndef CLIENT_DLL
-        //
-        // Knock the screen around a little bit, temporary effect (IF ENABLED)
-        //
-        if (mom_punchangle_enable.GetBool())
-        {
-            player->m_Local.m_vecPunchAngle.Set(ROLL, player->m_Local.m_flFallVelocity * 0.013 *
-                                                          mom_punchangle_enable.GetInt());
-
-            if (player->m_Local.m_vecPunchAngle[PITCH] > 8)
-            {
-                player->m_Local.m_vecPunchAngle.Set(PITCH, 8);
-            }
-        }
-#endif
-    }
 }
 
 float CMomentumGameMovement::LadderDistance() const

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -23,7 +23,7 @@ class CMomentumGameMovement : public CGameMovement
     void AirMove() override;
     void WalkMove() override;
 
-    void PlayerRoughLandingEffects(float) override;
+    void PlayerRoughLandingEffects(float);
 
     // Ladder
     float LadderDistance() const override;

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -23,8 +23,6 @@ class CMomentumGameMovement : public CGameMovement
     void AirMove() override;
     void WalkMove() override;
 
-    void PlayerRoughLandingEffects(float);
-
     // Ladder
     float LadderDistance() const override;
     bool GameHasLadders() const override;


### PR DESCRIPTION
Closes #322 

Added a fix to `mom_gamemovement.cpp` which will solve the bug where hitting a slope and losing a large amount of velocity will play the landing sound of the last surface touched. 

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->