### PR TITLE
Fix modal windows not preventing input to the game

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -553,6 +553,11 @@ int	ClientModeShared::KeyInput( int down, ButtonCode_t keynum, const char *pszCu
 {
 	if ( engine->Con_IsVisible() )
 		return 1;
+
+	if (vgui::input()->GetAppModalSurface() != 0)
+	{
+		return 0;
+	}
 	
 	// Should we start typing a message?
 	if ( pszCurrentBinding &&


### PR DESCRIPTION
Closes #326 

This PR fixes modal windows not properly being "modal" and allowing inputs to the game when open. An example can be found in the linked issue, but also when players fire when left clicking outside the color picker frame for the paintgun.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->