### PR TITLE
Extra Functionality for CvarTextEntry

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -231,22 +231,6 @@ void ComparisonsSettingsPage::OnCheckboxChecked(Panel *p)
     }
 }
 
-void ComparisonsSettingsPage::OnTextChanged(Panel *p)
-{
-    BaseClass::OnTextChanged(p);
-
-    if (p == m_pMaxZones)
-    {
-        char buf[64];
-        m_pMaxZones->GetText(buf, 64);
-        int input = Q_atoi(buf);
-        if (input > 0 && input < 11)
-        {
-            ConVarRef("mom_comparisons_max_zones").SetValue(input);
-        }
-    }
-}
-
 int ComparisonsSettingsPage::DetermineBogusPulse(Panel *panel) const
 {
     int bogusPulse = 0;

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -23,6 +23,7 @@ ComparisonsSettingsPage::ComparisonsSettingsPage(Panel *pParent)
     m_pCompareShow = new CvarToggleCheckButton(this, "CompareShow", "#MOM_Settings_Compare_Show", "mom_comparisons");
     m_pCompareShow->AddActionSignalTarget(this);
     m_pMaxZones = new CvarTextEntry(this, "Zones", "mom_comparisons_max_zones");
+    m_pMaxZones->SetAllowNumericInputOnly(true);
     m_pMaxZones->AddActionSignalTarget(this);
     m_pMaxZonesLabel = new Label(this, "ZonesLabel", "#MOM_Settings_Zones_Label");
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.h
@@ -31,8 +31,6 @@ class ComparisonsSettingsPage : public SettingsPage
     // This uses OnCheckbox and not OnModified because we want to be able to enable
     // the other checkboxes regardless of whether the player clicks Apply/OK
     void OnCheckboxChecked(Panel *p) OVERRIDE;
-    // Used for updating the max stage buffer label
-    void OnTextChanged(Panel *p) OVERRIDE;
 
     MESSAGE_FUNC_PTR(CursorEnteredCallback, "OnCursorEntered", panel);
     MESSAGE_FUNC_PTR(CursorExitedCallback, "OnCursorExited", panel);

--- a/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.cpp
+++ b/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.cpp
@@ -50,9 +50,11 @@ C_MomZoneMenu::C_MomZoneMenu() : Frame(g_pClientMode->GetViewport(), "ZoneMenu")
 
     m_pTrackNumberLabel = new Label(this, "TrackNumberLabel", "#MOM_ZoneMenu_TrackNumber");
     m_pTrackNumberEntry = new CvarTextEntry(this, "TrackNumberEntry", "mom_zone_track");
+    m_pTrackNumberEntry->SetAllowNumericInputOnly(true);
 
     m_pZoneNumberLabel = new Label(this, "ZoneNumberLabel", "#MOM_ZoneMenu_ZoneNumber");
     m_pZoneNumberEntry = new CvarTextEntry(this, "ZoneNumberEntry", "mom_zone_zonenum");
+    m_pZoneNumberEntry->SetAllowNumericInputOnly(true);
 
     m_pZoneTypeLabel = new Label(this, "ZoneTypeLabel", "#MOM_ZoneMenu_ZoneType");
     m_pZoneTypeCombo = new ComboBox(this, "ZoneTypeCombo", 7, false);
@@ -67,6 +69,7 @@ C_MomZoneMenu::C_MomZoneMenu() : Frame(g_pClientMode->GetViewport(), "ZoneMenu")
     m_pGridSizeLabel = new Label(this, "GridSizeLabel", "");
     m_pGridSizeSlider = new CvarSlider(this, "GridSizeSlider");
     m_pGridSizeTextEntry = new CvarTextEntry(this, "GridSizeTextEntry", "mom_zone_grid");
+    m_pGridSizeTextEntry->SetAllowNumericInputOnly(true);
     m_bUpdateGridSizeSlider = false;
 
     LoadControlSettingsAndUserConfig("resource/ui/ZoneMenu.res");

--- a/mp/src/public/vgui_controls/CvarTextEntry.h
+++ b/mp/src/public/vgui_controls/CvarTextEntry.h
@@ -27,6 +27,7 @@ namespace vgui
         void InitSettings() OVERRIDE;
         void Reset();
         void OnThink() OVERRIDE;
+        void OnKillFocus() OVERRIDE;
         bool HasBeenModified();
         bool HasBeenModifiedExternally() const;
 

--- a/mp/src/public/vgui_controls/CvarTextEntry.h
+++ b/mp/src/public/vgui_controls/CvarTextEntry.h
@@ -23,6 +23,7 @@ namespace vgui
         void ApplySchemeSettings(IScheme *pScheme) OVERRIDE;
         void ApplySettings(KeyValues* inResourceData) OVERRIDE;
         void GetSettings(KeyValues* outResourceData) OVERRIDE;
+        void SetText(const char *text) OVERRIDE;
         void InitSettings() OVERRIDE;
         void Reset();
         void OnThink() OVERRIDE;

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -130,5 +130,6 @@ void CvarTextEntry::OnTextChanged()
     if (HasBeenModified())
     {
         PostActionSignal(new KeyValues("ControlModified"));
+        ApplyChanges();
     }
 }

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -100,6 +100,7 @@ void CvarTextEntry::Reset()
     {
         SetText(value);
         Q_strncpy(m_pszStartValue, value, sizeof(m_pszStartValue));
+        GotoTextEnd();
     }
 }
 

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -62,6 +62,25 @@ void CvarTextEntry::GetSettings(KeyValues* pOutResource)
     pOutResource->SetString("cvar_name", m_cvarRef.GetName());
 }
 
+void CvarTextEntry::SetText(const char* text)
+{
+    if (!text || !text[0]) 
+        return;
+
+    if (text[strnlen(text, MAX_CVAR_TEXT) - 1] == '.')
+    {
+        // trying to enter a decimal number so set the text normally
+        BaseClass::SetText(text);
+    }
+    else // not in the middle of setting a decimal number
+    {
+        // making sure the formatting is correct (removing trailing zeros via %g)
+        char newText[MAX_CVAR_TEXT];
+        Q_snprintf(newText, MAX_CVAR_TEXT, "%g", atof(text));
+        BaseClass::SetText(newText);
+    }
+}
+
 void CvarTextEntry::InitSettings()
 {
     BEGIN_PANEL_SETTINGS()

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -129,6 +129,19 @@ void CvarTextEntry::OnThink()
         Reset();
 }
 
+void CvarTextEntry::OnKillFocus()
+{
+    if (!m_cvarRef.IsValid())
+        return;
+
+    char entryValue[MAX_CVAR_TEXT];
+    GetText(entryValue, MAX_CVAR_TEXT);
+    if (!entryValue[0] || stricmp(m_cvarRef.GetString(), m_pszStartValue) != 0)
+    {
+        Reset();
+    }
+}
+
 bool CvarTextEntry::HasBeenModified()
 {
     char szText[MAX_CVAR_TEXT];

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -67,17 +67,24 @@ void CvarTextEntry::SetText(const char* text)
     if (!text || !text[0]) 
         return;
 
-    if (text[strnlen(text, MAX_CVAR_TEXT) - 1] == '.')
+    if (GetAllowNumericInputOnly())
     {
-        // trying to enter a decimal number so set the text normally
-        BaseClass::SetText(text);
+        if (text[strnlen(text, MAX_CVAR_TEXT) - 1] == '.')
+        {
+            // trying to enter a decimal number so set the text normally
+            BaseClass::SetText(text);
+        }
+        else // not in the middle of setting a decimal number
+        {
+            // making sure the formatting is correct (removing trailing zeros via %g)
+            char newText[MAX_CVAR_TEXT];
+            Q_snprintf(newText, MAX_CVAR_TEXT, "%g", atof(text));
+            BaseClass::SetText(newText);
+        }
     }
-    else // not in the middle of setting a decimal number
+    else
     {
-        // making sure the formatting is correct (removing trailing zeros via %g)
-        char newText[MAX_CVAR_TEXT];
-        Q_snprintf(newText, MAX_CVAR_TEXT, "%g", atof(text));
-        BaseClass::SetText(newText);
+        BaseClass::SetText(text);
     }
 }
 


### PR DESCRIPTION
- Changed `CvarTextEntry` to immediately set cvar values when text is changed.
    - Done via an `ApplySettings()` call after the `OnTextChanged()` override.
- Handled text when cvar is set to be out of bounds (both via the `TextEntry` and directly setting it console)
    - Done using a `SetText` override that formats the incoming string. Avoids trailing zeros & allows decimal point entry.
- Removed unneed `OnTextChanged()` override in the ComparisonsSettingsPage.

Note that the cvar itself handles the case where it is set out of its bounds, however in doing that the cvar's text always has trailing 0's. Easily replicated by setting a cvar out of bounds then seeing that it set to the min or max with trailing zeros when there shouldn't be.

Initially I tried modifying the cvar's printout in this case by changing `ConVar_PrintDescription` function in [convar.cpp](https://github.com/momentum-mod/game/blob/af1cf4302adea52afa963db43e17d27ed5e5f9b3/mp/src/tier1/convar.cpp#L1208), but this didn't seem to do anything. Putting a breakpoint there I found that it's never called. Everything seemed to be fine when I removed it too but not 100% sure it didn't break anything.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review