### PR TITLE
Filter run comparison by track

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
@@ -157,6 +157,7 @@ void C_RunComparisons::LoadComparisons()
 
         const float tickRate = pRunData->m_flTickRate;
         const int runFlags = pRunData->m_iRunFlags;
+        const int currentTrack = pRunData->m_iCurrentTrack;
 
         if (!m_bLoadedComparison || !CloseEnough(tickRate, m_fLoadedTickRate) || runFlags != m_iLoadedRunFlags)
         {

--- a/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
@@ -157,13 +157,12 @@ void C_RunComparisons::LoadComparisons()
 
         const float tickRate = pRunData->m_flTickRate;
         const int runFlags = pRunData->m_iRunFlags;
-        const int currentTrack = pRunData->m_iCurrentTrack;
 
         if (!m_bLoadedComparison || !CloseEnough(tickRate, m_fLoadedTickRate) || runFlags != m_iLoadedRunFlags)
         {
             UnloadComparisons();
             m_rcCurrentComparison = new RunCompare_t();
-            m_bLoadedComparison = MomUtil::GetRunComparison(szMapName, tickRate, currentTrack, runFlags, m_rcCurrentComparison);
+            m_bLoadedComparison = MomUtil::GetRunComparison(szMapName, tickRate, pRunData->m_iCurrentTrack, runFlags, m_rcCurrentComparison);
         }
     }
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
@@ -163,7 +163,7 @@ void C_RunComparisons::LoadComparisons()
         {
             UnloadComparisons();
             m_rcCurrentComparison = new RunCompare_t();
-            m_bLoadedComparison = MomUtil::GetRunComparison(szMapName, tickRate, runFlags, m_rcCurrentComparison);
+            m_bLoadedComparison = MomUtil::GetRunComparison(szMapName, tickRate, currentTrack, runFlags, m_rcCurrentComparison);
         }
     }
 }

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -359,7 +359,7 @@ inline bool CheckReplayB(CMomReplayBase *pFastest, CMomReplayBase *pCheck, float
 }
 
 //!!! NOTE: The value returned here MUST BE DELETED, otherwise you get a memory leak!
-CMomReplayBase *MomUtil::GetBestTime(const char *szMapName, float tickrate, uint32 flags)
+CMomReplayBase *MomUtil::GetBestTime(const char *szMapName, float tickrate, int trackNumber, uint32 flags)
 {
     if (szMapName)
     {
@@ -380,7 +380,7 @@ CMomReplayBase *MomUtil::GetBestTime(const char *szMapName, float tickrate, uint
             CMomReplayBase *pBase = g_ReplayFactory.LoadReplayFile(pReplayPath, false);
             assert(pBase != nullptr);
                 
-            if (CheckReplayB(pFastest, pBase, tickrate, flags))
+            if (pBase->GetTrackNumber() == trackNumber && CheckReplayB(pFastest, pBase, tickrate, flags))
             {
                 pFastest = pBase;
             }
@@ -398,11 +398,11 @@ CMomReplayBase *MomUtil::GetBestTime(const char *szMapName, float tickrate, uint
     return nullptr;
 }
 
-bool MomUtil::GetRunComparison(const char *szMapName, const float tickRate, const int flags, RunCompare_t *into)
+bool MomUtil::GetRunComparison(const char *szMapName, const float tickRate, const int trackNumber, const int flags, RunCompare_t *into)
 {
     if (into && szMapName)
     {
-        CMomReplayBase *bestRun = GetBestTime(szMapName, tickRate, flags);
+        CMomReplayBase *bestRun = GetBestTime(szMapName, tickRate, trackNumber, flags);
         if (bestRun)
         {
             // MOM_TODO: this may not be a PB, for now it is, but we'll load times from online.

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -340,11 +340,11 @@ void MomUtil::GetHexStringFromColor(const Color& color, char* pBuffer, int maxLe
     Q_snprintf(pBuffer, maxLen, "%08x", colorHex);
 }
 
-inline bool CheckReplayB(CMomReplayBase *pFastest, CMomReplayBase *pCheck, float tickrate, uint32 flags)
+inline bool CheckReplayB(CMomReplayBase *pFastest, CMomReplayBase *pCheck, float tickrate, int trackNumber, uint32 flags)
 {
     if (pCheck)
     {
-        if (pCheck->GetRunFlags() == flags && CloseEnough(tickrate, pCheck->GetTickInterval(), FLT_EPSILON))
+        if (pCheck->GetRunFlags() == flags && pCheck->GetTrackNumber() == trackNumber && CloseEnough(tickrate, pCheck->GetTickInterval(), FLT_EPSILON))
         {
             if (pFastest)
             {
@@ -380,7 +380,7 @@ CMomReplayBase *MomUtil::GetBestTime(const char *szMapName, float tickrate, int 
             CMomReplayBase *pBase = g_ReplayFactory.LoadReplayFile(pReplayPath, false);
             assert(pBase != nullptr);
                 
-            if (pBase->GetTrackNumber() == trackNumber && CheckReplayB(pFastest, pBase, tickrate, flags))
+            if (CheckReplayB(pFastest, pBase, tickrate, trackNumber, flags))
             {
                 pFastest = pBase;
             }

--- a/mp/src/game/shared/momentum/util/mom_util.h
+++ b/mp/src/game/shared/momentum/util/mom_util.h
@@ -44,8 +44,8 @@ namespace MomUtil
     // Converts an ISO-8601 date string to a time_t
     bool ISODateToTimeT(const char *pISODate, time_t *out);
 
-    CMomReplayBase *GetBestTime(const char *szMapName, float tickrate, uint32 flags = 0);
-    bool GetRunComparison(const char *szMapName, const float tickRate, const int flags, RunCompare_t *into);
+    CMomReplayBase *GetBestTime(const char *szMapName, float tickrate, int trackNumber, uint32 flags = 0);
+    bool GetRunComparison(const char *szMapName, const float tickRate, const int trackNumber, const int flags, RunCompare_t *into);
     void FillRunComparison(const char *compareName, CMomRunStats *kvBestRun, RunCompare_t *into);
 
     // Checks if source is within a rectangle formed by leftCorner and rightCorner


### PR DESCRIPTION
Closes #647

MomUtil::GetRunComparison and subsequently MomUtil::GetBestTime now compare against a given track number when looking up runs. Runs that are not on the same track as the current player are ignored.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->