### PR TITLE
Hud/game text being activated by online ghosts

### DIFF
--- a/mp/src/game/server/maprules.cpp
+++ b/mp/src/game/server/maprules.cpp
@@ -353,19 +353,9 @@ void CGameText::Display( CBaseEntity *pActivator )
 	{
 		UTIL_HudMessageAll( m_textParms, MessageGet() );
 	}
-	else
+    else if (pActivator && pActivator->IsPlayer())
 	{
-		// If we're in singleplayer, show the message to the player.
-		if ( gpGlobals->maxClients == 1 )
-		{
-			CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
-			UTIL_HudMessage( pPlayer, m_textParms, MessageGet() );
-		}
-		// Otherwise show the message to the player that triggered us.
-		else if ( pActivator && pActivator->IsNetClient() )
-		{
-			UTIL_HudMessage( ToBasePlayer( pActivator ), m_textParms, MessageGet() );
-		}
+		UTIL_HudMessage( ToBasePlayer( pActivator ), m_textParms, MessageGet() );
 	}
 }
 


### PR DESCRIPTION
Closes #644 

Changed the `Display` function of `CGameText` to show local hud text popups only if the activator is the player. Tested with hex.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review