### PR TITLE
Fix weapon grabbing bugs

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -376,6 +376,7 @@ bool CMomentumPlayer::BumpWeapon(CBaseCombatWeapon *pWeapon)
     {
         // Switch to that weapon for convenience
         Weapon_Switch(pCurrWeapon);
+        UTIL_Remove(pWeapon);
         return false;
     }
     // Otherwise we can try to pick up that weapon

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -5370,7 +5370,7 @@ CBaseEntity	*CBasePlayer::GiveNamedItem( const char *pszName, int iSubType )
 		return NULL;
 	}
 
-	pent->SetLocalOrigin( GetLocalOrigin() );
+	pent->SetLocalOrigin( CollisionProp()->WorldSpaceCenter() );
 	pent->AddSpawnFlags( SF_NORESPAWN );
 
 	CBaseCombatWeapon *pWeapon = dynamic_cast<CBaseCombatWeapon*>( (CBaseEntity*)pent );
@@ -6099,12 +6099,6 @@ bool CBasePlayer::BumpWeapon( CBaseCombatWeapon *pWeapon )
 	{
 		// Don't let the player touch the item unless unobstructed
 		if ( !UTIL_ItemCanBeTouchedByPlayer( pWeapon, this ) && !gEvilImpulse101 )
-			return false;
-	}
-	else
-	{
-		// Don't let the player fetch weapons through walls (use MASK_SOLID so that you can't pickup through windows)
-		if( pWeapon->FVisible( this, MASK_SOLID ) == false && !(GetFlags() & FL_NOTARGET) )
 			return false;
 	}
 	


### PR DESCRIPTION
Closes #659 

This PR moves weapon spawn locations from giving to the center of the player's bounding box for a better chance that it will not spawn in the floor, as the issue describes. Furthermore, the check causing the gun to not be picked up through the floor was removed, as this is not a competitive game so picking up guns through walls *should* be fine (maps that use weapons do a pretty decent job of not putting them near really thin walls).

And when it comes to grabbing weapons on the map (not given to the player), the extra weapons are removed upon bumping them if the player already has the weapon, preventing annoying constant weapon switching.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->