### PR TITLE
Prevented spectator mode & player changes while map finished or lobby members panel is open

### DIFF
--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -241,19 +241,19 @@ int ClientModeMOMNormal::HandleSpectatorKeyInput(int down, ButtonCode_t keynum, 
             return 0; // we handled it, don't handle twice or send to server
         }
 
-        if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack") &&
-            !m_pSpectatorGUI->IsMouseInputEnabled())
+        bool shouldEatSpecInput = (m_pHudMapFinished && m_pHudMapFinished->IsVisible()) ||
+            (m_pLobbyMembers && m_pLobbyMembers->IsVisible()) || m_pSpectatorGUI->IsMouseInputEnabled();
+        if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_next");
             return 0;
         }
-        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack2") &&
-                 !m_pSpectatorGUI->IsMouseInputEnabled())
+        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack2") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_prev");
             return 0;
         }
-        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+jump"))
+        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+jump") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_mode");
             return 0;

--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -243,17 +243,17 @@ int ClientModeMOMNormal::HandleSpectatorKeyInput(int down, ButtonCode_t keynum, 
 
         bool shouldEatSpecInput = (m_pHudMapFinished && m_pHudMapFinished->IsVisible()) ||
             (m_pLobbyMembers && m_pLobbyMembers->IsVisible()) || m_pSpectatorGUI->IsMouseInputEnabled();
-        if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack") && !shouldEatSpecInput)
+        if (down && pszCurrentBinding && FStrEq(pszCurrentBinding, "+attack") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_next");
             return 0;
         }
-        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+attack2") && !shouldEatSpecInput)
+        else if (down && pszCurrentBinding && FStrEq(pszCurrentBinding, "+attack2") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_prev");
             return 0;
         }
-        else if (down && pszCurrentBinding && !Q_strcmp(pszCurrentBinding, "+jump") && !shouldEatSpecInput)
+        else if (down && pszCurrentBinding && FStrEq(pszCurrentBinding, "+jump") && !shouldEatSpecInput)
         {
             engine->ClientCmd("spec_mode");
             return 0;


### PR DESCRIPTION
Closes #648 

Prevented spectator mode & player changes while map finished or lobby members panel is open. This prevents the spec command bound to `mouse2` (either `+attack`, `+attack2`, or `+jump`) from executing when enabling mouse input via right click on these panels.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review