### PR TITLE
Changed appearance settings page's vgui controls to update instantly

### DIFF
--- a/mp/game/momentum/resource/ui/SettingsPanel_AppearanceSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_AppearanceSettings.res
@@ -185,7 +185,7 @@
     }
     "TrailEntry"
 	{
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"TrailEntry"
 		"xpos"		"0"
 		"ypos"		"4"
@@ -204,6 +204,7 @@
 		"maxchars"		"3"
 		"NumericInputOnly"		"1"
 		"unicode"		"0"
+		"cvar_name"     "mom_trail_length"
         "actionsignallevel" "1"
 		"Font"		"DefaultVerySmall"
 	}

--- a/mp/game/momentum/resource/ui/SettingsPanel_AppearanceSettings.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_AppearanceSettings.res
@@ -63,7 +63,7 @@
     }
     "BodygroupCombo"
 	{
-		"ControlName"		"ComboBox"
+		"ControlName"		"CvarComboBox"
 		"fieldName"		"BodygroupCombo"
 		"xpos"		"3"
 		"ypos"		"0"
@@ -82,6 +82,7 @@
 		"maxchars"		"-1"
 		"NumericInputOnly"		"0"
 		"unicode"		"0"
+		"cvar_name"     "mom_ghost_bodygroup"
         "font" "DefaultVerySmall"
 	}
     

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
@@ -8,6 +8,7 @@
 
 #include <vgui_controls/Frame.h>
 #include <vgui_controls/ComboBox.h>
+#include <vgui_controls/CvarTextEntry.h>
 #include <vgui_controls/CvarToggleCheckButton.h>
 #include "controls/ModelPanel.h"
 #include "controls/ColorPicker.h"
@@ -21,8 +22,8 @@ using namespace vgui;
     button->SetArmedColor(color, color); \
     button->SetSelectedColor(color, color);
 
-AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pParent, "AppearanceSettings"), ghost_color("mom_ghost_color"), ghost_bodygroup("mom_ghost_bodygroup"),
-      ghost_trail_color("mom_trail_color"), ghost_trail_length("mom_trail_length"), m_bModelPreviewFrameIsFadingOut(false)
+AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pParent, "AppearanceSettings"), ghost_color("mom_ghost_color"), 
+    ghost_bodygroup("mom_ghost_bodygroup"), ghost_trail_color("mom_trail_color"), m_bModelPreviewFrameIsFadingOut(false)
 {
     // Outer frame for the model preview
     m_pModelPreviewFrame = new Frame(nullptr, "ModelPreviewFrame");
@@ -56,7 +57,8 @@ AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pPare
 
     m_pPickBodyColorButton = new Button(this, "PickBodyColorButton", "", this, "picker_body");
 
-    m_pTrailLengthEntry = new TextEntry(this, "TrailEntry");
+    m_pTrailLengthEntry = new CvarTextEntry(this, "TrailEntry", "mom_trail_length");
+    m_pTrailLengthEntry->SetAllowNumericInputOnly(true);
 
     m_pBodygroupCombo = new ComboBox(this, "BodygroupCombo", 15, false);
     m_pBodygroupCombo->AddItem("#MOM_Settings_Bodygroup_0", nullptr);
@@ -112,7 +114,6 @@ void AppearanceSettingsPage::LoadSettings()
     SetButtonColors();
 
     m_pBodygroupCombo->ActivateItemByRow(ghost_bodygroup.GetInt());
-    m_pTrailLengthEntry->SetText(ghost_trail_length.GetString());
 
     const bool result = m_pModelPreview->LoadModel(ENTITY_MODEL);
     if (result)
@@ -155,12 +156,6 @@ void AppearanceSettingsPage::OnTextChanged(Panel *p)
     {
         ghost_bodygroup.SetValue(m_pBodygroupCombo->GetActiveItem());
         UpdateModelSettings();
-    }
-    else if (p == m_pTrailLengthEntry)
-    {
-        char buf[3];
-        m_pTrailLengthEntry->GetText(buf, 3);
-        ghost_trail_length.SetValue(buf);
     }
 }
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.cpp
@@ -7,8 +7,8 @@
 #include "mom_shareddefs.h"
 
 #include <vgui_controls/Frame.h>
-#include <vgui_controls/ComboBox.h>
 #include <vgui_controls/CvarTextEntry.h>
+#include <vgui_controls/CvarComboBox.h>
 #include <vgui_controls/CvarToggleCheckButton.h>
 #include "controls/ModelPanel.h"
 #include "controls/ColorPicker.h"
@@ -60,7 +60,7 @@ AppearanceSettingsPage::AppearanceSettingsPage(Panel *pParent) : BaseClass(pPare
     m_pTrailLengthEntry = new CvarTextEntry(this, "TrailEntry", "mom_trail_length");
     m_pTrailLengthEntry->SetAllowNumericInputOnly(true);
 
-    m_pBodygroupCombo = new ComboBox(this, "BodygroupCombo", 15, false);
+    m_pBodygroupCombo = new CvarComboBox(this, "BodygroupCombo", 15, false, "mom_ghost_bodygroup", true);
     m_pBodygroupCombo->AddItem("#MOM_Settings_Bodygroup_0", nullptr);
     m_pBodygroupCombo->AddItem("#MOM_Settings_Bodygroup_1", nullptr);
     m_pBodygroupCombo->AddItem("#MOM_Settings_Bodygroup_2", nullptr);
@@ -113,8 +113,6 @@ void AppearanceSettingsPage::LoadSettings()
 {
     SetButtonColors();
 
-    m_pBodygroupCombo->ActivateItemByRow(ghost_bodygroup.GetInt());
-
     const bool result = m_pModelPreview->LoadModel(ENTITY_MODEL);
     if (result)
         UpdateModelSettings();
@@ -154,7 +152,6 @@ void AppearanceSettingsPage::OnTextChanged(Panel *p)
     
     if (p == m_pBodygroupCombo)
     {
-        ghost_bodygroup.SetValue(m_pBodygroupCombo->GetActiveItem());
         UpdateModelSettings();
     }
 }

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
@@ -39,7 +39,7 @@ private:
 
     ConVarRef ghost_color, ghost_bodygroup, ghost_trail_color; // MOM_TODO add the rest of visible things here
 
-    vgui::ComboBox *m_pBodygroupCombo;
+    vgui::CvarComboBox *m_pBodygroupCombo;
 
     vgui::CvarToggleCheckButton *m_pEnableTrail;
 

--- a/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/AppearanceSettingsPage.h
@@ -37,13 +37,13 @@ private:
     vgui::Frame *m_pModelPreviewFrame;
     CRenderPanel *m_pModelPreview;
 
-    ConVarRef ghost_color, ghost_bodygroup, ghost_trail_color, ghost_trail_length; // MOM_TODO add the rest of visible things here
+    ConVarRef ghost_color, ghost_bodygroup, ghost_trail_color; // MOM_TODO add the rest of visible things here
 
     vgui::ComboBox *m_pBodygroupCombo;
 
     vgui::CvarToggleCheckButton *m_pEnableTrail;
 
-    vgui::TextEntry *m_pTrailLengthEntry;
+    vgui::CvarTextEntry *m_pTrailLengthEntry;
     vgui::ColorPicker *m_pColorPicker;
     vgui::Button *m_pPickTrailColorButton, *m_pPickBodyColorButton;
 


### PR DESCRIPTION
Child of PR #676 . Related to issue #685 

Converted the bodygroup `ComboBox` to `CvarComboBox` & the trail length `TextEntry` to `CvarTextEntry`.

The color settings are handled in a popup so nothing was needed to be changed for those to be updated instantly.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review