### PR TITLE
Changed CvarToggleCheckButton to instantly apply when checked/unchecked

### DIFF
--- a/mp/src/vgui2/vgui_controls/CvarToggleCheckButton.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarToggleCheckButton.cpp
@@ -114,6 +114,7 @@ void CvarToggleCheckButton::OnButtonChecked()
     if (HasBeenModified())
     {
         PostActionSignal(new KeyValues("ControlModified"));
+        ApplyChanges();
     }
 }
 


### PR DESCRIPTION
This makes the checkbutton not require an explicit `OnApplyChanges()` call to update the cvar. This is a step in the direction of removing the Apply button from the momentum settings panel.

Works when setting the corresponding cvar from console and with the settings panel's `OnCheckboxChecked()` overrides.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review