### PR TITLE
Removed unneeded OK/Cancel/Apply buttons from momentum settings dialog

### DIFF
--- a/mp/game/momentum/resource/ui/SettingsPanel_Base.res
+++ b/mp/game/momentum/resource/ui/SettingsPanel_Base.res
@@ -13,7 +13,7 @@
 		"enabled"		"1"
 		"tabPosition"		"0"
 		"settitlebarvisible"		"1"
-        "sheetinset_bottom" "24"
+        "sheetinset_bottom" "0"
 		"title"		"#MOM_Settings_Title"
 	}
     "Sheet"

--- a/mp/src/game/client/momentum/ui/SettingsPanel/MomentumSettingsDialog.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/MomentumSettingsDialog.cpp
@@ -47,7 +47,9 @@ CMomentumSettingsDialog::CMomentumSettingsDialog(VPANEL parent) : BaseClass(null
 
     SetMinimumSize(GetScaledVal(400), GetScaledVal(260));
     SetSize(GetScaledVal(400), GetScaledVal(260));
-    SetApplyButtonVisible(true);
+    SetOKButtonVisible(false);
+    SetCancelButtonVisible(false);
+    SetApplyButtonVisible(false);
     SetTitleBarVisible(true);
     SetMenuButtonResponsive(false);
     SetSysMenu(nullptr);

--- a/mp/src/game/client/momentum/ui/SettingsPanel/SettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/SettingsPage.cpp
@@ -22,20 +22,6 @@ void SettingsPage::NotifyParentOfUpdate()
     PostMessage(m_pScrollPanel->GetParent()->GetVPanel(), new KeyValues("ApplyButtonEnable"));
 }
 
-void SettingsPage::OnApplyChanges()
-{
-    // We're going to fire this to all our children, so the CVarToggleCheckButtons apply
-    // their new settings to the convars.
-    for (int i = 0; i < GetChildCount(); i++)
-    {
-        Panel *pChild = GetChild(i);
-        if (pChild)
-        {
-            PostMessage(pChild, new KeyValues("ApplyChanges"));
-        }
-    }
-}
-
 void SettingsPage::OnPageShow()
 {
     LoadSettings();

--- a/mp/src/game/client/momentum/ui/SettingsPanel/SettingsPage.h
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/SettingsPage.h
@@ -27,10 +27,6 @@ class SettingsPage : public vgui::PropertyPage
 
     // MOM_TODO: Add more message funcs if need be (other controls added)
 
-    // When the "Apply" button is pressed. Each settings panel should handle this separately.
-    // Due to different controls for each, which cannot be automated through here.
-    void OnApplyChanges() OVERRIDE;
-
     // Called when this page needs to load the current values into controls on the page.
     // This is primarily used for ComboBoxes, since there is no ConvarComboBox class.
     virtual void LoadSettings()
@@ -92,14 +88,6 @@ class SettingsPageScrollPanel : public vgui::ScrollableEditablePanel
         if (m_pChild)
         {
             m_pChild->OnPageHide();
-        }
-    }
-
-    MESSAGE_FUNC(OnApplyChanges, "ApplyChanges")
-    {
-        if (m_pChild)
-        {
-            m_pChild->OnApplyChanges();
         }
     }
 


### PR DESCRIPTION
Closes #685 

Since all of the options in this panel are updated instantly now, these buttons are no longer needed. 
Did this by

- Setting the visibility of them to `false` in the creation of `MomentumSettingsDialog`
- Setting the `sheetinset_bottom` in `SettingsPanel_Base.res` to `0`. This removes the space where the buttons used to sit.
- Removed unneeded `OnApplyChanges()` override and it's `MESSAGE_FUNC`.

Screenshot of change: 
![image](https://user-images.githubusercontent.com/9014762/79702889-df1c5700-825c-11ea-80fe-06e3f571c247.png)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review