### PR TITLE
Add sticky armtime proxy

### DIFF
--- a/mp/game/momentum/materials/models/weapons/mom_stickybomb_classic/mom_stickybomb_classic.vmt
+++ b/mp/game/momentum/materials/models/weapons/mom_stickybomb_classic/mom_stickybomb_classic.vmt
@@ -5,9 +5,8 @@
 	$bumpMap				"models/weapons/mom_stickybomb_classic/mom_stickybomb_classic_n"
 	
 	$selfIllum 						1									//Disables Shading on $baseTexture's alpha
-	$selfIllumTint 					"[1 1 1]"							//Tints the self-illumination
-	//$selfIllumFresnel				1									//Enables self-illumination $selfIllumFresnelMinMaxExp
-	//$selfIllumFresnelMinMaxExp	"[0 5 3]"							//Sets minimum intensity [0] , maximum intensity [1] and fresnel factor [2]
+	$selfIllumFresnel				1									//Enables self-illumination $selfIllumFresnelMinMaxExp
+	$selfIllumFresnelMinMaxExp	    "[0 1 0]"							//Sets minimum intensity [0] , maximum intensity [1] and fresnel factor [2]
 	
 	$envMap						"cubemaps\cubemap_sheen001.hdr"		//Sets the closest env_cubemap as the environment map (specular reflection)
 	$envMapTint					"[.3 .3 .32]"						//Tints the envmap
@@ -24,5 +23,11 @@
 	$rimlightexponent			1									//Same functionality as $phongexponent
 	$rimlightBoost				.5									//Same functionality as $phongboost
 
-
+    Proxies
+    {
+        ArmTime
+        {
+			resultvar	"$selfIllumFresnelMinMaxExp[1]"
+        }
+    }
 }

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -13,6 +13,8 @@
 #include "fx_mom_shared.h"
 #include "physics_collisionevent.h"
 #include "momentum/mom_stickybomb_verts.h"
+#else
+#include "functionproxy.h"
 #endif
 
 #include "tier0/memdbgon.h"
@@ -173,6 +175,26 @@ void CMomStickybomb::Simulate()
 
     BaseClass::Simulate();
 }
+
+class CStickybombArmTimeProxy : public CResultProxy
+{
+public:
+    void OnBind(void *pC_BaseEntity) override
+    {
+        Assert(m_pResult);
+
+        if (!pC_BaseEntity)
+            return;
+
+        const auto pEntity = BindArgToEntity(pC_BaseEntity);
+        if (!pEntity)
+            return;
+
+        m_pResult->SetFloatValue(RemapValClamped(gpGlobals->curtime - pEntity->m_flSpawnTime, MOM_STICKYBOMB_ARMTIME - 0.15f, MOM_STICKYBOMB_ARMTIME, 0.0f, 1.0f));
+    }
+};
+
+EXPOSE_INTERFACE(CStickybombArmTimeProxy, IMaterialProxy, "ArmTime" IMATERIAL_PROXY_INTERFACE_VERSION);
 
 #else
 

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -166,7 +166,7 @@ void CMomStickybomb::OnDataChanged(DataUpdateType_t type)
 
 void CMomStickybomb::Simulate()
 {
-    if (!m_bPulsed && IsArmed())
+    if (!m_bPulsed && (gpGlobals->curtime - m_flSpawnTime) > (MOM_STICKYBOMB_ARMTIME - 0.25f))
     {
         ParticleProp()->Create(g_pWeaponDef->GetWeaponParticle(WEAPON_STICKYLAUNCHER, "StickybombPulse"), PATTACH_ABSORIGIN_FOLLOW);
 


### PR DESCRIPTION
This branch adds an `ArmTime` stickybomb proxy that changes the blue selfillum color of the stickybomb to only show when armed. By default, it uses a buffer that is remapping from [armtime - 0.15, armtime] to [0, 1] for a fade-in effect. You can see this proxy in action here:

https://cdn.discordapp.com/attachments/602643431453360148/701654101259452456/2020-04-20_00-42-13.mp4

The time for the pulse particle was also bumped forward 0.25 seconds to better match the arming of the stickybomb, as the default (0.8.4) time was visibly late compared to arm time.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->