### PR TITLE
Appropriate whitelist for point_clientcommand

### DIFF
--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -552,13 +552,7 @@ void CPointClientCommand::InputCommand( inputdata_t& inputdata )
 	if ( !inputdata.value.String()[0] )
 		return;
 
-	bool bAllowed = (sAllowPointCommand == eAllowAlways);
-
-    if (sAllowPointCommand == eAllowWhitelist)
-    {
-        GameRulesMomentum()->PointCommandWhitelisted(inputdata.value.String());
-        return;
-    }
+	bool bAllowed = (sAllowPointCommand == eAllowAlways || sAllowPointCommand == eAllowWhitelist);
 
     if (!bAllowed)
     {
@@ -590,7 +584,14 @@ void CPointClientCommand::InputCommand( inputdata_t& inputdata )
 	if ( !pClient || !pClient->GetUnknown() )
 		return;
 
-	engine->ClientCommand( pClient, "%s\n", inputdata.value.String() );
+	if (sAllowPointCommand == eAllowWhitelist)
+	{
+		GameRulesMomentum()->RunPointClientCommandWhitelisted(pClient, inputdata.value.String());
+	}
+	else
+	{
+		engine->ClientCommand(pClient, "%s\n", inputdata.value.String());
+	}
 }
 
 BEGIN_DATADESC( CPointClientCommand )
@@ -622,7 +623,7 @@ void CPointServerCommand::InputCommand( inputdata_t& inputdata )
 	bool bAllowed = ( sAllowPointCommand == eAllowAlways );
     if (sAllowPointCommand == eAllowWhitelist)
     {
-        GameRulesMomentum()->PointCommandWhitelisted(inputdata.value.String());
+        GameRulesMomentum()->RunPointServerCommandWhitelisted(inputdata.value.String());
         return;
     }
 

--- a/mp/src/game/shared/momentum/mom_gamerules.h
+++ b/mp/src/game/shared/momentum/mom_gamerules.h
@@ -48,7 +48,8 @@ class CMomentumGameRules : public CSingleplayRules
     void ApplyRadiusDamage(CBaseEntity *pEntity, const CTakeDamageInfo &info, const Vector &vecSrc, float flRadius, float falloff);
 
     // Whitelist checking
-    void PointCommandWhitelisted(const char *pCmd);
+    void RunPointServerCommandWhitelisted(const char* pCmd);
+    void RunPointClientCommandWhitelisted(edict_t* pClient, const char *pCmd);
 
     void ClientSettingsChanged(CBasePlayer *) OVERRIDE;
 


### PR DESCRIPTION
There is a hardcoded whitelist for commands issued by `point_servercommand` entities when `sv_allow_point_command` is set to "whitelist", and the same whitelist and execution logic is also applied to `point_clientcommand` entities. This PR adds a separate whitelist for client commands.

The new whitelist allows these client commands:
- `r_screenoverlay` - Shows a texture on the client's screen. Sometimes used by maps to convey information.
- `play`/`playgamesound` - Plays a sound directly to the client. Maps sometimes use this as an alternative to playing a sound from the world, especially when other clients shouldn't hear it.

I used a script to double check 1400+ CSGO surf and bhop maps and found no commands other than these that would need to be whitelisted (these are in fact the only native client commands I found to be used by those maps).

I also added a warning for non-whitelisted client/server commands similar to the warning for when commands are disabled entirely:

![image](https://user-images.githubusercontent.com/2745352/79518801-94f66400-8017-11ea-8fa0-5b763388ce7b.png)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review