### PR TITLE
Converted momentum settings pages' comboboxes to CvarComboBox

### DIFF
--- a/mp/game/momentum/resource/ui/SettingsPanel_ComparisonsSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_ComparisonsSettings.res
@@ -158,7 +158,7 @@
     
     "TimeType"
 	{
-		"ControlName"		"ComboBox"
+		"ControlName"		"CvarComboBox"
 		"fieldName"		"TimeType"
 		"xpos"		"4"
 		"ypos"		"0"
@@ -177,6 +177,7 @@
 		"maxchars"		"-1"
 		"NumericInputOnly"		"0"
 		"unicode"		"0"
+		"cvar_name"     "mom_comparisons_time_type"
         "font" "DefaultVerySmall"
         "actionsignallevel" "1"
 	}

--- a/mp/game/momentum/resource/ui/SettingsPanel_ComparisonsSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_ComparisonsSettings.res
@@ -104,7 +104,7 @@
     
     "Zones"
     {
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"Zones"
 		"xpos"		"4"
 		"ypos"		"0"
@@ -124,6 +124,7 @@
 		"maxchars"		"-1"
 		"NumericInputOnly"		"1"
 		"unicode"		"0"
+        "cvar_name"     "mom_comparisons_max_zones"
         "actionsignallevel" "1"
 	}
     

--- a/mp/game/momentum/resource/ui/SettingsPanel_HudSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_HudSettings.res
@@ -209,7 +209,7 @@
     }
     "SpeedoUnits"
     {
-        "ControlName"		"ComboBox"
+        "ControlName"		"CvarComboBox"
         "fieldName"		"SpeedoUnits"
         "xpos"		"3"
         "ypos"		"0"
@@ -228,6 +228,7 @@
         "maxchars"		"-1"
         "NumericInputOnly"		"0"
         "unicode"		"0"
+        "cvar_name"		"mom_hud_speedometer_units"
         "font" "DefaultVerySmall"
     }   
     "SpeedoColorLabel"
@@ -259,7 +260,7 @@
     }
     "SpeedoShowColor"
     {
-        "ControlName"		"ComboBox"
+        "ControlName"		"CvarComboBox"
         "fieldName"		"SpeedoShowColor"
         "xpos"		"3"
         "ypos"		"0"
@@ -279,6 +280,7 @@
         "maxchars"		"-1"
         "NumericInputOnly"		"0"
         "unicode"		"0"
+        "cvar_name"     "mom_hud_speedometer_colorize"
         "font" "DefaultVerySmall"
     }
 	
@@ -460,7 +462,7 @@
     }
     "SyncType"
     {
-        "ControlName"		"ComboBox"
+        "ControlName"		"CvarComboBox"
         "fieldName"		"SyncType"
         "xpos"		"3"
         "ypos"		"0"
@@ -479,6 +481,7 @@
         "maxchars"		"-1"
         "NumericInputOnly"		"0"
         "unicode"		"0"
+        "cvar_name"     "mom_hud_strafesync_type"
         "font" "DefaultVerySmall"
     }
     "SyncColorTypeLabel"
@@ -510,7 +513,7 @@
     }
     "SyncColorize"
     {
-        "ControlName"		"ComboBox"
+        "ControlName"		"CvarComboBox"
         "fieldName"		"SyncColorize"
         "xpos"		"3"
         "ypos"		"0"
@@ -529,6 +532,7 @@
         "maxchars"		"-1"
         "NumericInputOnly"		"0"
         "unicode"		"0"
+        "cvar_name"     "mom_hud_strafesync_colorize"
         "font" "DefaultVerySmall"
     }
     

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -8,6 +8,7 @@
 #include <vgui_controls/Label.h>
 #include <vgui_controls/CvarComboBox.h>
 #include <vgui_controls/CvarToggleCheckButton.h>
+#include <vgui_controls/CvarTextEntry.h>
 #include <vgui_controls/Tooltip.h>
 #include <vgui_controls/Frame.h>
 #include <vgui_controls/AnimationController.h>
@@ -21,7 +22,7 @@ ComparisonsSettingsPage::ComparisonsSettingsPage(Panel *pParent)
 {
     m_pCompareShow = new CvarToggleCheckButton(this, "CompareShow", "#MOM_Settings_Compare_Show", "mom_comparisons");
     m_pCompareShow->AddActionSignalTarget(this);
-    m_pMaxZones = new TextEntry(this, "Zones");
+    m_pMaxZones = new CvarTextEntry(this, "Zones", "mom_comparisons_max_zones");
     m_pMaxZones->AddActionSignalTarget(this);
     m_pMaxZonesLabel = new Label(this, "ZonesLabel", "#MOM_Settings_Zones_Label");
 
@@ -136,44 +137,11 @@ void ComparisonsSettingsPage::OnMainDialogShow()
         m_pComparisonsFrame->SetVisible(true);
 }
 
-void ComparisonsSettingsPage::OnApplyChanges()
-{
-    BaseClass::OnApplyChanges();
-
-    if (m_pMaxZones)
-    {
-        ConVarRef zones("mom_comparisons_max_zones");
-        char buf[64];
-        m_pMaxZones->GetText(buf, sizeof(buf));
-        int zonesNum = atoi(buf);
-        if (zonesNum < 0) // Less than min
-        {
-            zones.SetValue(1);
-        }
-        else if (zonesNum > 10) // Greater than max
-        {
-            zones.SetValue(10);
-        }
-        else // In range
-        {
-            zones.SetValue(zonesNum);
-        }
-    }
-}
-
 void ComparisonsSettingsPage::OnScreenSizeChanged(int oldwide, int oldtall)
 {
     BaseClass::OnScreenSizeChanged(oldwide, oldtall);
 
     DestroyBogusComparePanel();
-}
-
-void ComparisonsSettingsPage::LoadSettings()
-{
-    if (m_pMaxZones)
-    {
-        m_pMaxZones->SetText(ConVarRef("mom_comparisons_max_zones").GetString());
-    }
 }
 
 void ComparisonsSettingsPage::OnPageShow()

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -6,7 +6,7 @@
 #include "hud_comparisons.h"
 
 #include <vgui_controls/Label.h>
-#include <vgui_controls/ComboBox.h>
+#include <vgui_controls/CvarComboBox.h>
 #include <vgui_controls/CvarToggleCheckButton.h>
 #include <vgui_controls/Tooltip.h>
 #include <vgui_controls/Frame.h>
@@ -30,7 +30,7 @@ ComparisonsSettingsPage::ComparisonsSettingsPage(Panel *pParent)
 
     m_pTimeTypeLabel = new Label(this, "TimeTypeLabel", "#MOM_Settings_Compare_Time_Type_Label");
     m_pTimeTypeLabel->GetTooltip()->SetTooltipFormatToSingleLine();
-    m_pTimeType = new ComboBox(this, "TimeType", 2, false);
+    m_pTimeType = new CvarComboBox(this, "TimeType", 2, false, "mom_comparisons_time_type");
     m_pTimeType->AddItem("#MOM_Settings_Compare_Time_Type_Overall", nullptr);
     m_pTimeType->AddItem("#MOM_Settings_Compare_Time_Type_PerZone", nullptr);
     m_pTimeType->AddActionSignalTarget(this);
@@ -159,11 +159,6 @@ void ComparisonsSettingsPage::OnApplyChanges()
             zones.SetValue(zonesNum);
         }
     }
-
-    if (m_pTimeType)
-    {
-        ConVarRef("mom_comparisons_time_type").SetValue(m_pTimeType->GetActiveItem());
-    }
 }
 
 void ComparisonsSettingsPage::OnScreenSizeChanged(int oldwide, int oldtall)
@@ -178,11 +173,6 @@ void ComparisonsSettingsPage::LoadSettings()
     if (m_pMaxZones)
     {
         m_pMaxZones->SetText(ConVarRef("mom_comparisons_max_zones").GetString());
-    }
-
-    if (m_pTimeType)
-    {
-        m_pTimeType->ActivateItemByRow(ConVarRef("mom_comparisons_time_type").GetInt());
     }
 }
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
@@ -20,13 +20,9 @@ class ComparisonsSettingsPage : public SettingsPage
     void OnMainDialogClosed() OVERRIDE;
     void OnMainDialogShow() OVERRIDE;
 
-    //Handle custom controls
-    void OnApplyChanges() OVERRIDE;
-
     void OnScreenSizeChanged(int oldwide, int oldtall) override;
 
     //Load the settings for this panel
-    void LoadSettings() OVERRIDE;
     void OnPageShow() OVERRIDE;
 
     //Overridden from PropertyPage so we can hide the comparisons frame
@@ -48,7 +44,7 @@ private:
     vgui::CvarToggleCheckButton *m_pCompareShow, *m_pCompareFormat, *m_pTimeShowOverall,
         *m_pTimeShowZone, *m_pVelocityShow, *m_pVelocityShowAvg, *m_pVelocityShowMax, *m_pVelocityShowEnter, 
         *m_pVelocityShowExit, *m_pSyncShow, *m_pSyncShowS1, *m_pSyncShowS2, *m_pJumpShow, *m_pStrafeShow;
-    vgui::TextEntry *m_pMaxZones;
+    vgui::CvarTextEntry *m_pMaxZones;
     vgui::ComboBox *m_pTimeType;
     vgui::Label *m_pTimeTypeLabel, *m_pMaxZonesLabel;
     vgui::Frame *m_pComparisonsFrame;

--- a/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.cpp
@@ -1,7 +1,7 @@
 #include "cbase.h"
 
 #include "HudSettingsPage.h"
-#include "vgui_controls/ComboBox.h"
+#include "vgui_controls/CvarComboBox.h"
 #include "vgui_controls/CvarToggleCheckButton.h"
 
 #include "tier0/memdbgon.h"
@@ -10,19 +10,19 @@ using namespace vgui;
 
 HudSettingsPage::HudSettingsPage(Panel *pParent) : BaseClass(pParent, "HudSettings")
 {
-    m_pSpeedometerUnits = new ComboBox(this, "SpeedoUnits", 4, false);
+    m_pSpeedometerUnits = new CvarComboBox(this, "SpeedoUnits", 4, false, "mom_hud_speedometer_units");
     m_pSpeedometerUnits->AddItem("#MOM_Settings_Speedometer_Units_UPS", nullptr);
     m_pSpeedometerUnits->AddItem("#MOM_Settings_Speedometer_Units_KPH", nullptr);
     m_pSpeedometerUnits->AddItem("#MOM_Settings_Speedometer_Units_MPH", nullptr);
     m_pSpeedometerUnits->AddItem("#MOM_Settings_Speedometer_Units_Energy", nullptr);
     m_pSpeedometerUnits->AddActionSignalTarget(this);
 
-    m_pSyncType = new ComboBox(this, "SyncType", 2, false);
+    m_pSyncType = new CvarComboBox(this, "SyncType", 2, false, "mom_hud_strafesync_type");
     m_pSyncType->AddItem("#MOM_Settings_Sync_Type_Sync1", nullptr);
     m_pSyncType->AddItem("#MOM_Settings_Sync_Type_Sync2", nullptr);
     m_pSyncType->AddActionSignalTarget(this);
 
-    m_pSyncColorize = new ComboBox(this, "SyncColorize", 3, false);
+    m_pSyncColorize = new CvarComboBox(this, "SyncColorize", 3, false, "mom_hud_strafesync_colorize");
     m_pSyncColorize->AddItem("#MOM_Settings_Sync_Color_Type_None", nullptr);
     m_pSyncColorize->AddItem("#MOM_Settings_Sync_Color_Type_1", nullptr);
     m_pSyncColorize->AddItem("#MOM_Settings_Sync_Color_Type_2", nullptr);
@@ -44,7 +44,7 @@ HudSettingsPage::HudSettingsPage(Panel *pParent) : BaseClass(pParent, "HudSettin
     m_pSpeedometerUnitLabels = new CvarToggleCheckButton(this, "SpeedoShowUnitLabels", "#MOM_Settings_Speedometer_Unit_Labels", "mom_hud_speedometer_unit_labels");
     m_pSpeedometerUnitLabels->AddActionSignalTarget(this);
 
-    m_pSpeedometerColorize = new ComboBox(this, "SpeedoShowColor", 3, false);
+    m_pSpeedometerColorize = new CvarComboBox(this, "SpeedoShowColor", 3, false, "mom_hud_speedometer_colorize");
     m_pSpeedometerColorize->AddItem("#MOM_Settings_Speedometer_Color_Type_None", nullptr);
     m_pSpeedometerColorize->AddItem("#MOM_Settings_Speedometer_Color_Type_1", nullptr);
     m_pSpeedometerColorize->AddItem("#MOM_Settings_Speedometer_Color_Type_2", nullptr);
@@ -63,29 +63,6 @@ HudSettingsPage::HudSettingsPage(Panel *pParent) : BaseClass(pParent, "HudSettin
     m_pTimerShow->AddActionSignalTarget(this);
 
     LoadControlSettings("resource/ui/SettingsPanel_HudSettings.res");
-}
-
-void HudSettingsPage::OnApplyChanges()
-{
-    BaseClass::OnApplyChanges();
-
-    ConVarRef units("mom_hud_speedometer_units"), sync_type("mom_hud_strafesync_type"),
-        sync_color("mom_hud_strafesync_colorize"), speed_color("mom_hud_speedometer_colorize");
-
-    units.SetValue(m_pSpeedometerUnits->GetActiveItem() + 1);
-    sync_type.SetValue(m_pSyncType->GetActiveItem() + 1); // Sync type needs +1 added to it before setting convar!
-    sync_color.SetValue(m_pSyncColorize->GetActiveItem());
-    speed_color.SetValue(m_pSpeedometerColorize->GetActiveItem());
-}
-
-void HudSettingsPage::LoadSettings()
-{
-    ConVarRef units("mom_hud_speedometer_units"), sync_type("mom_hud_strafesync_type"),
-        sync_color("mom_hud_strafesync_colorize"), speed_color("mom_hud_speedometer_colorize");
-    m_pSpeedometerUnits->ActivateItemByRow(units.GetInt() - 1);
-    m_pSyncType->ActivateItemByRow(sync_type.GetInt() - 1);
-    m_pSyncColorize->ActivateItemByRow(sync_color.GetInt());
-    m_pSpeedometerColorize->ActivateItemByRow(speed_color.GetInt());
 }
 
 void HudSettingsPage::OnCheckboxChecked(Panel *p)

--- a/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/HudSettingsPage.h
@@ -10,16 +10,12 @@ class HudSettingsPage : public SettingsPage
 
     ~HudSettingsPage() {}
 
-    void OnApplyChanges() OVERRIDE;
-
-    void LoadSettings() OVERRIDE;
-
     //This uses OnCheckbox and not OnModified because we want to be able to enable
     // the other checkboxes regardless of whether the player clicks Apply/OK
     void OnCheckboxChecked(Panel *p) OVERRIDE;
 
 private:
-    vgui::ComboBox *m_pSpeedometerUnits, *m_pSyncType, *m_pSyncColorize, *m_pSpeedometerColorize;
+    vgui::CvarComboBox *m_pSpeedometerUnits, *m_pSyncType, *m_pSyncColorize, *m_pSpeedometerColorize;
 
     vgui::CvarToggleCheckButton *m_pSpeedometerShow, *m_pSpeedometerHorizShow, *m_pSpeedometerShowLastJump, *m_pSpeedometerShowStageEnter,
         *m_pSpeedometerUnitLabels, *m_pSyncShow, *m_pSyncShowBar, *m_pButtonsShow, *m_pShowVersion, *m_pTimerShow;


### PR DESCRIPTION
Closes #592 . This is a branch off of PR #662 

Converted the momentum settings pages to use cvarcombobox. 

The GameUI comboboxes were not changed as the current implementation `CvarComboBox` does not support

1. Cvars that have non-linear values, such as `mat_forceaniso`.
2. Comboboxes that set multiple cvars.
    - eg. Filtering mode combobox sets `mat_trilinear` or `mat_forceaniso` depending on the active item.

`CvarComboBox` will need more functionality to convert the GameUI pages. Perhaps this can be tackled in #662 or another PR. 

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review