### PR TITLE
SJ Touchup / Fixes

### DIFF
--- a/mp/game/momentum/particles/particles_manifest.txt
+++ b/mp/game/momentum/particles/particles_manifest.txt
@@ -42,7 +42,7 @@ particles_manifest
     //"file"        "!particles/crit.pcf"
     //"file"        "!particles/medicgun_beam.pcf"
     //"file"        "!particles/bigboom.pcf"
-    //"file"        "!particles/water.pcf"
+    "file"        "!particles/water.pcf"
     "file"        "!particles/stickybomb.pcf"
     //"file"        "!particles/buildingdamage.pcf"
     //"file"        "!particles/nailtrails.pcf"

--- a/mp/game/momentum/resource/ui/HudStickyCharge.res
+++ b/mp/game/momentum/resource/ui/HudStickyCharge.res
@@ -1,5 +1,19 @@
 "Resource/ui/HudStickyCharge.res"
 {
+    "HudStickyCharge"
+    {
+        "ControlName" "CHudStickyCharge"
+        "fieldName" "HudStickyCharge"
+        "visible"		"1"
+        "enabled"		"1"
+        "xpos"          "c-75"
+        "ypos"          "c-20"
+        "wide"			"150"
+        "tall"          "100"
+        "paintbackground" "0"
+        "bgcolor_override" "0 0 0 0"
+    }
+
     "ChargeMeter"
     {	
         "ControlName"	"ContinuousProgressBar"
@@ -7,7 +21,6 @@
         "font"			"DefaultVerySmall"
         "xpos"			"15"
         "ypos"			"89"
-        "zpos"			"2"
         "wide"			"120"
         "tall"			"9"				
         "autoResize"	"0"
@@ -24,12 +37,9 @@
         "ControlName"       "Label"
         "fieldName"         "ChargeMeterLabel"
         "xpos"              "0"
-        "ypos"              "91"
-        "zpos"              "3"
-        "wide"              "150"
+        "ypos"              "1"
+        "wide"              "120"
         "tall"              "7"
-        "autoResize"        "1"
-        "pinCorner"         "2"
         "visible"           "1"
         "enabled"           "1"
         "tabPosition"       "0"
@@ -37,7 +47,11 @@
         "textAlignment"     "center"
         "dulltext"          "0"
         "brighttext"        "0"
+        "pin_to_sibling" "ChargeMeter"
+        "pin_to_sibling_corner" "0"
+        "pin_corner_to_sibling" "0"
         "font"              "HudNumbersExtremelySmall"
         "fgcolor_override" 	"150 150 150 255"
+        "auto_tall_tocontents" "1"
     }
 }

--- a/mp/game/momentum/resource/ui/HudStickybombs.res
+++ b/mp/game/momentum/resource/ui/HudStickybombs.res
@@ -1,13 +1,26 @@
 "Resource/ui/HudStickybombs.res"
 {
+    "CHudStickybombs"
+    {
+        "ControlName"		"CHudStickybombs"
+        "fieldName"		"CHudStickybombs"
+        "visible"		"1"
+        "enabled"		"1"
+        "xpos"          "c-75"
+        "ypos"          "c35"
+        "wide"			"150"
+        "tall"			"50"
+        "fgcolor_override"		"0 0 0 0"
+        "bgcolor_override"		"0 0 0 0"
+    }
     "StickybombsLabel"
     {
         "ControlName"	"Label"
         "fieldName"		"StickybombsLabel"
-        "xpos"			"25"
+        "xpos"			"0"
         "ypos"			"20"
-        "zpos"			"2"
-        "wide"			"100"
+        "wide"			"f0"
+        "proportionalToParent" "1"
         "tall"			"20"
         "autoResize"	"1"
         "pinCorner"		"2"
@@ -19,5 +32,6 @@
         "brighttext"	"0"
         "font"			"HudNumbersSmallBold"
         "fgcolor"       "243 243 243 255"
-    }		
+        "auto_tall_tocontents" "1"
+    }
 }

--- a/mp/game/momentum/scripts/HudLayout.res
+++ b/mp/game/momentum/scripts/HudLayout.res
@@ -393,27 +393,10 @@
     HudStickyCharge
     {
         "fieldName"		"HudStickyCharge"
-        "visible"		"1"
-        "enabled"		"1"
-        "xpos"          "c-75"
-        "ypos"          "c-20"
-        "zpos"			"1"
-        "wide"			"150"
-        "tall"          "100"
-        "paintbackground" "0"
-        "bgcolor_override" "0 0 0 0"
     }
 
     CHudStickybombs
     {
         "fieldName"		"CHudStickybombs"
-        "visible"		"1"
-        "enabled"		"1"
-        "xpos"          "c-75"
-        "ypos"          "c35"
-        "wide"			"150"
-        "tall"			"50"
-        "fgcolor_override"		"0 0 0 0"
-        "bgcolor_override"		"0 0 0 0"
     }
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -1,5 +1,8 @@
 #include "cbase.h"
 
+#include <vgui/ILocalize.h>
+#include <vgui/ISurface.h>
+#include <vgui/IVGui.h>
 #include <vgui_controls/EditablePanel.h>
 #include <vgui_controls/ProgressBar.h>
 #include <vgui_controls/Label.h>
@@ -8,6 +11,8 @@
 #include "hud.h"
 #include "hudelement.h"
 #include "iclientmode.h"
+#include "ienginevgui.h"
+
 #include "mom_system_gamemode.h"
 #include "weapon/weapon_mom_stickybomblauncher.h"
 
@@ -16,6 +21,12 @@
 using namespace vgui;
 
 static MAKE_TOGGLE_CONVAR(mom_hud_sj_chargemeter_enable, "1", FCVAR_ARCHIVE, "Toggles the charge meter on or off.\n");
+static MAKE_CONVAR(mom_hud_sj_chargemeter_units, "0", FCVAR_ARCHIVE,
+                   "If above 0, shows the speed at which a sticky will be launched when charged.\n"
+                   " 0 = OFF\n"
+                   " 1 = Speed in Hammer units (900-2400u/s)\n"
+                   " 2 = Speed in percent (0% = 900u/s, 100% = 2400u/s)",
+                   0, 2);
 
 class CHudStickyCharge : public CHudElement, public EditablePanel
 {
@@ -89,11 +100,19 @@ void CHudStickyCharge::OnThink()
     if (!m_pLauncher)
         return;
 
+    // Reset the charge label when player stops charging
+    if (mom_hud_sj_chargemeter_units.GetInt() >= 0 && m_pLauncher->GetChargeBeginTime() == 0)
+    {
+        m_pChargeLabel->SetText("CHARGE");
+    }
+
     // Turn charge meter red while inside start zone to indicate that stickies can't be charged
     if (!m_pLauncher->IsChargeEnabled())
     {
         m_pChargeMeter->SetFgColor(Color(192, 28, 0, 140));
         m_pChargeMeter->SetProgress(1.0f);
+
+        m_pChargeLabel->SetVisible(false);
     }
     else
     {
@@ -110,6 +129,21 @@ void CHudStickyCharge::OnThink()
                 float flPercentCharged = min(1.0, flTimeCharged / flChargeMaxTime);
 
                 m_pChargeMeter->SetProgress(flPercentCharged);
+
+                if (mom_hud_sj_chargemeter_units.GetInt() == 1)
+                {
+                    char buf[64];
+                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) RemapValClamped(flTimeCharged, 0.0f, 4.0f, 900.0f, 2400.0f));
+
+                    m_pChargeLabel->SetText(buf);
+                }
+                else if (mom_hud_sj_chargemeter_units.GetInt() == 2)
+                {
+                    char buf[64];
+                    Q_snprintf(buf, sizeof(buf), "%d%%", (int) (flPercentCharged * 100));
+
+                    m_pChargeLabel->SetText(buf);
+                }
             }
             else
             {

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -101,7 +101,7 @@ void CHudStickyCharge::OnThink()
         return;
 
     // Reset the charge label when player stops charging
-    if (mom_hud_sj_chargemeter_units.GetInt() >= 0 && m_pLauncher->GetChargeBeginTime() == 0)
+    if (m_pLauncher->GetChargeBeginTime() == 0)
     {
         m_pChargeLabel->SetText("CHARGE");
     }
@@ -116,6 +116,10 @@ void CHudStickyCharge::OnThink()
     }
     else
     {
+        // If charge label was disabled by start zone, enable it again
+        if (!m_pChargeLabel->IsVisible())
+            m_pChargeLabel->SetVisible(true);
+
         m_pChargeMeter->SetFgColor(Color(235, 235, 235, 255));
         float flChargeMaxTime = m_pLauncher->GetChargeMaxTime();
 
@@ -133,7 +137,7 @@ void CHudStickyCharge::OnThink()
                 if (mom_hud_sj_chargemeter_units.GetInt() == 1)
                 {
                     char buf[64];
-                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) RemapValClamped(flTimeCharged, 0.0f, 4.0f, 900.0f, 2400.0f));
+                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) m_pLauncher->CalculateProjectileSpeed(flTimeCharged));
 
                     m_pChargeLabel->SetText(buf);
                 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -101,7 +101,7 @@ void CHudStickyCharge::OnThink()
         return;
 
     // Reset the charge label when player stops charging
-    if (m_pLauncher->GetChargeBeginTime() == 0)
+    if (m_pLauncher->GetChargeBeginTime() <= 0.0f)
     {
         m_pChargeLabel->SetText("CHARGE");
     }

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -1,15 +1,13 @@
 #include "cbase.h"
-#include <vgui/ILocalize.h>
-#include <vgui/ISurface.h>
-#include <vgui/IVGui.h>
+
 #include <vgui_controls/EditablePanel.h>
 #include <vgui_controls/ProgressBar.h>
 #include <vgui_controls/Label.h>
+
 #include "c_mom_player.h"
 #include "hud.h"
 #include "hudelement.h"
 #include "iclientmode.h"
-#include "ienginevgui.h"
 #include "mom_system_gamemode.h"
 #include "weapon/weapon_mom_stickybomblauncher.h"
 

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombs.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombs.cpp
@@ -1,14 +1,11 @@
 #include "cbase.h"
-#include <vgui/ILocalize.h>
-#include <vgui/ISurface.h>
-#include <vgui/IVGui.h>
+
 #include <vgui_controls/EditablePanel.h>
 #include <vgui_controls/Label.h>
+
 #include "c_mom_player.h"
-#include "hud.h"
 #include "hudelement.h"
 #include "iclientmode.h"
-#include "ienginevgui.h"
 #include "mom_system_gamemode.h"
 #include "weapon/weapon_mom_stickybomblauncher.h"
 
@@ -17,6 +14,7 @@
 using namespace vgui;
 
 static MAKE_TOGGLE_CONVAR(mom_hud_sj_stickycount_enable, "1", FCVAR_ARCHIVE, "Toggles the stickybomb counter.\n");
+static MAKE_TOGGLE_CONVAR(mom_hud_sj_stickycount_autohide, "0", FCVAR_ARCHIVE, "Toggles automatically hiding the stickybomb counter at 0 stickies. 0 = OFF, 1 = ON\n");
 
 class CHudStickybombs : public CHudElement, public EditablePanel
 {
@@ -79,11 +77,15 @@ void CHudStickybombs::OnThink()
     if (!m_pLauncher)
         return;
 
-    int iStickybombs = m_pLauncher->GetStickybombCount();
-    if (iStickybombs < 1)
-        m_pStickyLabel->SetVisible(false);
+    const auto iStickybombs = m_pLauncher->GetStickybombCount();
+    if (mom_hud_sj_stickycount_autohide.GetBool())
+    {
+        m_pStickyLabel->SetVisible(iStickybombs > 0);
+    }
     else
+    {
         m_pStickyLabel->SetVisible(true);
+    }
 
     char buf[64];
     Q_snprintf(buf, sizeof(buf), "%u", iStickybombs);

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -10,6 +10,7 @@
 #include "momentum/mom_triggers.h"
 #include "IEffects.h"
 #include "fx_mom_shared.h"
+#include "physics_collisionevent.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -353,7 +354,8 @@ void CMomStickybomb::VPhysicsCollision(int index, gamevcollisionevent_t *pEvent)
     if (pHitEntity && (pHitEntity->IsWorld() || bIsDynamicProp) && gpGlobals->curtime > 0)
     {
         m_bTouched = true;
-        VPhysicsGetObject()->EnableMotion(false);
+
+        g_PostSimulationQueue.QueueCall(VPhysicsGetObject(), &IPhysicsObject::EnableMotion, false);
 
         // Save impact data for explosions.
         m_bUseImpactNormal = true;

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -57,7 +57,7 @@ LINK_ENTITY_TO_CLASS(momentum_stickybomb, CMomStickybomb);
 PRECACHE_WEAPON_REGISTER(momentum_stickybomb);
 
 #ifdef CLIENT_DLL
-static MAKE_CONVAR(mom_sj_stickybomb_drawdelay, "0.1", FCVAR_ARCHIVE,
+static MAKE_CONVAR(mom_sj_stickybomb_drawdelay, "0", FCVAR_ARCHIVE,
                    "Determines how long it takes for stickies to start being drawn upon spawning.\n", 0, 1);
 #endif
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -1,10 +1,10 @@
 #include "cbase.h"
 
+#include "weapon_mom_stickybomblauncher.h"
+
 #include "in_buttons.h"
 #include "mom_player_shared.h"
-#include "mom_stickybomb.h"
 #include "mom_system_gamemode.h"
-#include "weapon_mom_stickybomblauncher.h"
 
 #ifdef CLIENT_DLL
 #include "prediction.h"

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -253,6 +253,12 @@ void CMomentumStickybombLauncher::SecondaryAttack()
     }
 }
 
+float CMomentumStickybombLauncher::CalculateProjectileSpeed(float flProgress)
+{
+    return RemapValClamped(flProgress, 0.0f, MOM_STICKYBOMB_MAX_CHARGE_TIME,
+                           MOM_STICKYBOMB_MIN_CHARGE_VEL, MOM_STICKYBOMB_MAX_CHARGE_VEL);
+}
+
 float CMomentumStickybombLauncher::GetProjectileSpeed()
 {
 #ifdef CLIENT_DLL
@@ -262,10 +268,7 @@ float CMomentumStickybombLauncher::GetProjectileSpeed()
     if (!mom_sj_charge_enable.GetBool())
         return 900.0f;
 
-    return RemapValClamped((gpGlobals->curtime - m_flChargeBeginTime), 0.0f, 
-                           MOM_STICKYBOMB_MAX_CHARGE_TIME, 
-                           MOM_STICKYBOMB_MIN_CHARGE_VEL, 
-                           MOM_STICKYBOMB_MAX_CHARGE_VEL);
+    return CalculateProjectileSpeed(gpGlobals->curtime - m_flChargeBeginTime);
 }
 
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -39,6 +39,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
     void DeathNotice(CBaseEntity *pVictim);
     int GetStickybombCount() { return m_iStickybombCount.Get(); }
     float GetProjectileSpeed();
+    float CalculateProjectileSpeed(float flProgress);
 
     bool IsChargeEnabled() { return m_bIsChargeEnabled.Get(); }
     bool SetChargeEnabled(bool state) { return m_bIsChargeEnabled.Set(state); }

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "weapon_base_gun.h"
-
-class CMomStickybomb;
+#include "mom_stickybomb.h"
 
 #ifdef CLIENT_DLL
 #define CMomentumStickybombLauncher C_MomentumStickybombLauncher


### PR DESCRIPTION
General SJ touchup and fixes:

 - Added water particles to particle manifest mounting
 - Added `mom_hud_sj_stickycount_autohide` which can autohide the count if the count is 0
 - Made the stickybomb drawdelay default to 0
 - Added `mom_hud_sj_chargemeter_units` to change the label of the charge meter to be either the units of the stickybomb (1) or a percentage (2)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->