### PR TITLE
Hardcode BurnLevel proxy to always be 0

### DIFF
--- a/mp/src/game/client/momentum/tf2proxy.cpp
+++ b/mp/src/game/client/momentum/tf2proxy.cpp
@@ -34,9 +34,10 @@ EXPOSE_INTERFACE(CYellowLevelProxy, IMaterialProxy, "YellowLevel" IMATERIAL_PROX
 class CBurnLevelProxy : public CResultProxy
 {
   public:
-    bool Init(IMaterial *pMaterial, KeyValues *pKeyValues) { return true; }
-    void OnBind(void *pC_BaseEntity) {}
-    IMaterial *GetMaterial() { return nullptr; }
+    void OnBind(void *pC_BaseEntity)
+    {
+        m_pResult->SetFloatValue(0.0f);
+    }
 };
 
 EXPOSE_INTERFACE(CBurnLevelProxy, IMaterialProxy, "BurnLevel" IMATERIAL_PROXY_INTERFACE_VERSION);


### PR DESCRIPTION
This stops certain TF2 models from showing the burn texture.

Closes #678 

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review