### PR TITLE
Reset chargemeter state regardless of whether stickylauncher is active

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -907,7 +907,7 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
             {
                 if (g_pGameModeSystem->GameModeIs(GAMEMODE_SJ))
                 {
-                    const auto pLauncher = dynamic_cast<CMomentumStickybombLauncher *>(GetActiveWeapon());
+                    const auto pLauncher = static_cast<CMomentumStickybombLauncher *> (GetWeapon(WEAPON_STICKYLAUNCHER));
                     if (pLauncher)
                     {
                         pLauncher->SetChargeEnabled(false);
@@ -1042,7 +1042,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
         if (g_pGameModeSystem->GameModeIs(GAMEMODE_SJ))
         {
             // Re-enable charge on start zone exit and set charge time to 0 to prevent pre-charged stickies
-            const auto pLauncher = dynamic_cast<CMomentumStickybombLauncher *>(GetActiveWeapon());
+            const auto pLauncher = static_cast<CMomentumStickybombLauncher *>(GetWeapon(WEAPON_STICKYLAUNCHER));
             if (pLauncher)
             {
                 pLauncher->SetChargeEnabled(true);


### PR DESCRIPTION
Closes #652 , which should be apart of the 0.8.5 project.

Charge meter state was only being reset in the start zone enter/exit code if the sticky launcher was the active weapon. Changed this to reset the state regardless of what weapon is currently active.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review