### PR TITLE
Hide scoreboard and lobby panels during credits

### DIFF
--- a/mp/src/game/client/hl2/hud_credits.cpp
+++ b/mp/src/game/client/hl2/hud_credits.cpp
@@ -5,6 +5,7 @@
 //=============================================================================//
 
 #include "cbase.h"
+#include <game/client/iviewport.h>
 #include <vgui/ILocalize.h>
 #include <vgui/ISurface.h>
 #include <vgui_controls/AnimationController.h>

--- a/mp/src/game/client/hl2/hud_credits.cpp
+++ b/mp/src/game/client/hl2/hud_credits.cpp
@@ -5,7 +5,6 @@
 //=============================================================================//
 
 #include "cbase.h"
-#include <game/client/iviewport.h>
 #include <vgui/ILocalize.h>
 #include <vgui/ISurface.h>
 #include <vgui_controls/AnimationController.h>

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -12,6 +12,8 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+extern bool g_bRollingCredits;
+
 using namespace vgui;
 
 #define UPDATE_INTERVAL 15.0f
@@ -175,6 +177,9 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
 
     if (bShow)
     {
+        if (g_bRollingCredits)
+            return;
+
         Reset(true);
         SetVisible(true);
         MoveToFront();

--- a/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/lobby/LobbyMembersPanel.cpp
@@ -28,6 +28,8 @@
 
 #include "tier0/memdbgon.h"
 
+extern bool g_bRollingCredits;
+
 using namespace vgui;
 
 static CSteamID s_LobbyID = k_steamIDNil;
@@ -296,6 +298,9 @@ void LobbyMembersPanel::ShowPanel(bool bShow)
 
     if (bShow)
     {
+        if (g_bRollingCredits)
+            return;
+
         Reset();
         SetVisible(true);
         // SetEnabled(true);


### PR DESCRIPTION
Closes #559

During the credits sequence, hide the leaderboard and lobby panels if they're visible.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->