### PR TITLE
Added gravity into jump height calculation

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1078,15 +1078,13 @@ bool CMomentumGameMovement::CheckJumpButton()
     // Acclerate upward
     float startz = mv->m_vecVelocity[2];
 
-    const float fJumpFactor = sqrtf(2.f * sv_gravity.GetFloat() * g_pGameModeSystem->GetGameMode()->GetJumpHeight());
-
     if (!g_pGameModeSystem->IsCSBasedMode() && (player->m_Local.m_bDucking || player->GetFlags() & FL_DUCKING))
     {
-        mv->m_vecVelocity[2] = flGroundFactor * fJumpFactor;
+        mv->m_vecVelocity[2] = flGroundFactor * g_pGameModeSystem->GetGameMode()->GetJumpFactor();
     }
     else
     {
-        mv->m_vecVelocity[2] += flGroundFactor * fJumpFactor;
+        mv->m_vecVelocity[2] += flGroundFactor * g_pGameModeSystem->GetGameMode()->GetJumpFactor();
     }
 
     // stamina stuff (scroll/kz gamemode only)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -50,6 +50,12 @@ void CGameModeBase::SetGameModeVars()
     sv_edge_fix.SetValue(false); // MOM_TODO Let people test the edge fix in 0.8.4 so we can get their opinions
 }
 
+float CGameModeBase::GetJumpFactor()
+{
+    // sqrt(JumpHeight * 2 * GamemodeBaseGrav)
+    return sqrtf(57.0f * 2.0f * 800.0f);
+}
+
 void CGameModeBase::OnPlayerSpawn(CMomentumPlayer *pPlayer)
 {
 #ifdef GAME_DLL
@@ -120,6 +126,11 @@ void CGameMode_RJ::SetGameModeVars()
     sv_ground_trigger_fix.SetValue(false); // MOM_TODO Remove when bounce triggers have been implemented
 }
 
+float CGameMode_RJ::GetJumpFactor()
+{
+    return 289.0f;
+}
+
 void CGameMode_RJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
 {
     CGameModeBase::OnPlayerSpawn(pPlayer);
@@ -151,6 +162,11 @@ void CGameMode_SJ::SetGameModeVars()
     sv_considered_on_ground.SetValue(2);
     sv_duck_collision_fix.SetValue(false);
     sv_ground_trigger_fix.SetValue(false); // MOM_TODO Remove when bounce triggers have been implemented
+}
+
+float CGameMode_SJ::GetJumpFactor()
+{
+    return 289.0f;
 }
 
 void CGameMode_SJ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
@@ -192,6 +208,11 @@ void CGameMode_Ahop::SetGameModeVars()
     sv_maxspeed.SetValue(320);
     sv_stopspeed.SetValue(100);
     sv_considered_on_ground.SetValue(2);
+}
+
+float CGameMode_Ahop::GetJumpFactor()
+{
+    return 160.0f;
 }
 
 void CGameMode_Ahop::OnPlayerSpawn(CMomentumPlayer *pPlayer)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -26,7 +26,7 @@ public:
 
     // Movement vars
     virtual float       GetViewScale() = 0;
-    virtual float       GetJumpHeight() = 0;
+    virtual float       GetJumpFactor() = 0;
 
     virtual ~IGameMode() {}
 };
@@ -42,7 +42,7 @@ public:
     const char* GetGameModeCfg() override { return nullptr; }
     float GetIntervalPerTick() override { return 0.015f; }
     float GetViewScale() override { return 0.5f; }
-    float GetJumpHeight() override { return 57.0f; }
+    float GetJumpFactor() override;
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return true; }
@@ -98,7 +98,7 @@ public:
     const char* GetMapPrefix() override { return "rj_"; }
     const char* GetGameModeCfg() override { return "rj.cfg"; }
     float GetViewScale() override { return 1.0f; }
-    float GetJumpHeight() override { return 52.200625; }
+    float GetJumpFactor() override;
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
@@ -115,7 +115,7 @@ class CGameMode_SJ : public CGameModeBase
     const char *GetMapPrefix() override { return "sj_"; }
     const char *GetGameModeCfg() override { return "sj.cfg"; }
     float GetViewScale() override { return 1.0f; }
-    float GetJumpHeight() override { return 52.200625; }
+    float GetJumpFactor() override;
 
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
@@ -153,7 +153,7 @@ public:
     bool WeaponIsAllowed(WeaponID_t weapon) override;
 
     float GetViewScale() override { return 1.0f; }
-    float GetJumpHeight() override { return 21.333333333333333; }
+    float GetJumpFactor() override;
 };
 
 class CGameModeSystem : public CAutoGameSystem


### PR DESCRIPTION
Closes #539 when merged into `develop`

Found the factors based on what the jump height should be at the gamemode's default gravity & added `sv_gravity` into the calculation.
IE. found `x^2` where `jumpHeight = x^2 / (2 * baseGrav)`. For ahop, `jumpHeight ~ 21.333333` and `baseGrav = 600`.
I just used the squared value since the calculation involves squaring anyhow.

- **ahop** -> jump should be `21.333333..` at base gravity (`600`). This gives `25600` (not squared is `160`).
- **TF2** -> jump should be ~`52.200625` at base gravity (`800`). This gives `83521` (not squared is `289.0`).
- **Base** -> jump should be `57` at base gravity (`800`). This gives `91200` (not squared is `301.99337741083..`).

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review