### PR TITLE
fixed edge case causing lobby panel to not have mouse input

### DIFF
--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -233,6 +233,8 @@ int ClientModeMOMNormal::HandleSpectatorKeyInput(int down, ButtonCode_t keynum, 
             m_pSpectatorGUI->SetMouseInputEnabled(!bMouseState);
             if (m_pHudMapFinished && m_pHudMapFinished->IsVisible())
                 m_pHudMapFinished->SetMouseInputEnabled(!bMouseState);
+            if (m_pLobbyMembers && m_pLobbyMembers->IsVisible())
+                m_pLobbyMembers->SetMouseInputEnabled(!bMouseState);
             // MOM_TODO: re-enable this in alpha+ when we add movie-style controls to the spectator menu!
             // m_pViewport->ShowPanel(PANEL_SPECMENU, true);
 


### PR DESCRIPTION
Closes #642 . This issue should be apart of 0.8.5.

Fixed edge case where the lobby members panel did not have mouse input when it should:
In spectate, the key bound to `+duck` now properly enables mouse on lobby members panel if it is open. Did this exactly how it is done for the map finished panel.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review