### PR TITLE
Fix paint doing damage

### DIFF
--- a/mp/src/game/client/momentum/fx_mom_impacts.cpp
+++ b/mp/src/game/client/momentum/fx_mom_impacts.cpp
@@ -14,6 +14,8 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+static MAKE_TOGGLE_CONVAR(mom_paintgun_limit_to_world, "0", FCVAR_ARCHIVE, "Limits applying paint decals to only world geometry. 0 = OFF, 1 = ON\n");
+
 //-----------------------------------------------------------------------------
 // Purpose: Handle gauss impacts
 //-----------------------------------------------------------------------------
@@ -105,16 +107,13 @@ bool Painting(Vector &vecOrigin, Vector &vecStart, int iHitbox, C_BaseEntity *pE
     if (!pEntity)
         return false;
 
-    if ((pEntity->entindex() == 0) && (iHitbox != 0))
+    if (pEntity->entindex() == 0 && iHitbox != 0)
     {
-        staticpropmgr->AddColorDecalToStaticProp(vecStart, traceExt, iHitbox - 1, decalNumber, true, tr, true,
-                                                    color);
+        staticpropmgr->AddColorDecalToStaticProp(vecStart, traceExt, iHitbox - 1, decalNumber, true, tr, true, color);
     }
     else
     {
-        // Here we deal with decals on entities.
-        pEntity->AddColoredDecal(vecStart, traceExt, vecOrigin, iHitbox, decalNumber, true, tr, color,
-            ADDDECAL_TO_ALL_LODS, nFlags);
+        pEntity->AddColoredDecal(vecStart, traceExt, vecOrigin, iHitbox, decalNumber, true, tr, color, ADDDECAL_TO_ALL_LODS, nFlags);
     }
 
     return true;
@@ -127,8 +126,7 @@ void PaintingCallback(const CEffectData &data)
     Vector vecOrigin, vecStart, vecShotDir;
     int iMaterial, iDamageType, iHitbox;
     short nSurfaceProp;
-    C_BaseEntity *pEntity =
-        ParseImpactData(data, &vecOrigin, &vecStart, &vecShotDir, nSurfaceProp, iMaterial, iDamageType, iHitbox);
+    const auto pEntity = ParseImpactData(data, &vecOrigin, &vecStart, &vecShotDir, nSurfaceProp, iMaterial, iDamageType, iHitbox);
     if (!pEntity)
     {
         // This happens for impacts that occur on an object that's then destroyed.
@@ -138,8 +136,8 @@ void PaintingCallback(const CEffectData &data)
         return;
     }
 
-    // Let's only allow the world for now...
-    if (pEntity->entindex() != 0)
+    // Let's only allow the world if the user wants us to
+    if (pEntity->entindex() != 0 && mom_paintgun_limit_to_world.GetBool())
         return;
 
     Color color;
@@ -178,8 +176,7 @@ void KnifeSlash(const CEffectData &data)
     int iMaterial, iDamageType, iHitbox;
     short nSurfaceProp;
 
-    C_BaseEntity *pEntity =
-        ParseImpactData(data, &vecOrigin, &vecStart, &vecShotDir, nSurfaceProp, iMaterial, iDamageType, iHitbox);
+    const auto pEntity = ParseImpactData(data, &vecOrigin, &vecStart, &vecShotDir, nSurfaceProp, iMaterial, iDamageType, iHitbox);
 
     if (!pEntity)
         return;

--- a/mp/src/game/shared/ammodef.cpp
+++ b/mp/src/game/shared/ammodef.cpp
@@ -104,7 +104,7 @@ CAmmoGrenade::CAmmoGrenade()
 CAmmoPaint::CAmmoPaint()
 {
     m_WeaponID = WEAPON_PAINTGUN;
-    m_iDamageAmount = 1;
+    m_iDamageAmount = 0;
     m_iPenetrationAmount = 0;
 }
 


### PR DESCRIPTION
Closes #630

This fixes paint being able to do damage to open doors while having other guns (rocket/sticky launchers) out with `+paint`. Also introduced a `mom_paintgun_limit_to_world` cvar that lets players toggle if paint should apply to just the world or everything possible.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->