### PR TITLE
Fixed map finish panel labels not being reset properly

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -100,7 +100,7 @@ void CHudMapFinishedDialog::FireGameEvent(IGameEvent* pEvent)
     {
         m_bCanClose = true;
 
-        SetRunSaved(pEvent->GetBool("save"));
+        SetRunSaved(pEvent->GetBool("save") && IsVisible());
         SetCurrentPage(m_iCurrentPage);
         // MOM_TODO: There's a file name parameter as well, do we want to use it here?
     }
@@ -111,9 +111,10 @@ void CHudMapFinishedDialog::FireGameEvent(IGameEvent* pEvent)
     else if (FStrEq(pEvent->GetName(), "run_upload"))
     {
         const auto bPosted = pEvent->GetBool("run_posted");
-        SetRunUploaded(bPosted);
-        if (bPosted)
+        // don't write to labels if panel is not visible
+        if (bPosted && IsVisible())
         {
+            SetRunUploaded(true);
             const auto cXP = pEvent->GetInt("cos_xp");
             m_pXPGainCosmetic->SetVisible(cXP > 0);
             if (cXP)


### PR DESCRIPTION
Closes #300 . This is a branch off of PR #633

Added a check in the API calls to see if the panel is visible before writing to labels. This solves the issue of the map finished panel not being reset properly when using `mom_reset` / `mom_restart` (#300).

The fix is done as described by Gocnak.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review