### PR TITLE
Included gravity component in calculating jump height

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1076,7 +1076,7 @@ bool CMomentumGameMovement::CheckJumpButton()
     if (g_pGameModeSystem->IsTF2BasedMode())
     {
         // Gravity dependance, but ensuring it exactly gives 289 at 800 gravity
-        float height = 289.0f * 289.0f / (2.0f * 800.0f);
+        float height = 289.0f * 289.0f / (2.0f * GetCurrentGravity());
         float vel = GetCurrentGravity() == 800.0f ? 289.0f : sqrt(2.f * GetCurrentGravity() * height);
         if (player->m_Local.m_bDucking)
         {
@@ -1089,7 +1089,9 @@ bool CMomentumGameMovement::CheckJumpButton()
     }
     else
     {
-        mv->m_vecVelocity[2] += flGroundFactor * sqrt(2.f * GetCurrentGravity() * 57.0f); // 2 * gravity * height
+        float height = 301.99337741083f * 301.99337741083f / (2.0f * GetCurrentGravity());
+        float vel = GetCurrentGravity() == 800.0f ? 301.99337741083f : sqrt(2.f * GetCurrentGravity() * height);
+        mv->m_vecVelocity[2] += flGroundFactor * vel; // 2 * gravity * height
     }
 
     // stamina stuff (scroll/kz gamemode only)


### PR DESCRIPTION
Closes #539 

Added in gravity calculation for jump height/velocity in `mom_gamemovement.cpp`.

- Replaced the `800` constant in the TF2 jump height calculation with a `GetCurrentGravity()` call.
- For non-TF2 gamemodes, found the appropriate value given that height should be exactly 57 with 800 gravity (~301.99337741083), then added in the gravity component. 
IE found `x` where `57 = x^2 / (2 * 800)`.
   - Used this to add gravity to the calculation as is done in the TF2 calculation.

Here are the values with these new changes & 800 gravity:
![image](https://user-images.githubusercontent.com/9014762/79724647-bf0c8800-829c-11ea-8999-84a5b150172c.png)
and here they are without (current dev branch):
![image](https://user-images.githubusercontent.com/9014762/79725485-24ad4400-829e-11ea-898c-75802b25e859.png)

Did not touch `gamemovement.cpp`. 

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review