### PR TITLE
Added credits to maps POST request params

### DIFF
--- a/mp/src/game/client/momentum/mom_api_requests.cpp
+++ b/mp/src/game/client/momentum/mom_api_requests.cpp
@@ -68,7 +68,7 @@ bool CAPIRequests::GetMaps(KeyValues *pKvFilters, CallbackFunc func)
         }
 
         SteamHTTP()->SetHTTPRequestGetOrPostParameter(req->handle, "expand", 
-                                                      "info,thumbnail,inLibrary,inFavorites,personalBest,worldRecord");
+                                                      "info,thumbnail,credits,inLibrary,inFavorites,personalBest,worldRecord");
 
         return SendAPIRequest(req, func, __FUNCTION__);
     }


### PR DESCRIPTION
Closes #664

Self-explanatory, adds the "credits" parameter in the GetMaps API request so the credits are always included in the cache when a map is fetched.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->