### PR TITLE
Test for a short buffer after detonating two stickies

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -244,7 +244,10 @@ void CMomentumStickybombLauncher::SecondaryAttack()
         return;
 
     float flTimeFrom2Det = gpGlobals->curtime - m_fl2DetCooldownBeginTime;
-    if (flTimeFrom2Det < mom_sj_det_buffer_ticks.GetInt() * 0.015f + MOM_STICKYBOMB_TICK_EPSILON)
+    // TODO: replace with time value calculated from chosen tick count if this change is agreed upon
+    float flTestingBufferLength =
+        mom_sj_det_buffer_ticks.GetInt() * gpGlobals->interval_per_tick + MOM_STICKYBOMB_TICK_EPSILON;
+    if (flTimeFrom2Det < flTestingBufferLength)
         return;
 
     const auto pPlayer = GetPlayerOwner();
@@ -430,7 +433,11 @@ int CMomentumStickybombLauncher::DetonateRemoteStickybombs()
     {
         m_fl2DetCooldownBeginTime = gpGlobals->curtime;
     }
-    
+    else
+    {
+        m_fl2DetCooldownBeginTime = 0;
+    }
+
     for (const auto hCloseSticky : stickyBombsAffecting)
     {
         vecArmedStickies.FindAndRemove(hCloseSticky);

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -62,6 +62,8 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
 
     CNetworkVar(int, m_iStickybombCount);
     CNetworkVar(float, m_flChargeBeginTime);
+    CNetworkVar(float, m_fl2DetCooldownBeginTime);
+
     float m_flLastDenySoundTime;
 
     // This var mainly serves to disable the charge animation, sound and turn the charge meter red if set to false


### PR DESCRIPTION
Closes no issue - experimental.

 A short buffer after detonating two stickies before detonating another is allowed. Number of ticks for buffer can be changed with cvar mom_sj_det_buffer_ticks for testing purposes, default is 5 ticks (0.075s).

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->