### PR TITLE
Convert momentum settings pages sliders to update cvars instantly

### DIFF
--- a/mp/game/momentum/resource/ui/SettingsPanel_GameplaySettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_GameplaySettings.res
@@ -41,7 +41,7 @@
     
     "YawSpeedEntry"
     {
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"YawSpeedEntry"
 		"xpos"		"206"
 		"ypos"		"16"
@@ -61,6 +61,7 @@
 		"maxchars"		"-1"
 		"NumericInputOnly"		"1"
 		"unicode"		"0"
+        "cvar_name" "cl_yawspeed"
         "actionsignallevel" "1"
 	}
     

--- a/mp/game/momentum/resource/ui/SettingsPanel_OnlineSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_OnlineSettings.res
@@ -194,7 +194,7 @@
 	}
 	"AlphaOverrideEntry"
 	{
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"AlphaOverrideEntry"
 		"xpos"		"5"
 		"ypos"		"0"
@@ -214,6 +214,7 @@
 		"maxchars"		"3"
 		"NumericInputOnly"		"1"
 		"unicode"		"0"
+		"cvar_name"		"mom_ghost_online_alpha_override"
         "actionsignallevel" "1"
 		"Font"		"DefaultVerySmall"
 	}

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
@@ -41,35 +41,6 @@ void GameplaySettingsPage::LoadSettings()
 {
     if (m_pLowerSpeedCVarEntry && m_pLowerSpeed)
         m_pLowerSpeedCVarEntry->SetEnabled(m_pLowerSpeed->IsSelected());
-    UpdateSliderEntries();
-    
-}
-
-void GameplaySettingsPage::OnTextChanged(Panel *p)
-{
-    BaseClass::OnTextChanged(p);
-
-    if (p == m_pYawSpeedEntry)
-    {
-        char buf[64];
-        m_pYawSpeedEntry->GetText(buf, 64);
-
-        float fValue = static_cast<float>(atof(buf));
-        if (fValue >= 1.0)
-        {
-            m_pYawSpeedSlider->SetSliderValue(fValue);
-        }
-    }
-}
-
-void GameplaySettingsPage::OnControlModified(Panel *p)
-{
-    BaseClass::OnControlModified(p);
-
-    if (p == m_pYawSpeedSlider)
-    {
-        UpdateSliderEntries();
-    }
 }
 
 void GameplaySettingsPage::OnCheckboxChecked(Panel* p)
@@ -80,11 +51,4 @@ void GameplaySettingsPage::OnCheckboxChecked(Panel* p)
         m_pLowerSpeedCVarEntry->SetEnabled(m_pLowerSpeed->IsSelected());
         m_pLowerSpeedLabel->SetEnabled(m_pLowerSpeed->IsSelected());
     }
-}
-
-void GameplaySettingsPage::UpdateSliderEntries() const
-{
-    char buf[64];
-    Q_snprintf(buf, sizeof(buf), "%.1f", m_pYawSpeedSlider->GetSliderValue());
-    m_pYawSpeedEntry->SetText(buf);
 }

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
@@ -13,7 +13,7 @@ GameplaySettingsPage::GameplaySettingsPage(Panel *pParent) : BaseClass(pParent, 
 {
     m_pYawSpeedSlider = new CvarSlider(this, "YawSpeed", nullptr, 0.0f, 360.0f, "cl_yawspeed", false, true);
     m_pYawSpeedSlider->AddActionSignalTarget(this);
-    m_pYawSpeedEntry = new TextEntry(this, "YawSpeedEntry");
+    m_pYawSpeedEntry = new CvarTextEntry(this, "YawSpeedEntry", "cl_yawspeed");
     m_pYawSpeedEntry->SetAllowNumericInputOnly(true);
     m_pYawSpeedEntry->AddActionSignalTarget(this);
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
@@ -39,14 +39,13 @@ GameplaySettingsPage::GameplaySettingsPage(Panel *pParent) : BaseClass(pParent, 
 
 void GameplaySettingsPage::LoadSettings()
 {
-    if (m_pLowerSpeedCVarEntry && m_pLowerSpeed)
-        m_pLowerSpeedCVarEntry->SetEnabled(m_pLowerSpeed->IsSelected());
+    m_pLowerSpeedCVarEntry->SetEnabled(m_pLowerSpeed->IsSelected());
 }
 
 void GameplaySettingsPage::OnCheckboxChecked(Panel* p)
 {
     BaseClass::OnCheckboxChecked(p);
-    if (p == m_pLowerSpeed && m_pLowerSpeedCVarEntry)
+    if (p == m_pLowerSpeed)
     {
         m_pLowerSpeedCVarEntry->SetEnabled(m_pLowerSpeed->IsSelected());
         m_pLowerSpeedLabel->SetEnabled(m_pLowerSpeed->IsSelected());

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.cpp
@@ -11,7 +11,7 @@ using namespace vgui;
 
 GameplaySettingsPage::GameplaySettingsPage(Panel *pParent) : BaseClass(pParent, "GameplaySettings")
 {
-    m_pYawSpeedSlider = new CvarSlider(this, "YawSpeed", nullptr, 0.0f, 360.0f, "cl_yawspeed", false);
+    m_pYawSpeedSlider = new CvarSlider(this, "YawSpeed", nullptr, 0.0f, 360.0f, "cl_yawspeed", false, true);
     m_pYawSpeedSlider->AddActionSignalTarget(this);
     m_pYawSpeedEntry = new TextEntry(this, "YawSpeedEntry");
     m_pYawSpeedEntry->SetAllowNumericInputOnly(true);

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.h
@@ -27,7 +27,7 @@ private:
     vgui::CvarToggleCheckButton *m_pPlayBlockSound;
     vgui::CvarToggleCheckButton *m_pSaveCheckpoints;
     vgui::CvarSlider *m_pYawSpeedSlider;
-    vgui::TextEntry *m_pYawSpeedEntry;
+    vgui::CvarTextEntry *m_pYawSpeedEntry;
 
     vgui::CvarTextEntry *m_pLowerSpeedCVarEntry;
     vgui::CvarToggleCheckButton *m_pLowerSpeed;

--- a/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/GameplaySettingsPage.h
@@ -12,15 +12,9 @@ class GameplaySettingsPage : public SettingsPage
 
     void LoadSettings() OVERRIDE;
 
-    void OnTextChanged(Panel *p) OVERRIDE;
-
-    void OnControlModified(Panel *p) OVERRIDE;
-
     void OnCheckboxChecked(Panel *p) OVERRIDE;
 
 private:
-    void UpdateSliderEntries() const;
-
     vgui::CvarToggleCheckButton *m_pOverlappingKeys;
     vgui::CvarToggleCheckButton *m_pReleaseForwardOnJump;
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
@@ -2,7 +2,7 @@
 
 #include "OnlineSettingsPage.h"
 #include "vgui_controls/CvarSlider.h"
-#include "vgui_controls/TextEntry.h"
+#include "vgui_controls/CvarTextEntry.h"
 #include <vgui_controls/CvarToggleCheckButton.h>
 
 #include "tier0/memdbgon.h"
@@ -23,7 +23,7 @@ OnlineSettingsPage::OnlineSettingsPage(Panel* pParent) : BaseClass(pParent, "Onl
     m_pEnableColorAlphaOverride->AddActionSignalTarget(this);
     m_pAlphaOverrideSlider = new CvarSlider(this, "AlphaOverrideSlider", nullptr, 0.0f, 255.0f, "mom_ghost_online_alpha_override", false, true);
     m_pAlphaOverrideSlider->AddActionSignalTarget(this);
-    m_pAlphaOverrideInput = new TextEntry(this, "AlphaOverrideEntry");
+    m_pAlphaOverrideInput = new CvarTextEntry(this, "AlphaOverrideEntry", "mom_ghost_online_alpha_override");
     m_pAlphaOverrideInput->SetAllowNumericInputOnly(true);
     m_pAlphaOverrideInput->AddActionSignalTarget(this);
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
@@ -32,5 +32,16 @@ OnlineSettingsPage::OnlineSettingsPage(Panel* pParent) : BaseClass(pParent, "Onl
 
 void OnlineSettingsPage::LoadSettings()
 {
-    BaseClass::LoadSettings();
+    m_pAlphaOverrideSlider->SetEnabled(m_pEnableColorAlphaOverride->IsSelected());
+    m_pAlphaOverrideInput->SetEnabled(m_pEnableColorAlphaOverride->IsSelected());
+}
+
+void OnlineSettingsPage::OnCheckboxChecked(Panel *p)
+{
+    BaseClass::OnCheckboxChecked(p);
+    if (p == m_pEnableColorAlphaOverride)
+    {
+        m_pAlphaOverrideSlider->SetEnabled(m_pEnableColorAlphaOverride->IsSelected());
+        m_pAlphaOverrideInput->SetEnabled(m_pEnableColorAlphaOverride->IsSelected());
+    }
 }

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
@@ -21,7 +21,7 @@ OnlineSettingsPage::OnlineSettingsPage(Panel* pParent) : BaseClass(pParent, "Onl
     m_pEnableGhostTrails->AddActionSignalTarget(this);
     m_pEnableColorAlphaOverride = new CvarToggleCheckButton(this, "EnableAlphaOverride", "#MOM_Settings_Override_Alpha_Enable", "mom_ghost_online_alpha_override_enable");
     m_pEnableColorAlphaOverride->AddActionSignalTarget(this);
-    m_pAlphaOverrideSlider = new CvarSlider(this, "AlphaOverrideSlider", nullptr, 0.0f, 255.0f, "mom_ghost_online_alpha_override");
+    m_pAlphaOverrideSlider = new CvarSlider(this, "AlphaOverrideSlider", nullptr, 0.0f, 255.0f, "mom_ghost_online_alpha_override", false, true);
     m_pAlphaOverrideSlider->AddActionSignalTarget(this);
     m_pAlphaOverrideInput = new TextEntry(this, "AlphaOverrideEntry");
     m_pAlphaOverrideInput->SetAllowNumericInputOnly(true);

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.cpp
@@ -30,53 +30,7 @@ OnlineSettingsPage::OnlineSettingsPage(Panel* pParent) : BaseClass(pParent, "Onl
     LoadControlSettings("resource/ui/SettingsPanel_OnlineSettings.res");
 }
 
-void OnlineSettingsPage::OnApplyChanges()
-{
-    BaseClass::OnApplyChanges();
-
-    
-}
-
 void OnlineSettingsPage::LoadSettings()
 {
-
-    UpdateSliderSettings();
-}
-
-void OnlineSettingsPage::OnCheckboxChecked(Panel* p)
-{
-}
-
-void OnlineSettingsPage::OnTextChanged(vgui::Panel* panel)
-{
-    BaseClass::OnTextChanged(panel);
-
-    if (panel == m_pAlphaOverrideInput)
-    {
-        char buf[64];
-        m_pAlphaOverrideInput->GetText(buf, 64);
-
-        float fValue = static_cast<float>(Q_atof(buf));
-        if (fValue >= 0.0f && fValue <= 255.0f)
-        {
-            m_pAlphaOverrideSlider->SetSliderValue(fValue);
-        }
-    }
-}
-
-void OnlineSettingsPage::OnControlModified(vgui::Panel* p)
-{
-    BaseClass::OnControlModified(p);
-
-    if (p == m_pAlphaOverrideSlider)
-    {
-        UpdateSliderSettings();
-    }
-}
-
-void OnlineSettingsPage::UpdateSliderSettings()
-{
-    char buf[64];
-    Q_snprintf(buf, sizeof(buf), "%i", static_cast<int>(m_pAlphaOverrideSlider->GetSliderValue()));
-    m_pAlphaOverrideInput->SetText(buf);
+    BaseClass::LoadSettings();
 }

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
@@ -12,6 +12,8 @@ class OnlineSettingsPage : public SettingsPage
 
     void LoadSettings() OVERRIDE;
 
+    void OnCheckboxChecked(Panel *p) OVERRIDE;
+
 private:
     vgui::CvarSlider *m_pAlphaOverrideSlider;
     vgui::CvarTextEntry *m_pAlphaOverrideInput;

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
@@ -26,7 +26,7 @@ private:
     void UpdateSliderSettings();
 
     vgui::CvarSlider *m_pAlphaOverrideSlider;
-    vgui::TextEntry *m_pAlphaOverrideInput;
+    vgui::CvarTextEntry *m_pAlphaOverrideInput;
     vgui::CvarToggleCheckButton *m_pEnableGhostRotations, *m_pEnableGhostSounds, *m_pEnableEntityPanels,
         *m_pEnableGhostTrails, *m_pEnableColorAlphaOverride;
 };

--- a/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/OnlineSettingsPage.h
@@ -10,21 +10,9 @@ class OnlineSettingsPage : public SettingsPage
 
     ~OnlineSettingsPage() {}
 
-    void OnApplyChanges() OVERRIDE;
-
     void LoadSettings() OVERRIDE;
 
-    //This uses OnCheckbox and not OnModified because we want to be able to enable
-    // the other checkboxes regardless of whether the player clicks Apply/OK
-    void OnCheckboxChecked(Panel *p) OVERRIDE;
-
-    void OnTextChanged(vgui::Panel* panel) OVERRIDE;
-
-    void OnControlModified(vgui::Panel* panel) OVERRIDE;
-
 private:
-    void UpdateSliderSettings();
-
     vgui::CvarSlider *m_pAlphaOverrideSlider;
     vgui::CvarTextEntry *m_pAlphaOverrideInput;
     vgui::CvarToggleCheckButton *m_pEnableGhostRotations, *m_pEnableGhostSounds, *m_pEnableEntityPanels,


### PR DESCRIPTION
This branch is a child of PR #676 . Related to #685
This is another step in the direction of removing the apply buttons from the momentum settings pages. 

No changes were made to `CvarSlider` since it already had functionality to update instantly. The instantiation of the `CvarSlider`s were modified to include the flag necessary for this. The `TextEntry`s corresponding to these sliders were changed to `CvarTextEntry`s. The now unneeded overrides were removed.
Also added a proper enabling/disabling of the ghost alpha override slider when the ghost alpha override enable checkbox is checked/unchecked.

With this change, the only page that will need to be changed is the appearance tab, which is a bit different. It's formatting is different than the other pages as well so probably worth it to have a separate PR for that specific tab.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review