### PR TITLE
Improved entity IO saving and restoring for savelocs

### DIFF
--- a/mp/src/game/server/cbase.cpp
+++ b/mp/src/game/server/cbase.cpp
@@ -1334,20 +1334,32 @@ void CEventQueueEvent::ToPrioritizedEvent(EventQueuePrioritizedEvent_t* pe, CBas
 	pe->m_iTarget = m_iTarget;
 	pe->m_iTargetInput = m_iTargetInput;
 
-	if (pAbstractedEntity && m_bAbstractActivator)
+	if ( pAbstractedEntity && m_bAbstractActivator )
+	{
 		pe->m_pActivator = pAbstractedEntity;
+	}
 	else
+	{
 		pe->m_pActivator = GetEntityFromName( m_szActivator );
+	}
 
-	if (pAbstractedEntity && m_bAbstractCaller)
+	if ( pAbstractedEntity && m_bAbstractCaller )
+	{
 		pe->m_pCaller = pAbstractedEntity;
+	}
 	else
+	{
 		pe->m_pCaller = UTIL_EntityByIndex( m_iCaller );
+	}
 
-	if (pAbstractedEntity && m_bAbstractTarget)
+	if ( pAbstractedEntity && m_bAbstractTarget )
+	{
 		pe->m_pEntTarget = pAbstractedEntity;
+	}
 	else
+	{
 		pe->m_pEntTarget = GetEntityFromName( m_szEntTarget );
+	}
 
 	pe->m_VariantValue = m_VariantValue;
 }

--- a/mp/src/game/server/cbase.cpp
+++ b/mp/src/game/server/cbase.cpp
@@ -1048,6 +1048,18 @@ void CEventQueue::CancelEvents( CBaseEntity *pCaller )
 	}
 }
 
+bool CEventQueue::EventAffectsEntity(EventQueuePrioritizedEvent_t* event, CBaseEntity* pTarget)
+{
+	CBaseEntity* pSearchingEntity = event->m_pCaller;
+	if (event->m_pEntTarget == pTarget ||
+		pTarget == gEntList.FindEntityByName(nullptr, event->m_iTarget, pSearchingEntity, event->m_pActivator, event->m_pCaller))
+	{
+		return true;
+	}
+
+	return false;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Removes all pending events of the specified type from the I/O queue of the specified target
 // Input  : *pTarget - 
@@ -1066,9 +1078,7 @@ void CEventQueue::CancelEventOn( CBaseEntity *pTarget, const char *sInputName )
 	while (pCur != nullptr)
 	{
 		bool bDelete = false;
-		CBaseEntity *pSearchingEntity = pCur->m_pCaller;
-		if (pCur->m_pEntTarget == pTarget ||
-			pTarget == gEntList.FindEntityByName(nullptr, pCur->m_iTarget, pSearchingEntity, pCur->m_pActivator, pCur->m_pCaller))
+		if (EventAffectsEntity(pCur, pTarget))
 		{
 			if (!sInputName || !Q_strncmp(STRING(pCur->m_iTargetInput), sInputName, inputNameSize))
 			{
@@ -1102,9 +1112,7 @@ bool CEventQueue::HasEventPending( CBaseEntity *pTarget, const char *sInputName 
 	const size_t inputNameSize = sInputName ? strlen(sInputName) : 0;
 	while (pCur != nullptr)
 	{
-		CBaseEntity *pSearchingEntity = pCur->m_pCaller;
-		if (pCur->m_pEntTarget == pTarget ||
-			pTarget == gEntList.FindEntityByName(nullptr, pCur->m_iTarget, pSearchingEntity, pCur->m_pActivator, pCur->m_pCaller))
+		if (EventAffectsEntity(pCur, pTarget))
 		{
 			if (!sInputName || !Q_strncmp(STRING(pCur->m_iTargetInput), sInputName, inputNameSize))
 				return true;
@@ -1235,7 +1243,7 @@ void CEventQueue::SaveAll( CEventQueueState& state )
 		state.m_vecEvents.AddToTail();
 
 		CEventQueueEvent &e = state.m_vecEvents.Tail();
-		e.FromPrioritizedEvent( pe );
+		e.FromPrioritizedEvent( pe, nullptr );
 	}
 }
 
@@ -1247,7 +1255,7 @@ void CEventQueue::RestoreAll( const CEventQueueState &state )
 	FOR_EACH_VEC( state.m_vecEvents, i )
 	{
 		EventQueuePrioritizedEvent_t *newEvent = new EventQueuePrioritizedEvent_t;
-		state.m_vecEvents[i].ToPrioritizedEvent(newEvent);
+		state.m_vecEvents[i].ToPrioritizedEvent( newEvent, nullptr );
 		AddEvent( newEvent );
 	}
 }
@@ -1257,16 +1265,13 @@ void CEventQueue::SaveForTarget( CBaseEntity *pTarget, CEventQueueState &state )
 	state.m_vecEvents.RemoveAll();
 	for ( EventQueuePrioritizedEvent_t *pe = m_Events.m_pNext; pe != nullptr; pe = pe->m_pNext )
 	{
-		// Only add the event if it has the correct target ent
-		CBaseEntity *pSearchingEntity = pe->m_pCaller;
-
-		if ( pTarget == pe->m_pEntTarget ||
-			pTarget == gEntList.FindEntityByName( nullptr, pe->m_iTarget, pSearchingEntity, pe->m_pActivator, pe->m_pCaller ) )
+		// Only add the event if it affects the entity of interest
+		if (EventAffectsEntity(pe, pTarget))
 		{
 			state.m_vecEvents.AddToTail();
 
 			CEventQueueEvent &e = state.m_vecEvents.Tail();
-			e.FromPrioritizedEvent( pe );
+			e.FromPrioritizedEvent( pe, pTarget );
 		}
 	}
 }
@@ -1280,7 +1285,7 @@ void CEventQueue::RestoreForTarget( CBaseEntity *pTarget, const CEventQueueState
 	FOR_EACH_VEC( state.m_vecEvents, i )
 	{
 		EventQueuePrioritizedEvent_t *newEvent = new EventQueuePrioritizedEvent_t;
-		state.m_vecEvents[i].ToPrioritizedEvent( newEvent );
+		state.m_vecEvents[i].ToPrioritizedEvent( newEvent, pTarget );
 		AddEvent( newEvent );
 	}
 }
@@ -1294,7 +1299,7 @@ static CBaseEntity *GetEntityFromName( string_t name )
 	return gEntList.FindEntityByName( nullptr, name );
 }
 
-void CEventQueueEvent::FromPrioritizedEvent( const EventQueuePrioritizedEvent_t *pe )
+void CEventQueueEvent::FromPrioritizedEvent( const EventQueuePrioritizedEvent_t *pe, CBaseEntity *pAbstractedEntity )
 {
 	// Convert from absolute tick count to an offset so its correct regardless of current tickcount
 	m_iFireDelayTicks = pe->m_iFireTick - gpGlobals->tickcount;
@@ -1305,18 +1310,44 @@ void CEventQueueEvent::FromPrioritizedEvent( const EventQueuePrioritizedEvent_t 
 	m_iCaller = pe->m_pCaller ? pe->m_pCaller->entindex() : 0;
 	m_szEntTarget = pe->m_pEntTarget ? pe->m_pEntTarget->GetEntityName() : NULL_STRING;
 	m_VariantValue = pe->m_VariantValue;
+
+	if (pAbstractedEntity)
+	{
+		m_bAbstractTarget = (pe->m_pEntTarget == pAbstractedEntity);
+		m_bAbstractActivator = (pe->m_pActivator == pAbstractedEntity);
+		m_bAbstractCaller = (pe->m_pCaller == pAbstractedEntity);
+	}
+	else
+	{
+		m_bAbstractTarget = false;
+		m_bAbstractActivator = false;
+		m_bAbstractCaller = false;
+	}
 }
 
-void CEventQueueEvent::ToPrioritizedEvent(EventQueuePrioritizedEvent_t* pe) const
+void CEventQueueEvent::ToPrioritizedEvent(EventQueuePrioritizedEvent_t* pe, CBaseEntity *pAbstractedEntity ) const
 {
 	// Convert from tick offset to absolute tick count
 	pe->m_iFireTick = m_iFireDelayTicks + gpGlobals->tickcount;
 	pe->m_iOutputID = m_iOutputID;
 	pe->m_iTarget = m_iTarget;
 	pe->m_iTargetInput = m_iTargetInput;
-	pe->m_pActivator = GetEntityFromName( m_szActivator );
-	pe->m_pCaller = UTIL_EntityByIndex( m_iCaller );
-	pe->m_pEntTarget = GetEntityFromName( m_szEntTarget );;
+
+	if (pAbstractedEntity && m_bAbstractActivator)
+		pe->m_pActivator = pAbstractedEntity;
+	else
+		pe->m_pActivator = GetEntityFromName( m_szActivator );
+
+	if (pAbstractedEntity && m_bAbstractCaller)
+		pe->m_pCaller = pAbstractedEntity;
+	else
+		pe->m_pCaller = UTIL_EntityByIndex( m_iCaller );
+
+	if (pAbstractedEntity && m_bAbstractTarget)
+		pe->m_pEntTarget = pAbstractedEntity;
+	else
+		pe->m_pEntTarget = GetEntityFromName( m_szEntTarget );
+
 	pe->m_VariantValue = m_VariantValue;
 }
 
@@ -1333,6 +1364,10 @@ void CEventQueueEvent::LoadFromKeyValues( KeyValues *kv )
 	fieldtype_t fieldtype = (fieldtype_t)kv->GetInt( "variant_field_type" );
 	m_VariantValue.SetString( MAKE_STRING( kv->GetString( "variant_value" ) ) );
 	m_VariantValue.Convert( fieldtype );
+
+	m_bAbstractTarget = kv->GetBool( "abstract_target" );
+	m_bAbstractActivator = kv->GetBool( "abstract_activator" );
+	m_bAbstractCaller = kv->GetBool( "abstract_caller" );
 }
 
 void CEventQueueEvent::SaveToKeyValues( KeyValues *kv ) const
@@ -1352,6 +1387,9 @@ void CEventQueueEvent::SaveToKeyValues( KeyValues *kv ) const
 	kv->SetString( "ent_target", STRING( m_szEntTarget ) );
 	kv->SetInt( "variant_field_type", m_VariantValue.FieldType() );
 	kv->SetString( "variant_value", m_VariantValue.String() );
+	kv->SetBool( "abstract_target", m_bAbstractTarget );
+	kv->SetBool( "abstract_activator", m_bAbstractActivator );
+	kv->SetBool( "abstract_caller", m_bAbstractCaller );
 }
 
 void CEventQueueState::LoadFromKeyValues( KeyValues *kv )

--- a/mp/src/game/server/cbase.cpp
+++ b/mp/src/game/server/cbase.cpp
@@ -1051,7 +1051,8 @@ void CEventQueue::CancelEvents( CBaseEntity *pCaller )
 bool CEventQueue::EventAffectsEntity(EventQueuePrioritizedEvent_t* event, CBaseEntity* pTarget)
 {
 	CBaseEntity* pSearchingEntity = event->m_pCaller;
-	if (event->m_pEntTarget == pTarget ||
+	if (event->m_pActivator == pTarget ||
+		event->m_pEntTarget == pTarget ||
 		pTarget == gEntList.FindEntityByName(nullptr, event->m_iTarget, pSearchingEntity, event->m_pActivator, event->m_pCaller))
 	{
 		return true;

--- a/mp/src/game/server/eventqueue.h
+++ b/mp/src/game/server/eventqueue.h
@@ -39,8 +39,8 @@ struct EventQueuePrioritizedEvent_t
 class CEventQueueEvent
 {
 public:
-	void FromPrioritizedEvent( const EventQueuePrioritizedEvent_t *pe );
-	void ToPrioritizedEvent( EventQueuePrioritizedEvent_t *pe ) const;
+	void FromPrioritizedEvent( const EventQueuePrioritizedEvent_t *pe, CBaseEntity *pAbstractedEntity );
+	void ToPrioritizedEvent( EventQueuePrioritizedEvent_t *pe, CBaseEntity *pAbstractedEntity ) const;
 	void LoadFromKeyValues( KeyValues* kv );
 	void SaveToKeyValues( KeyValues* kv ) const;
 public:
@@ -53,6 +53,13 @@ public:
 	string_t m_szEntTarget; // name of entity to target; overrides m_iTarget
 
 	variant_t m_VariantValue; // variable-type parameter
+
+	// This event gets saved with respect to a certain entity we are interested in (probably a player).
+	// If any of the target, activator, or caller are that entity, keep a record of that so we can
+	// set those to the entity we end up restoring this event for later.
+	bool m_bAbstractTarget;
+	bool m_bAbstractActivator;
+	bool m_bAbstractCaller;
 };
 
 class CEventQueueState
@@ -75,6 +82,7 @@ public:
 	void CancelEvents( CBaseEntity *pCaller );
 	void CancelEventOn( CBaseEntity *pTarget, const char *sInputName );
 	bool HasEventPending( CBaseEntity *pTarget, const char *sInputName );
+	bool EventAffectsEntity( EventQueuePrioritizedEvent_t* event, CBaseEntity* pTarget );
 
 	// services the queue, firing off any events who's time hath come
 	void ServiceEvents( void );


### PR DESCRIPTION
The events that we want to save with a saveloc are ones that affect the player, which we find by checking the player entity against active delayed events. (#263) However, at the time we want to restore those events, the player we want them to affect might be a different entity.

For example, one player might make a saveloc, and another player wishes to load it. Events that are part of that loaded saveloc may need to have the `activator` or other properties set to the player that is loading it. This can be handled by remembering if any of the `target`, `activator`, or `caller` entities are the entity the event was saved for, and then filling those in with the new entity when the saveloc is loaded. Essentially, those matching entities are instead treated as an abstracted/blank entity to be filled in later. This allows events to work properly when restored from KeyValues.

This PR also tweaks the logic that decides which events should be saved, restored, or removed when savelocs are used. Previously, only events which directly target the player are incorporated, however some entity IO targets other entities which then in turn perform some action on the original activator. Some entities which behave this way are `player_speedmod`, `point_clientcommand`, and `env_fade`. I changed the saveloc logic to include any event for which the player is the activator because those effects probably impact the player in some way, either by coming back and directly affecting the player entity, or by changing something on the map near the player. 

Beyond this, savelocs might also need to store the state of other entities like doors or platforms that move in response to player actions, but that's a separate issue.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review