### PR TITLE
Allow rocket launcher to fire while attack2 is held

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_rocketlauncher.h
@@ -24,4 +24,7 @@ class CMomentumRocketLauncher : public CWeaponBaseGun
     WeaponID_t GetWeaponID() const OVERRIDE { return WEAPON_ROCKETLAUNCHER; }
 
     float DeployTime() const OVERRIDE { return 0.5f; }
+
+  private:
+    bool DualFire() OVERRIDE { return true; }
 };


### PR DESCRIPTION
Plopy suggested this change in discord, and @Hat-Kid explained the fix: override the `DualFire()` function and have it return true. Did this exactly how it is done in the sticky launcher code.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review