### PR TITLE
Stopped stickybomb from firing before releasing mouse1 when charge is disabled

### DIFF
--- a/mp/game/momentum/scripts/game_sounds_momentum_weapons.txt
+++ b/mp/game/momentum/scripts/game_sounds_momentum_weapons.txt
@@ -148,6 +148,14 @@
     "wave"		"weapons/stickybomblauncher_charge_up.wav"
 }
 
+"StickybombLauncher.ChargeStop"
+{
+    "channel"	"CHAN_AUTO"
+    "volume"	"1.0"
+    "soundlevel"	"SNDLVL_94dB"
+    "wave"		"common/wpn_denyselect.wav"
+}
+
 "StickybombLauncher.Explosion"
 {
     "channel" "CHAN_WEAPON"

--- a/mp/game/momentum/scripts/weapon_momentum_stickylauncher.txt
+++ b/mp/game/momentum/scripts/weapon_momentum_stickylauncher.txt
@@ -31,6 +31,7 @@ WeaponData
         "detonate"          "StickybombLauncher.Detonate"
         "deny"              "StickybombLauncher.Deny"
         "charge"            "StickybombLauncher.Charge"
+        "chargestop"        "StickybombLauncher.ChargeStop"
     }
     
     // Weapon particles

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -910,7 +910,6 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
                     const auto pLauncher = static_cast<CMomentumStickybombLauncher *> (GetWeapon(WEAPON_STICKYLAUNCHER));
                     if (pLauncher)
                     {
-                        pLauncher->StopChargeSound();
                         pLauncher->SetChargeEnabled(false);
                     }
                 }

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -910,6 +910,7 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
                     const auto pLauncher = static_cast<CMomentumStickybombLauncher *> (GetWeapon(WEAPON_STICKYLAUNCHER));
                     if (pLauncher)
                     {
+                        pLauncher->StopChargeSound();
                         pLauncher->SetChargeEnabled(false);
                     }
                 }

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -286,13 +286,17 @@ float CMomentumStickybombLauncher::CalculateProjectileSpeed(float flProgress)
                            MOM_STICKYBOMB_MIN_CHARGE_VEL, MOM_STICKYBOMB_MAX_CHARGE_VEL);
 }
 
-void CMomentumStickybombLauncher::StopChargeSound() 
+bool CMomentumStickybombLauncher::SetChargeEnabled(bool state) 
 {
-    if (m_flChargeBeginTime > 0) // stop only if charging
+    if (!state)
     {
         StopWeaponSound(GetWeaponSound("charge"));
-        WeaponSound(GetWeaponSound("chargestop"));
+        if (m_flChargeBeginTime > 0) // was charging when disabled
+        {
+            WeaponSound(GetWeaponSound("chargestop"));
+        }
     }
+    return m_bIsChargeEnabled.Set(state); 
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -286,6 +286,15 @@ float CMomentumStickybombLauncher::CalculateProjectileSpeed(float flProgress)
                            MOM_STICKYBOMB_MIN_CHARGE_VEL, MOM_STICKYBOMB_MAX_CHARGE_VEL);
 }
 
+void CMomentumStickybombLauncher::StopChargeSound() 
+{
+    if (m_flChargeBeginTime > 0) // stop only if charging
+    {
+        StopWeaponSound(GetWeaponSound("charge"));
+        WeaponSound(GetWeaponSound("chargestop"));
+    }
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Add stickybombs to our list as they're fired
 //-----------------------------------------------------------------------------

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -231,7 +231,15 @@ void CMomentumStickybombLauncher::PrimaryAttack()
         float flTotalChargeTime = gpGlobals->curtime - m_flChargeBeginTime;
         if (flTotalChargeTime >= MOM_STICKYBOMB_MAX_CHARGE_TIME)
         {
-            LaunchGrenade();
+            if (m_bIsChargeEnabled)
+            {
+                LaunchGrenade();
+            }
+            else
+            {
+                // stop this from getting too large
+                m_flChargeBeginTime = 0.0f;
+            }
         }
     }
 }

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -48,6 +48,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
 
     bool IsChargeEnabled() { return m_bIsChargeEnabled.Get(); }
     bool SetChargeEnabled(bool state) { return m_bIsChargeEnabled.Set(state); }
+    void StopChargeSound();
 
     CMomStickybomb *GetStickyByCount(int count) { return m_Stickybombs[count]; }
     void SetChargeBeginTime(float value) { m_flChargeBeginTime = value; }

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -47,8 +47,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
     float CalculateProjectileSpeed(float flProgress);
 
     bool IsChargeEnabled() { return m_bIsChargeEnabled.Get(); }
-    bool SetChargeEnabled(bool state) { return m_bIsChargeEnabled.Set(state); }
-    void StopChargeSound();
+    bool SetChargeEnabled(bool state);
 
     CMomStickybomb *GetStickyByCount(int count) { return m_Stickybombs[count]; }
     void SetChargeBeginTime(float value) { m_flChargeBeginTime = value; }


### PR DESCRIPTION
Closes #655 

Holding down `+attack` when charge is disabled will no longer fire a sticky before it is released. That is, apart from their velocity, stickybombs are acting as if they are charged when charging is disabled.
Added a check to see if charging is enabled in the spot that fires a sticky when it's fully charged.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review