### PR TITLE
Extra Functionality for CvarComboBox

### DIFF
--- a/mp/src/public/tier1/convar.h
+++ b/mp/src/public/tier1/convar.h
@@ -502,6 +502,9 @@ public:
     const char *GetString(void) const;
     Color GetColor(void) const;
 
+    bool GetMin(float &minVal) const;
+    bool GetMax(float &maxVal) const;
+
 	void SetValue( const char *pValue );
 	void SetValue( float flValue );
 	void SetValue( int nValue );
@@ -559,6 +562,16 @@ FORCEINLINE_CVAR Color ConVarRef::GetColor() const
     extern void CONVAR_StringToColor(Color & color, const char *pString);
     CONVAR_StringToColor(clr, m_pConVarState->m_pszString);
     return clr;
+}
+
+FORCEINLINE_CVAR bool ConVarRef::GetMin(float &minVal) const
+{ 
+    return m_pConVarState->GetMin(minVal);
+}
+
+FORCEINLINE_CVAR bool ConVarRef::GetMax(float &maxVal) const
+{ 
+    return m_pConVarState->GetMax(maxVal);
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/public/vgui_controls/CvarComboBox.h
+++ b/mp/src/public/vgui_controls/CvarComboBox.h
@@ -30,7 +30,7 @@ class CvarComboBox : public ComboBox
     MESSAGE_FUNC(OnTextChanged, "TextChanged");
 
     ConVarRef m_cvar;
-    int m_iStartValue;
+    int m_iStartValue, m_iCvarMin, m_iCvarMax;
     bool m_bIgnoreMissingCvar;
 };
 

--- a/mp/src/public/vgui_controls/CvarComboBox.h
+++ b/mp/src/public/vgui_controls/CvarComboBox.h
@@ -25,6 +25,8 @@ class CvarComboBox : public ComboBox
     void GetSettings(KeyValues *outResources) OVERRIDE;
     void InitSettings() OVERRIDE;
 
+    int AddItem(const char *itemText, const KeyValues *userData) OVERRIDE;
+
   private:
     MESSAGE_FUNC(OnApplyChanges, "ApplyChanges");
     MESSAGE_FUNC(OnTextChanged, "TextChanged");

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -20,9 +20,9 @@ CvarComboBox::CvarComboBox(Panel *parent, const char *panelName, int numLines, b
 {
     InitSettings();
     m_bIgnoreMissingCvar = ignoreMissingCvar;
-    float m_flCvarMin, m_flCvarMax;
-    m_iCvarMin = m_cvar.GetMin(m_flCvarMin) ? RoundFloatToInt(m_flCvarMin) : 0;
-    m_iCvarMax = m_cvar.GetMin(m_flCvarMax) ? RoundFloatToInt(m_flCvarMax) : 0;
+    float flCvarMin, flCvarMax;
+    m_iCvarMin = m_cvar.GetMin(flCvarMin) ? RoundFloatToInt(flCvarMin) : 0;
+    m_iCvarMax = m_cvar.GetMax(flCvarMax) ? RoundFloatToInt(flCvarMax) : 0;
     m_iStartValue = 0;
 
     AddActionSignalTarget(this);

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -23,23 +23,24 @@ CvarComboBox::CvarComboBox(Panel *parent, const char *panelName, int numLines, b
     float m_flCvarMin, m_flCvarMax;
     m_iCvarMin = m_cvar.GetMin(m_flCvarMin) ? RoundFloatToInt(m_flCvarMin) : 0;
     m_iCvarMax = m_cvar.GetMin(m_flCvarMax) ? RoundFloatToInt(m_flCvarMax) : 0;
-    float m_flCvarMin;
-    if (m_cvar.GetMin(m_flCvarMin))
-    {
-        m_iCvarMin = RoundFloatToInt(m_flCvarMin);
-    }
-    else
-    {
-        m_iCvarMin = 0;
-    }
     m_iStartValue = 0;
 
-    Reset();
     AddActionSignalTarget(this);
 }
 
 CvarComboBox::~CvarComboBox()
 {
+}
+
+int CvarComboBox::AddItem(const char* itemText, const KeyValues* userData)
+{
+    int iRtnVal = BaseClass::AddItem(itemText, userData);
+    // reset combobox when it's full
+    if (GetItemCount() >= m_iCvarMax - m_iCvarMin) 
+    {
+        Reset();
+    }
+    return iRtnVal;
 }
 
 void CvarComboBox::OnThink()

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -20,6 +20,18 @@ CvarComboBox::CvarComboBox(Panel *parent, const char *panelName, int numLines, b
 {
     InitSettings();
     m_bIgnoreMissingCvar = ignoreMissingCvar;
+    float m_flCvarMin, m_flCvarMax;
+    m_iCvarMin = m_cvar.GetMin(m_flCvarMin) ? RoundFloatToInt(m_flCvarMin) : 0;
+    m_iCvarMax = m_cvar.GetMin(m_flCvarMax) ? RoundFloatToInt(m_flCvarMax) : 0;
+    float m_flCvarMin;
+    if (m_cvar.GetMin(m_flCvarMin))
+    {
+        m_iCvarMin = RoundFloatToInt(m_flCvarMin);
+    }
+    else
+    {
+        m_iCvarMin = 0;
+    }
     m_iStartValue = 0;
 
     Reset();
@@ -34,7 +46,7 @@ void CvarComboBox::OnThink()
 {
     if (m_cvar.IsValid())
     {
-        if (m_cvar.GetInt() != m_iStartValue)
+        if (m_cvar.GetInt() != m_iStartValue + m_iCvarMin)
             Reset();
     }
 }
@@ -50,7 +62,7 @@ void CvarComboBox::ApplyChanges()
         return;
 
     m_iStartValue = GetActiveItem();
-    m_cvar.SetValue(m_iStartValue);
+    m_cvar.SetValue(m_iStartValue + m_iCvarMin);
 }
 
 void CvarComboBox::Reset()
@@ -59,12 +71,12 @@ void CvarComboBox::Reset()
         return;
 
     m_iStartValue = m_cvar.GetInt();
-    ActivateItemByRow(m_iStartValue);
+    ActivateItemByRow(m_iStartValue - m_iCvarMin);
 }
 
 bool CvarComboBox::HasBeenModified()
 {
-    return GetActiveItem() != m_iStartValue;
+    return GetActiveItem() != m_iStartValue - m_iCvarMin;
 }
 
 void CvarComboBox::OnTextChanged()


### PR DESCRIPTION
Related to #592 

In converting cvar-tied comboboxes to cvarcombobox, I found that it did not have the needed functionality to use it on cvars with minimum values other than 0. To do this I 

1. Added `GetMin` and `GetMax` functions to `ConVarRef`.
2. Used `GetMin` to change how the combobox indexes.
3. Used `GetMax` to solve an issue where the combobox was not setting a value in some cases.
    - The `Reset()` call in the constructor was removed as it didn't do anything since the items have not been added to the combobox yet.
    - Added an `AddItem` override to call `Reset()` when all the items have been added to the combobox.

After this was done, the comboboxes in the momentum settings pages were converted to use this. 

The GameUI comboboxes were not changed as the current implementation `CvarComboBox` does not support

1. Cvars that have non-linear values, such as `mat_forceaniso`.
2. Comboboxes that set multiple cvars.
    - eg. Filtering mode combobox sets `mat_trilinear` or `mat_forceaniso` depending on the active item.

I believe `CvarComboBox` will need more functionality, perhaps for a different PR as this is mainly converting the momentum settings pages.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review