### PR TITLE
Take away "give" and "givecurrentammo", but give "give_weapon"

### DIFF
--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -923,7 +923,7 @@ static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETI
 
 CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCompletion)
 {
-	CBasePlayer *pPlayer = ToBasePlayer(UTIL_GetCommandClient());
+	const auto pPlayer = ToCMOMPlayer(UTIL_GetCommandClient());
 	if (pPlayer && !pPlayer->IsObserver() && args.ArgC() == 2)
 	{
 		WeaponID_t foundID = WEAPON_NONE;
@@ -948,10 +948,7 @@ CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCom
 			return;
 	    }
 
-		char item[64];
-		Q_strncpy(item, args.Arg(1), 64);
-		Q_strnlwr(item, 64);
-		pPlayer->GiveNamedItem(item);
+		pPlayer->GiveWeapon(foundID);
 	}
 }
 

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -859,7 +859,7 @@ static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETI
 
 	int current = 0;
 	// Skip over weapon_none
-	for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
+	for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX && current < COMMAND_COMPLETION_MAXITEMS; weaponID++)
 	{
 		if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed((WeaponID_t)weaponID))
 			continue;

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -859,7 +859,7 @@ static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETI
 
 	int current = 0;
 	// Skip over weapon_none
-	for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
+	for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
 	{
 		if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed((WeaponID_t)weaponID))
 			continue;
@@ -882,7 +882,7 @@ CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCom
 	if (pPlayer && !pPlayer->IsObserver() && args.ArgC() == 2)
 	{
 		WeaponID_t foundID = WEAPON_NONE;
-		for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
+		for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
 		{
 		    if (!Q_strnicmp(g_szWeaponNames[weaponID], args.Arg(1), 64))
 		    {

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -864,13 +864,13 @@ static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETI
 		if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed((WeaponID_t)weaponID))
 			continue;
 
-	    if ((!substring || !substring[0]) || Q_stristr(g_szWeaponNames[weaponID], substring))
-	    {
+		if ((!substring || !substring[0]) || Q_stristr(g_szWeaponNames[weaponID], substring))
+		{
 			char command[COMMAND_COMPLETION_ITEM_LENGTH];
 			Q_snprintf(command, COMMAND_COMPLETION_ITEM_LENGTH, "%s %s", pCmdName, g_szWeaponNames[weaponID]);
-	        Q_strncpy(commands[current], command, COMMAND_COMPLETION_ITEM_LENGTH);
+			Q_strncpy(commands[current], command, COMMAND_COMPLETION_ITEM_LENGTH);
 			current++;
-	    }
+		}
 	}
 
 	return current;
@@ -884,24 +884,24 @@ CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCom
 		WeaponID_t foundID = WEAPON_NONE;
 		for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
 		{
-		    if (!Q_strnicmp(g_szWeaponNames[weaponID], args.Arg(1), 64))
-		    {
-	            foundID = (WeaponID_t)weaponID;
+			if (!Q_strnicmp(g_szWeaponNames[weaponID], args.Arg(1), 64))
+			{
+				foundID = (WeaponID_t)weaponID;
 				break;
-		    }
+			}
 		}
 
 		if (foundID == WEAPON_NONE)
 		{
-		    Warning("Could not give weapon with name %s, weapon not found!\n", args.Arg(1));
+			Warning("Could not give weapon with name %s, weapon not found!\n", args.Arg(1));
 			return;
 		}
 
-	    if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed(foundID))
-	    {
-	        Warning("The weapon %s is not allowed in this gamemode!\n", args.Arg(1));
+		if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed(foundID))
+		{
+			Warning("The weapon %s is not allowed in this gamemode!\n", args.Arg(1));
 			return;
-	    }
+		}
 
 		pPlayer->GiveWeapon(foundID);
 	}

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -851,11 +851,13 @@ CON_COMMAND( say_team, "Display player message to team" )
 static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
 {
 	const auto pCmdName = "give_weapon";
-	char *substring = nullptr;
+	char *pSubstring = nullptr;
 	if (Q_strstr(pPartial, pCmdName) && strlen(pPartial) > strlen(pCmdName) + 1)
 	{
-		substring = (char *)pPartial + strlen(pCmdName) + 1;
+		pSubstring = (char *)pPartial + strlen(pCmdName) + 1;
 	}
+
+	const bool bSubstringNullOrEmpty = !pSubstring || !pSubstring[0];
 
 	int current = 0;
 	// Skip over weapon_none
@@ -864,7 +866,7 @@ static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETI
 		if (!g_pGameModeSystem->GetGameMode()->WeaponIsAllowed((WeaponID_t)weaponID))
 			continue;
 
-		if ((!substring || !substring[0]) || Q_stristr(g_szWeaponNames[weaponID], substring))
+		if (bSubstringNullOrEmpty || Q_stristr(g_szWeaponNames[weaponID], pSubstring))
 		{
 			char command[COMMAND_COMPLETION_ITEM_LENGTH];
 			Q_snprintf(command, COMMAND_COMPLETION_ITEM_LENGTH, "%s %s", pCmdName, g_szWeaponNames[weaponID]);

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -892,6 +892,58 @@ CON_COMMAND( give, "Give item to player.\n\tArguments: <item_name>" )
 	}
 }
 
+static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
+{
+	const auto pCmdName = "give_weapon";
+	char *substring = nullptr;
+	if (Q_strstr(pPartial, pCmdName) && strlen(pPartial) > strlen(pCmdName) + 1)
+	{
+		substring = (char *)pPartial + strlen(pCmdName) + 1;
+	}
+
+	int current = 0;
+	// Skip over weapon_none
+	for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
+	{
+	    if ((!substring || !substring[0]) || Q_stristr(g_szWeaponNames[weaponID], substring))
+	    {
+			char command[COMMAND_COMPLETION_ITEM_LENGTH];
+			Q_snprintf(command, COMMAND_COMPLETION_ITEM_LENGTH, "%s %s", pCmdName, g_szWeaponNames[weaponID]);
+	        Q_strncpy(commands[current], command, COMMAND_COMPLETION_ITEM_LENGTH);
+			current++;
+	    }
+	}
+
+	return current;
+}
+
+CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCompletion)
+{
+	CBasePlayer *pPlayer = ToBasePlayer(UTIL_GetCommandClient());
+	if (pPlayer && !pPlayer->IsObserver() && args.ArgC() == 2)
+	{
+		bool bFound = false;
+		for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
+		{
+		    if (!Q_strnicmp(g_szWeaponNames[weaponID], args.Arg(1), 64))
+		    {
+	            bFound = true;
+				break;
+		    }
+		}
+
+		if (!bFound)
+		{
+		    Warning("Could not give weapon with name %s, weapon not found!\n", args.Arg(1));
+			return;
+		}
+
+		char item[64];
+		Q_strncpy(item, args.Arg(1), 64);
+		Q_strnlwr(item, 64);
+		pPlayer->GiveNamedItem(item);
+	}
+}
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------

--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -848,51 +848,6 @@ CON_COMMAND( say_team, "Display player message to team" )
 	}
 }
 
-
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-CON_COMMAND( give, "Give item to player.\n\tArguments: <item_name>" )
-{
-	CBasePlayer *pPlayer = ToBasePlayer( UTIL_GetCommandClient() ); 
-	if ( pPlayer 
-		&& (gpGlobals->maxClients == 1 || sv_cheats->GetBool()) 
-		&& args.ArgC() >= 2
-		&& !pPlayer->IsObserver() )
-	{
-		char item_to_give[ 256 ];
-		Q_strncpy( item_to_give, args[1], sizeof( item_to_give ) );
-		Q_strlower( item_to_give );
-
-		// Don't allow regular users to create point_servercommand entities for the same reason as blocking ent_fire
-		if ( !Q_stricmp( item_to_give, "point_servercommand" ) )
-		{
-			if ( engine->IsDedicatedServer() )
-			{
-				// We allow people with disabled autokick to do it, because they already have rcon.
-				if ( pPlayer->IsAutoKickDisabled() == false )
-					return;
-			}
-			else if ( gpGlobals->maxClients > 1 )
-			{
-				// On listen servers with more than 1 player, only allow the host to create point_servercommand.
-				CBasePlayer *pHostPlayer = UTIL_GetListenServerHost();
-				if ( pPlayer != pHostPlayer )
-					return;
-			}
-		}
-
-		// Dirty hack to avoid suit playing it's pickup sound
-		if ( !Q_stricmp( item_to_give, "item_suit" ) )
-		{
-			pPlayer->EquipSuit( false );
-			return;
-		}
-
-		string_t iszItem = AllocPooledString( item_to_give );	// Make a copy of the classname
-		pPlayer->GiveNamedItem( STRING(iszItem) );
-	}
-}
-
 static int WeaponCompletion(const char *pPartial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
 {
 	const auto pCmdName = "give_weapon";

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -379,6 +379,11 @@ bool CMomentumPlayer::BumpWeapon(CBaseCombatWeapon *pWeapon)
     return BaseClass::BumpWeapon(pWeapon);
 }
 
+bool CMomentumPlayer::Weapon_CanUse(CBaseCombatWeapon *pWeapon)
+{
+    return g_pGameModeSystem->GetGameMode()->WeaponIsAllowed(pWeapon->GetWeaponID());
+}
+
 void CMomentumPlayer::FlashlightTurnOn()
 {
     // Emit sound by default

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -384,6 +384,17 @@ bool CMomentumPlayer::Weapon_CanUse(CBaseCombatWeapon *pWeapon)
     return g_pGameModeSystem->GetGameMode()->WeaponIsAllowed(pWeapon->GetWeaponID());
 }
 
+bool CMomentumPlayer::GiveWeapon(WeaponID_t weapon)
+{
+    if (GetWeapon(weapon))
+    {
+        Warning("Failed to give the player the weapon %s, they already have it!\n", g_szWeaponNames[weapon]);
+        return false;
+    }
+
+    return GiveNamedItem(g_szWeaponNames[weapon]) != nullptr;
+}
+
 void CMomentumPlayer::FlashlightTurnOn()
 {
     // Emit sound by default

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -70,6 +70,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     // Make sure we don't pick up weapons we shouldn't (default behaviour is weird)
     bool BumpWeapon(CBaseCombatWeapon *pWeapon) OVERRIDE;
     bool Weapon_CanUse(CBaseCombatWeapon *pWeapon) override;
+    bool GiveWeapon(WeaponID_t weapon);
 
     // MOM_TODO: This is called when the player spawns so that HUD elements can be updated
     // void InitHUD() OVERRIDE;

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -69,6 +69,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     // Make sure we don't pick up weapons we shouldn't (default behaviour is weird)
     bool BumpWeapon(CBaseCombatWeapon *pWeapon) OVERRIDE;
+    bool Weapon_CanUse(CBaseCombatWeapon *pWeapon) override;
 
     // MOM_TODO: This is called when the player spawns so that HUD elements can be updated
     // void InitHUD() OVERRIDE;

--- a/mp/src/game/server/momentum/server_events.cpp
+++ b/mp/src/game/server/momentum/server_events.cpp
@@ -29,7 +29,17 @@ bool CMomServerEvents::Init()
         FileFindHandle_t handle;
         const auto pFound = g_pFullFileSystem->FindFirstEx("addons/*.vdf", "GAME", &handle);
         if (pFound)
-            Error("Boot the game with -mapping to be able to use plugins!");
+        {
+            char foundFile[MAX_PATH];
+            Q_snprintf(foundFile, MAX_PATH, "addons/%s", pFound);
+
+            char fullPath[MAX_PATH];
+            g_pFullFileSystem->RelativePathToFullPath_safe(foundFile, "GAME", fullPath);
+
+            Error("Boot the game with -mapping to be able to use plugins!\n"
+                "A common fix to this is to rename your \"addons\" folder in your TF2/CSS folders.\n"
+                "Full path to bad folder: %s", fullPath);
+        }
 
         g_pFullFileSystem->FindClose(handle);
 
@@ -39,6 +49,7 @@ bool CMomServerEvents::Init()
         UnloadConVarOrCommand("net_fakeloss");
         UnloadConVarOrCommand("net_droppackets");
         UnloadConVarOrCommand("net_fakejitter");
+        UnloadConVarOrCommand("net_blockmsg");
         UnloadConVarOrCommand("singlestep");
         UnloadConVarOrCommand("host_sleep");
         UnloadConVarOrCommand("map_edit");

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -182,33 +182,6 @@ ConVar  sv_player_display_usercommand_errors( "sv_player_display_usercommand_err
 ConVar  player_debug_print_damage( "player_debug_print_damage", "0", FCVAR_CHEAT, "When true, print amount and type of all damage received by player to console." );
 
 
-void CC_GiveCurrentAmmo( void )
-{
-	CBasePlayer *pPlayer = UTIL_PlayerByIndex(1);
-
-	if( pPlayer )
-	{
-		CBaseCombatWeapon *pWeapon = pPlayer->GetActiveWeapon();
-
-		if( pWeapon )
-		{
-            int ammoIndex = -1;
-			if( pWeapon->UsesPrimaryAmmo() )
-			{
-				ammoIndex = pWeapon->GetPrimaryAmmoType();
-			}
-            else if (pWeapon->UsesSecondaryAmmo() && pWeapon->HasSecondaryAmmo())
-            {
-                ammoIndex = pWeapon->GetSecondaryAmmoType();
-            }
-
-            pPlayer->GiveAmmo(g_pAmmoDef->MaxCarry(ammoIndex), ammoIndex);
-		}
-	}
-}
-static ConCommand givecurrentammo("givecurrentammo", CC_GiveCurrentAmmo, "Give a supply of ammo for current weapon..\n", FCVAR_CHEAT );
-
-
 // pl
 BEGIN_SIMPLE_DATADESC( CPlayerState )
 	// DEFINE_FIELD( netname, FIELD_STRING ),  // Don't stomp player name with what's in save/restore

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -5710,7 +5710,7 @@ void CBasePlayer::CheatImpulseCommands( int iImpulse )
 		EquipSuit();
 
 		// Give the player everything!
-		for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
+		for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
 		{
 		    GiveNamedItem(g_szWeaponNames[weaponID]);
 		}

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -5712,7 +5712,7 @@ void CBasePlayer::CheatImpulseCommands( int iImpulse )
 		// Give the player everything!
 		for (int weaponID = WEAPON_FIRST; weaponID < WEAPON_MAX; weaponID++)
 		{
-		    GiveNamedItem(g_szWeaponNames[weaponID]);
+			GiveNamedItem(g_szWeaponNames[weaponID]);
 		}
 		
 		gEvilImpulse101		= false;

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -5737,24 +5737,9 @@ void CBasePlayer::CheatImpulseCommands( int iImpulse )
 		EquipSuit();
 
 		// Give the player everything!
-        // MOM_TODO give the player all momentum guns
-		GiveNamedItem( "weapon_smg1" );
-		GiveNamedItem( "weapon_frag" );
-		GiveNamedItem( "weapon_crowbar" );
-		GiveNamedItem( "weapon_pistol" );
-		GiveNamedItem( "weapon_ar2" );
-		GiveNamedItem( "weapon_shotgun" );
-		GiveNamedItem( "weapon_physcannon" );
-		GiveNamedItem( "weapon_bugbait" );
-		GiveNamedItem( "weapon_rpg" );
-		GiveNamedItem( "weapon_357" );
-		GiveNamedItem( "weapon_crossbow" );
-#ifdef HL2_EPISODIC
-		// GiveNamedItem( "weapon_magnade" );
-#endif
-		if ( GetHealth() < 100 )
+		for (int weaponID = WEAPON_PISTOL; weaponID < WEAPON_MAX; weaponID++)
 		{
-			TakeHealth( 25, DMG_GENERIC );
+		    GiveNamedItem(g_szWeaponNames[weaponID]);
 		}
 		
 		gEvilImpulse101		= false;

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -122,8 +122,8 @@ void CGameMode_RJ::SetGameModeVars()
 void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
 {
 #ifdef GAME_DLL
-    pPlayer->GiveNamedItem("weapon_momentum_rocketlauncher");
-    pPlayer->GiveNamedItem("weapon_momentum_shotgun");
+    pPlayer->GiveWeapon(WEAPON_ROCKETLAUNCHER);
+    pPlayer->GiveWeapon(WEAPON_SHOTGUN);
 #endif
 }
 
@@ -153,8 +153,8 @@ void CGameMode_SJ::SetGameModeVars()
 void CGameMode_SJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
 {
 #ifdef GAME_DLL
-    pPlayer->GiveNamedItem("weapon_momentum_stickylauncher");
-    pPlayer->GiveNamedItem("weapon_momentum_pistol");
+    pPlayer->GiveWeapon(WEAPON_STICKYLAUNCHER);
+    pPlayer->GiveWeapon(WEAPON_PISTOL);
 #endif
 }
 

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -66,6 +66,13 @@ void CGameModeBase::ExecGameModeCfg()
 #endif
 }
 
+bool CGameMode_Surf::WeaponIsAllowed(WeaponID_t weapon)
+{
+    // Surf only blacklists weapons
+    return weapon != WEAPON_ROCKETLAUNCHER &&
+           weapon != WEAPON_STICKYLAUNCHER;
+}
+
 void CGameMode_Bhop::SetGameModeVars()
 {
     CGameModeBase::SetGameModeVars();
@@ -75,6 +82,13 @@ void CGameMode_Bhop::SetGameModeVars()
     sv_airaccelerate.SetValue(1000);
 }
 
+bool CGameMode_Bhop::WeaponIsAllowed(WeaponID_t weapon)
+{
+    // Bhop only blacklists weapons
+    return weapon != WEAPON_ROCKETLAUNCHER &&
+           weapon != WEAPON_STICKYLAUNCHER;
+}
+
 void CGameMode_KZ::SetGameModeVars()
 {
     CGameModeBase::SetGameModeVars();
@@ -82,6 +96,13 @@ void CGameMode_KZ::SetGameModeVars()
     // KZ-specific
     sv_airaccelerate.SetValue(100);
     sv_maxspeed.SetValue(250);
+}
+
+bool CGameMode_KZ::WeaponIsAllowed(WeaponID_t weapon)
+{
+    // KZ only blacklists weapons
+    return weapon != WEAPON_ROCKETLAUNCHER &&
+           weapon != WEAPON_STICKYLAUNCHER;
 }
 
 void CGameMode_RJ::SetGameModeVars()
@@ -98,6 +119,23 @@ void CGameMode_RJ::SetGameModeVars()
     sv_ground_trigger_fix.SetValue(false); // MOM_TODO Remove when bounce triggers have been implemented
 }
 
+void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
+{
+#ifdef GAME_DLL
+    pPlayer->GiveNamedItem("weapon_momentum_rocketlauncher");
+    pPlayer->GiveNamedItem("weapon_momentum_shotgun");
+#endif
+}
+
+bool CGameMode_RJ::WeaponIsAllowed(WeaponID_t weapon)
+{
+    // RJ only allows 3 weapons + paintgun:
+    return weapon == WEAPON_ROCKETLAUNCHER ||
+           weapon == WEAPON_SHOTGUN        ||
+           weapon == WEAPON_KNIFE          ||
+           weapon == WEAPON_PAINTGUN;
+}
+
 void CGameMode_SJ::SetGameModeVars()
 {
     CGameModeBase::SetGameModeVars();
@@ -112,20 +150,21 @@ void CGameMode_SJ::SetGameModeVars()
     sv_ground_trigger_fix.SetValue(false); // MOM_TODO Remove when bounce triggers have been implemented
 }
 
-void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
-{
-#ifdef GAME_DLL
-    pPlayer->GiveNamedItem("weapon_momentum_rocketlauncher");
-    pPlayer->GiveNamedItem("weapon_momentum_shotgun");
-#endif
-}
-
 void CGameMode_SJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
 {
 #ifdef GAME_DLL
     pPlayer->GiveNamedItem("weapon_momentum_stickylauncher");
     pPlayer->GiveNamedItem("weapon_momentum_pistol");
 #endif
+}
+
+bool CGameMode_SJ::WeaponIsAllowed(WeaponID_t weapon)
+{
+    // SJ only allows 3 weapons + paintgun:
+    return weapon == WEAPON_STICKYLAUNCHER ||
+           weapon == WEAPON_PISTOL         ||
+           weapon == WEAPON_KNIFE          ||
+           weapon == WEAPON_PAINTGUN;
 }
 
 void CGameMode_Tricksurf::SetGameModeVars()

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -22,6 +22,7 @@ public:
     virtual void        OnPlayerSpawn(CMomentumPlayer *pPlayer) = 0;
     virtual void        ExecGameModeCfg() = 0;
     virtual float       GetIntervalPerTick() = 0;
+    virtual bool        WeaponIsAllowed(WeaponID_t weapon) = 0;
 
     // Movement vars
     virtual float       GetViewScale() = 0;
@@ -45,6 +46,7 @@ public:
     bool PlayerHasAutoBhop() override { return true; }
     void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
     void ExecGameModeCfg() override;
+    bool WeaponIsAllowed(WeaponID_t weapon) override { return true; } // Unknown allows all weapons
 };
 
 class CGameMode_Surf : public CGameModeBase
@@ -55,6 +57,7 @@ public:
     const char* GetDiscordIcon() override { return "mom_icon_surf"; }
     const char* GetMapPrefix() override { return "surf_"; }
     const char* GetGameModeCfg() override { return "surf.cfg"; }
+    bool WeaponIsAllowed(WeaponID_t weapon) override;
 };
 
 class CGameMode_Bhop : public CGameModeBase
@@ -67,6 +70,7 @@ public:
     const char* GetGameModeCfg() override { return "bhop.cfg"; }
     float GetIntervalPerTick() override { return 0.01f; }
     void SetGameModeVars() override;
+    bool WeaponIsAllowed(WeaponID_t weapon) override;
 };
 
 class CGameMode_KZ : public CGameModeBase
@@ -80,6 +84,7 @@ public:
     float GetIntervalPerTick() override { return 0.01f; }
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
+    bool WeaponIsAllowed(WeaponID_t weapon) override;
 };
 
 class CGameMode_RJ : public CGameModeBase
@@ -95,6 +100,7 @@ public:
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
     void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
+    bool WeaponIsAllowed(WeaponID_t weapon) override;
 };
 
 class CGameMode_SJ : public CGameModeBase
@@ -110,6 +116,7 @@ class CGameMode_SJ : public CGameModeBase
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
     void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
+    bool WeaponIsAllowed(WeaponID_t weapon) override;
 };
 
 class CGameMode_Tricksurf : public CGameModeBase

--- a/mp/src/game/shared/momentum/weapon/weapon_def.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_def.cpp
@@ -284,7 +284,7 @@ CON_COMMAND(weapon_reload_scripts, "Reloads all weapon scripts.\n")
 
             FOR_EACH_VEC(vecCurrentWeps, i)
             {
-                pPlayer->GiveNamedItem(g_szWeaponNames[vecCurrentWeps[i]]);
+                pPlayer->GiveWeapon(vecCurrentWeps[i]);
             }
 
             pPlayer->Weapon_Switch(pPlayer->GetWeapon(iActiveWpn));
@@ -316,7 +316,7 @@ CON_COMMAND(weapon_reload_script_current, "Reloads weapon script for the current
         g_pWeaponDef->ReloadWeaponDefinition(iWpnID);
 
         const auto pName = g_szWeaponNames[iWpnID];
-        pPlayer->GiveNamedItem(pName);
+        pPlayer->GiveWeapon(iWpnID);
         pPlayer->Weapon_Switch(pPlayer->GetWeapon(iWpnID));
 
         Msg("Successfully reloaded weapon script for weapon %s.\n", pName);

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.cpp
@@ -213,11 +213,3 @@ void CMomentumRocketLauncher::PrimaryAttack()
     g_pMomentumGhostClient->SendDecalPacket(&rocket);
 #endif
 }
-
-bool CMomentumRocketLauncher::CanDeploy()
-{
-    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_RJ))
-        return false;
-
-    return BaseClass::CanDeploy();
-}

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.h
@@ -26,7 +26,6 @@ class CMomentumRocketLauncher : public CWeaponBaseGun
     const char *GetWorldModel() const OVERRIDE;
 
     bool Deploy() OVERRIDE;
-    bool CanDeploy() OVERRIDE;
 
     WeaponID_t GetWeaponID() const OVERRIDE { return WEAPON_ROCKETLAUNCHER; }
 

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -445,11 +445,3 @@ float CMomentumStickybombLauncher::GetChargeMaxTime()
 {
     return MOM_STICKYBOMB_MAX_CHARGE_TIME;
 }
-
-bool CMomentumStickybombLauncher::CanDeploy()
-{
-    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_SJ))
-        return false;
-
-    return BaseClass::CanDeploy();
-}

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -27,7 +27,6 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
     void PrimaryAttack() OVERRIDE;
     void SecondaryAttack() OVERRIDE;
 
-    bool CanDeploy() OVERRIDE;
     bool Deploy() OVERRIDE;
     bool Holster(CBaseCombatWeapon *pSwitchingTo) OVERRIDE;
     void WeaponIdle() OVERRIDE;

--- a/mp/src/game/shared/momentum/weapon/weapon_shareddefs.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_shareddefs.h
@@ -24,6 +24,9 @@ enum WeaponID_t
     WEAPON_STICKYLAUNCHER,
 
     WEAPON_MAX, // number of weapons weapon index
+
+    WEAPON_FIRST = WEAPON_PISTOL,
+    WEAPON_LAST = WEAPON_STICKYLAUNCHER,
 };
 
 static const char *const g_szWeaponNames[WEAPON_MAX] = 


### PR DESCRIPTION
This PR removes the "give" command as it can be abused to spawn any entity in the game. But fear not, this PR adds a `give_weapon` command that autocompletes based on the weapons you can spawn.

Gamemodes now define what weapons they allow, and the `UNKNOWN` gametype (maps with no recognized prefix) now allow every weapon type to be had. A note about this: the rocket and sticky launchers overlap by default so one will be on the ground. You can change the weapon script temporarily to put one in a different slot, or just drop the weapon to pick up the other.

I also went and fixed impulse 101 to properly give every momentum weapon there is so you don't need any aliases or anything to give them all. It does still require `sv_cheats 1`, though!

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->