### PR TITLE
Normalize entities' angles when they hit the angle limit

### DIFF
--- a/mp/src/game/server/baseentity.cpp
+++ b/mp/src/game/server/baseentity.cpp
@@ -5932,22 +5932,12 @@ void CBaseEntity::SetLocalOrigin( const Vector& origin )
 
 void CBaseEntity::SetLocalAngles( const QAngle& angles )
 {
-	// NOTE: The angle normalize is a little expensive, but we can save
-	// a bunch of time in interpolation if we don't have to invalidate everything
-	// and sometimes it's off by a normalization amount
-
-	// FIXME: The normalize caused problems in server code like momentary_rot_button that isn't
-	//        handling things like +/-180 degrees properly. This should be revisited.
-	//QAngle angleNormalize( AngleNormalize( angles.x ), AngleNormalize( angles.y ), AngleNormalize( angles.z ) );
-
 	// Safety check against NaN's or really huge numbers
+	// And actually normalize the angles rather than freeze the entity and spam warnings
 	if ( !IsEntityQAngleReasonable( angles ) )
 	{
-		if ( CheckEmitReasonablePhysicsSpew() )
-		{
-			Warning( "Bad SetLocalAngles(%f,%f,%f) on %s\n", angles.x, angles.y, angles.z, GetDebugName() );
-		}
-		AssertMsg( false, "Bad SetLocalAngles(%f,%f,%f) on %s\n", angles.x, angles.y, angles.z, GetDebugName() );
+		QAngle angleNormalize(AngleNormalize(angles.x), AngleNormalize(angles.y), AngleNormalize(angles.z));
+		SetLocalAngles(angleNormalize);
 		return;
 	}
 


### PR DESCRIPTION
Closes #383 

Previously, whenever an entity's angles hit ±360000 degrees on any axis (usually func_rotating), it would refuse to update its angles any further which froze the entity while showing constant warnings. Instead, the angles are now normalized to within ±180 degrees whenever the limit is hit.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review