### PR TITLE
Better uphill slope RNG fix

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -38,8 +38,6 @@
 // remove this eventually
 ConVar sv_slope_fix("sv_slope_fix", "1");
 ConVar sv_ramp_fix("sv_ramp_fix", "1");
-ConVar sv_nojump_slope_boosts("sv_nojump_slope_boosts", "1", 0,
-    "Keep original engine behavior which makes going up slopes without holding jump usually result in extra speed.");
 ConVar sv_ramp_bumpcount("sv_ramp_bumpcount", "8", 0, "Helps with fixing surf/ramp bugs", true, 4, true, 16);
 ConVar sv_ramp_initial_retrace_length("sv_ramp_initial_retrace_length", "0.2", 0,
                                       "Amount of units used in offset for retraces", true, 0.2f, true, 5.f);
@@ -350,7 +348,7 @@ void CMomentumGameMovement::StepMove(Vector &vecDestination, trace_t &trace)
     // to do ground movement instead of air movement. Instead, we should use one entire result or the other instead of
     // combining them. The main reason we might want to use the down result over the up result even if the up result
     // goes farther is if the down result causes the player to not be grounded in the future.
-    if (!sv_nojump_slope_boosts.GetBool() && mv->m_vecVelocity.z > NON_JUMP_VELOCITY)
+    if (mv->m_vecVelocity.z > NON_JUMP_VELOCITY)
     {
         float flStepDist = mv->GetAbsOrigin().z - vecPos.z;
         if (flStepDist > 0.0f)
@@ -426,15 +424,6 @@ void CMomentumGameMovement::StepMove(Vector &vecDestination, trace_t &trace)
     {
         mv->SetAbsOrigin(vecDownPos);
         VectorCopy(vecDownVel, mv->m_vecVelocity);
-    }
-    else
-    {
-        if (sv_nojump_slope_boosts.GetBool())
-        {
-            // copy z value from slide move
-            // This probably results in gaining some z-velocity for free!
-            mv->m_vecVelocity.z = vecDownVel.z;
-        }
     }
 
     float flStepDist = mv->GetAbsOrigin().z - vecPos.z;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1404,6 +1404,8 @@ void CMomentumGameMovement::CategorizePosition()
                         // allowed, all that matters is if bhopping is allowed.
 
                         // On modes that can't bhop, colliding before landing is better if it means they start sliding.
+                        // If this check fails, we want to pretend they collided first and couldn't land,
+                        // so we don't set the ground entity.
                         if (g_pGameModeSystem->GetGameMode()->CanBhop() || vecNextVelocity.z <= NON_JUMP_VELOCITY)
                         {
                             // Only update velocity as if we collided if it results in horizontal speed gain.
@@ -1414,14 +1416,6 @@ void CMomentumGameMovement::CategorizePosition()
                             }
 
                             SetGroundEntity(&pm);
-                        }
-                        else
-                        {
-                            // Pretend the player collided first and since that means they can't land,
-                            // don't set the ground entity
-
-                            // Should we also pre-apply the ClipVelocity result?
-                            // VectorCopy(vecNextVelocity, mv->m_vecVelocity);
                         }
                     }
                     else
@@ -2016,8 +2010,6 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
             {
                 TracePlayerBBox(mv->GetAbsOrigin(), end, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, pm);
 
-                // This fix might also need to be applied after the sv_ramp_fix TracePlayerBBox above...
-                // Applying it here will handle the vast majority of cases, though.
                 if (sv_slope_fix.GetBool() && player->GetMoveType() == MOVETYPE_WALK &&
                     player->GetGroundEntity() == nullptr && player->GetWaterLevel() < WL_Waist &&
                     g_pGameModeSystem->GetGameMode()->CanBhop())

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2006,7 +2006,7 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
                 // This fix might also need to be applied after the sv_ramp_fix TracePlayerBBox above...
                 // Applying it here will handle the vast majority of cases, though.
                 if (sv_slope_fix.GetBool() && player->GetMoveType() == MOVETYPE_WALK &&
-                    player->GetGroundEntity() == nullptr)
+                    player->GetGroundEntity() == nullptr && player->GetWaterLevel() < WL_Waist)
                 {
                     bool bValidHit = !pm.allsolid && pm.fraction < 1.0f;
 
@@ -2031,7 +2031,7 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
                         {
                             // A fraction of 1.0 implies no collision, which means ClipVelocity will not be called.
                             // It also suggests movement for this tick is complete, so TryPlayerMove won't perform
-                            // additonal movement traces and the tick will essentially end early. We want this to
+                            // additional movement traces and the tick will essentially end early. We want this to
                             // happen because we need landing/jumping logic to be applied before movement continues.
                             // Ending the tick early is a safe and easy way to do this.
 

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -36,6 +36,7 @@ class CMomentumGameMovement : public CGameMovement
 
     int TryPlayerMove(Vector *pFirstDest = nullptr, trace_t *pFirstTrace = nullptr) override;
     void FullWalkMove() override;
+    void StepMove(Vector &vecDestination, trace_t &trace) override;
     void CategorizePosition() override;
 
     void ProcessMovement(CBasePlayer *pBasePlayer, CMoveData *pMove) override;

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -64,8 +64,6 @@ class CMomentumGameMovement : public CGameMovement
     float GetPlayerGravity() override;
     void FinishGravity() override;
 
-    int ClipVelocity(Vector in, Vector &normal, Vector &out, float overbounce) override;
-
     // Momentum-specific
     virtual void StuckGround();
     virtual void LimitStartZoneSpeed();

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -26,6 +26,7 @@ public:
 
     // Movement vars
     virtual float       GetViewScale() = 0;
+    virtual bool        CanBhop() = 0;
 
     virtual ~IGameMode() {}
 };
@@ -41,6 +42,7 @@ public:
     const char* GetGameModeCfg() override { return nullptr; }
     float GetIntervalPerTick() override { return 0.015f; }
     float GetViewScale() override { return 0.5f; }
+    bool CanBhop() override { return true; }
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return true; }
@@ -96,6 +98,7 @@ public:
     const char* GetMapPrefix() override { return "rj_"; }
     const char* GetGameModeCfg() override { return "rj.cfg"; }
     float GetViewScale() override { return 1.0f; }
+    bool CanBhop() override { return false; }
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
@@ -112,6 +115,7 @@ class CGameMode_SJ : public CGameModeBase
     const char *GetMapPrefix() override { return "sj_"; }
     const char *GetGameModeCfg() override { return "sj.cfg"; }
     float GetViewScale() override { return 1.0f; }
+    bool CanBhop() override { return false; }
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }


### PR DESCRIPTION
Hello! I made [RNGFix](https://forums.alliedmods.net/showthread.php?t=310825) which aims to make psuedo-random physics behavior behave consistently. Momentum already contains fixes for some of these things, but not all (yet!), and this PR focuses on the uphill slopes issue.

An explanation of the issue for those unaware:

At the end of a tick of physics simulation, if the player is within 2 units of a shallow-enough surface and is not moving up too fast, they are immediately considered "on the ground", which sets their z-velocity to zero. When this happens, it means the player never actually collides with the ground and ends up landing (and jumping) as if on totally flat ground. Whether or not this happens *essentially* comes down to chance -- it just depends on how the ticks happen to line up with the ground.

So the player will either collide with the ground first, or "land" first. When hitting an incline going "downhill", the player would rather collide first, because doing so results in their z-velocity being turned into some horizontal velocity, which is often the purpose of such inclines (Momentum already makes sure this happens). While it does make sense from a purely physical perspective for the player to also always collide first when going *uphill* into an incline, landing first is actually more beneficial to the player as it helps them retain more speed.

The fact is that ever since game modes that support bunny hopping like bhop and surf have been around, players have played on an engine that gave them that chance -- often not very small -- to "land" first when going up slopes and keep more speed. It has been used in many record runs, and has implications on many scenarios including launching off slopes, but also just bhopping on shallow inclines or bumpy ground. 

I think anyone would agree that random chance has no place in a skill-focused game, and if we break down the choice as either giving the player "good RNG" every time, or giving them "bad RNG" every time, to me the clear choice is "good RNG". A more long-winded version of my philosophy on this can be found [here](https://pastebin.com/raw/WTYy7077).

---

This implementation of the fix is smarter and cleaner than the current public version of RNGFix. During the main part of air movement simulation (`TryPlayerMove()`), it checks if the player is about to collide with an incline that they *could have* landed on -- given the game's requirements on landing -- had they been luckier and things lined up differently. When it sees this, it stops the movement simulation part of the tick immediately. This allows other routines `CategorizePosition()`, and later `CheckJumpButton()` on the following tick, to be run before movement continues and the collision is able to occur. This method has been in-use in my newer, beta version of RNGFix on Horizon Servers for over a year now, so I'm confident in it's correctness, barring perhaps some obscure interaction with Momentum's ramp bug fix.

Finally, once the engine has been changed to always make the player land first when going uphill, another engine quirk reveals itself more clearly: Hitting an incline while *not* holding jump often gives the player more speed than if they had held jump. This is both unintuitive and something that could more clearly be called a bug, as the increase in speed essentially comes from nowhere due to how the `StepMove()` function acts (it wasn't really designed for bhop speeds). This PR also adds a ConVar, `sv_nojump_slope_boosts` which can be turned off to enable an experimental tweak to `StepMove()` that keeps the player from being given extra speed from nowhere. Because this boost effect is entirely consistent, I wouldn't say preventing it is *obviously* necessary, but I included the fix because I didn't want the approval of the main part of this PR from being held back by this secondary issue.


### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->