### PR TITLE
Keep CRLF for surfaceproperties files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,3 +51,6 @@ ccache binary
 gtest_output_test_golden_lin.txt binary
 
 *.res text
+
+surfaceproperties_cs.txt text eol=crlf
+surfaceproperties_tf.txt text eol=crlf


### PR DESCRIPTION
On Linux, git converts line endings to LF which changes the hash, which
is checked when the game is loading. This should prevent that.

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->