### PR TITLE
Add Leaderboard Toggle On Mouse Detach

### DIFF
--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -258,6 +258,21 @@ void CClientTimesDisplay::FillScoreBoard(bool bFullUpdate)
         m_pTimes->FillLeaderboards(bFullUpdate);
 }
 
+void CClientTimesDisplay::SetLeaderboardsHideHud(bool bState)
+{
+    C_BasePlayer* player = C_BasePlayer::GetLocalPlayer();
+    if (player)
+    {
+        if (bState)
+        {
+            player->m_Local.m_iHideHUD |= HIDEHUD_LEADERBOARDS;
+        }
+        else
+        {
+            player->m_Local.m_iHideHUD &= ~HIDEHUD_LEADERBOARDS;
+        }
+    }
+}
 //-----------------------------------------------------------------------------
 // Purpose: Center the dialog on the screen.  (vgui has this method on
 //          Frame, but we're an EditablePanel, need to roll our own.)

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -198,6 +198,12 @@ void CClientTimesDisplay::SetMouseInputEnabled(bool bState)
     if(bState)
         m_bToggledOpen = true;
 }
+void CClientTimesDisplay::SetVisible(bool bState)
+{
+    BaseClass::SetVisible(bState);
+
+    SetLeaderboardsHideHud(bState);
+}
 
 void CClientTimesDisplay::FireGameEvent(IGameEvent *event)
 {

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -25,6 +25,8 @@ CClientTimesDisplay::CClientTimesDisplay(IViewPort *pViewPort) : EditablePanel(n
 
     m_nCloseKey = BUTTON_CODE_INVALID;
 
+    m_bToggledOpen = false;
+
     m_pViewPort = pViewPort;
     // initialize dialog
     SetProportional(true);

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -195,9 +195,12 @@ void CClientTimesDisplay::SetMouseInputEnabled(bool bState)
 {
     BaseClass::SetMouseInputEnabled(bState);
 
-    if(bState)
+    if (bState)
+    {
         m_bToggledOpen = true;
+    }
 }
+
 void CClientTimesDisplay::SetVisible(bool bState)
 {
     BaseClass::SetVisible(bState);

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -182,6 +182,11 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
     }
 }
 
+void CClientTimesDisplay::SetMouseInputEnabled(bool bState)
+{
+    BaseClass::SetMouseInputEnabled(bState);
+}
+
 void CClientTimesDisplay::FireGameEvent(IGameEvent *event)
 {
     if (!event)

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -153,6 +153,15 @@ void CClientTimesDisplay::PerformLayout()
 //-----------------------------------------------------------------------------
 void CClientTimesDisplay::ShowPanel(bool bShow)
 {
+    if (m_bToggledOpen)
+    {
+        if (bShow == false)
+        {
+            m_bToggledOpen = false;
+        }
+        return;
+    }
+
     if (m_pTimes)
         m_pTimes->OnPanelShow(bShow);
 
@@ -185,6 +194,9 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
 void CClientTimesDisplay::SetMouseInputEnabled(bool bState)
 {
     BaseClass::SetMouseInputEnabled(bState);
+
+    if(bState)
+        m_bToggledOpen = true;
 }
 
 void CClientTimesDisplay::FireGameEvent(IGameEvent *event)

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -38,6 +38,8 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
 
     void ShowPanel(bool bShow) OVERRIDE;
 
+    void SetMouseInputEnabled(bool bState) OVERRIDE;
+
     // both vgui::Frame and IViewPortPanel define these, so explicitly define them here as passthroughs to vgui
     vgui::VPANEL GetVPanel(void) OVERRIDE { return BaseClass::GetVPanel(); }
     bool IsVisible() OVERRIDE { return BaseClass::IsVisible(); }

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -76,6 +76,8 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
 
     float m_flNextUpdateTime;
 
+    bool m_bToggledOpen;
+
     // methods
     void FillScoreBoard();
     void FillScoreBoard(bool pFullUpdate);

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -83,4 +83,6 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
     // methods
     void FillScoreBoard();
     void FillScoreBoard(bool pFullUpdate);
+
+    void SetLeaderboardsHideHud(bool bState);
 };

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -40,6 +40,8 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
 
     void SetMouseInputEnabled(bool bState) OVERRIDE;
 
+    void SetVisible(bool bState) OVERRIDE;
+
     // both vgui::Frame and IViewPortPanel define these, so explicitly define them here as passthroughs to vgui
     vgui::VPANEL GetVPanel(void) OVERRIDE { return BaseClass::GetVPanel(); }
     bool IsVisible() OVERRIDE { return BaseClass::IsVisible(); }

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -790,16 +790,6 @@ void CMomentumPlayer::DoMuzzleFlash()
     }
 }
 
-void CMomentumPlayer::PreThink()
-{
-    BaseClass::PreThink();
-
-    if (m_nButtons & IN_SCORE)
-        m_Local.m_iHideHUD |= HIDEHUD_LEADERBOARDS;
-    else
-        m_Local.m_iHideHUD &= ~HIDEHUD_LEADERBOARDS;
-}
-
 void CMomentumPlayer::ToggleDuckThisFrame(bool bState)
 {
     if (m_Local.m_bDucked != bState)

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -223,7 +223,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void ClearStartMark(int track);
 
     void DoMuzzleFlash() OVERRIDE;
-    void PreThink() OVERRIDE;
     void PostThink() OVERRIDE;
 
     int OnTakeDamage_Alive(const CTakeDamageInfo &info) OVERRIDE;


### PR DESCRIPTION
Closes #286 

When right clicking with the leaderboard open, it will now stay open when tab is released. Pressing and releasing tab again will close the leaderboard.

A flag was added to the leaderboard class to track this state, and in order to make sure the hud elements do not reappear when tab is released, the logic updating `HIDEHUD_LEADERBOARD` was moved to the client so that it could access the viewport and the visibility of the leaderboard.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->