### PR TITLE
Prevent preview frame from disappearing

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
@@ -21,8 +21,8 @@ using namespace vgui;
     button->SetArmedColor(color, color); \
     button->SetSelectedColor(color, color);
 
-AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pParent, "AppearanceSettings"), ghost_color("mom_ghost_color"),
-ghost_bodygroup("mom_ghost_bodygroup"), ghost_trail_color("mom_trail_color"), ghost_trail_length("mom_trail_length")
+AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pParent, "AppearanceSettings"), ghost_color("mom_ghost_color"), ghost_bodygroup("mom_ghost_bodygroup"),
+      ghost_trail_color("mom_trail_color"), ghost_trail_length("mom_trail_length"), m_bModelPreviewFrameIsFadingOut(false)
 {
     // Outer frame for the model preview
     m_pModelPreviewFrame = new Frame(nullptr, "ModelPreviewFrame");
@@ -121,14 +121,20 @@ void AppearanceSettingsPage::LoadSettings()
 
 void AppearanceSettingsPage::OnPageShow()
 {
-    if (!m_pModelPreviewFrame->IsVisible())
+    if (!m_pModelPreviewFrame->IsVisible() || m_bModelPreviewFrameIsFadingOut)
+    {
         m_pModelPreviewFrame->Activate();
+        m_bModelPreviewFrameIsFadingOut = false;
+    }
 }
 
 void AppearanceSettingsPage::OnPageHide()
 {
     if (m_pModelPreviewFrame)
+    {
         m_pModelPreviewFrame->Close();
+        m_bModelPreviewFrameIsFadingOut = true;
+    }
 }
 
 void AppearanceSettingsPage::OnMainDialogClosed()

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
@@ -46,4 +46,6 @@ private:
     vgui::TextEntry *m_pTrailLengthEntry;
     vgui::ColorPicker *m_pColorPicker;
     vgui::Button *m_pPickTrailColorButton, *m_pPickBodyColorButton;
+
+    bool m_bModelPreviewFrameIsFadingOut;
 };

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -16,7 +16,8 @@
 
 using namespace vgui;
 
-ComparisonsSettingsPage::ComparisonsSettingsPage(Panel *pParent) : BaseClass(pParent, "ComparisonsSettings")
+ComparisonsSettingsPage::ComparisonsSettingsPage(Panel *pParent)
+    : BaseClass(pParent, "ComparisonsSettings"), m_bComparisonsFrameIsFadingOut(false)
 {
     m_pCompareShow = new CvarToggleCheckButton(this, "CompareShow", "#MOM_Settings_Compare_Show", "mom_comparisons");
     m_pCompareShow->AddActionSignalTarget(this);
@@ -191,14 +192,20 @@ void ComparisonsSettingsPage::OnPageShow()
 
     if (!m_pComparisonsFrame)
         InitBogusComparePanel();
-    else if (!m_pComparisonsFrame->IsVisible())
+    else if (!m_pComparisonsFrame->IsVisible() || m_bComparisonsFrameIsFadingOut)
+    {
         m_pComparisonsFrame->Activate();
+        m_bComparisonsFrameIsFadingOut = false;
+    }
 }
 
 void ComparisonsSettingsPage::OnPageHide()
 {
     if (m_pComparisonsFrame)
+    {
         m_pComparisonsFrame->Close();
+        m_bComparisonsFrameIsFadingOut = true;
+    }
 }
 
 void ComparisonsSettingsPage::OnCheckboxChecked(Panel *p)

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
@@ -54,6 +54,8 @@ private:
     vgui::Frame *m_pComparisonsFrame;
     C_RunComparisons *m_pBogusComparisonsPanel;
 
+    bool m_bComparisonsFrameIsFadingOut;
+
     //Determines what should pulse for the bogus panel
     int DetermineBogusPulse(Panel *panel) const;
 };


### PR DESCRIPTION
Closes #589

<!-- Describe what your pull request is doing here -->
When switching between tabs that have preview frames in the Momentum settings, the frame will still be considered visible if it is in the process of fading out. This can cause the frame to not appear when quickly switching back and forth between tabs. My solution aimed to preserve the fading effect, but it could also be solved by disabling the fading effect on the preview frames.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->