### PR TITLE
Fix settings preview panels not appearing

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
@@ -121,7 +121,7 @@ void AppearanceSettingsPage::LoadSettings()
 
 void AppearanceSettingsPage::OnPageShow()
 {
-    if (!m_pModelPreviewFrame->IsVisible())
+    if (m_pModelPreviewFrame)
         m_pModelPreviewFrame->Activate();
 }
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -132,7 +132,7 @@ void ComparisonsSettingsPage::OnMainDialogClosed()
 void ComparisonsSettingsPage::OnMainDialogShow()
 {
     if (m_pComparisonsFrame)
-        m_pComparisonsFrame->SetVisible(true);
+        m_pComparisonsFrame->Activate();
 }
 
 void ComparisonsSettingsPage::OnApplyChanges()
@@ -190,9 +190,13 @@ void ComparisonsSettingsPage::OnPageShow()
     BaseClass::OnPageShow();
 
     if (!m_pComparisonsFrame)
+    {
         InitBogusComparePanel();
-    else if (!m_pComparisonsFrame->IsVisible())
+    }
+    else
+    {
         m_pComparisonsFrame->Activate();
+    }
 }
 
 void ComparisonsSettingsPage::OnPageHide()


### PR DESCRIPTION
Closes #589 

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->

The `IsVisible()` calls return false while the preview panel is still fading out, so clicking into the page while the preview is still in it's fade animation wouldn't open it again. I removed the `IsVisible()` checks entirely since they don't seem necessary (opening the panel while it's still visible doesn't seem to do anything).