### PR TITLE
Move localization methods

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
@@ -101,21 +101,6 @@ C_RunComparisons::~C_RunComparisons() { UnloadComparisons(); }
 
 void C_RunComparisons::Init()
 {
-    // LOCALIZE STUFF HERE
-    FIND_LOCALIZATION(m_wStage, "#MOM_Stage");
-    FIND_LOCALIZATION(m_wCheckpoint, "#MOM_Checkpoint");
-    LOCALIZE_TOKEN(StageTime, "#MOM_Compare_Time_Zone", stageTimeLocalized);
-    LOCALIZE_TOKEN(OverallTime, "#MOM_Compare_Time_Overall", overallTimeLocalized);
-    LOCALIZE_TOKEN(Compare, "#MOM_Compare_Against", compareLocalized);
-    LOCALIZE_TOKEN(VelAvg, "#MOM_Compare_Velocity_Avg", velocityAvgLocalized);
-    LOCALIZE_TOKEN(VelMax, "#MOM_Compare_Velocity_Max", velocityMaxLocalized);
-    LOCALIZE_TOKEN(VelEnter, "#MOM_Compare_Velocity_Enter", velocityStartLocalized);
-    LOCALIZE_TOKEN(VelExit, "#MOM_Compare_Velocity_Exit", velocityExitLocalized);
-    LOCALIZE_TOKEN(Sync1, "#MOM_Compare_Sync1", sync1Localized);
-    LOCALIZE_TOKEN(Sync2, "#MOM_Compare_Sync2", sync2Localized);
-    LOCALIZE_TOKEN(Jumps, "#MOM_Compare_Jumps", jumpsLocalized);
-    LOCALIZE_TOKEN(Strafes, "#MOM_Compare_Strafes", strafesLocalized);
-
     if (!m_bLoadedBogusComparison)
         ListenForGameEvent("replay_save");
 }
@@ -145,6 +130,21 @@ void C_RunComparisons::Reset()
     m_iMaxWide = m_iDefaultWidth;
     m_iWidestLabel = 0;
     m_iWidestValue = 0;
+
+    // LOCALIZE STUFF HERE
+    FIND_LOCALIZATION(m_wStage, "#MOM_Stage");
+    FIND_LOCALIZATION(m_wCheckpoint, "#MOM_Checkpoint");
+    LOCALIZE_TOKEN(StageTime, "#MOM_Compare_Time_Zone", stageTimeLocalized);
+    LOCALIZE_TOKEN(OverallTime, "#MOM_Compare_Time_Overall", overallTimeLocalized);
+    LOCALIZE_TOKEN(Compare, "#MOM_Compare_Against", compareLocalized);
+    LOCALIZE_TOKEN(VelAvg, "#MOM_Compare_Velocity_Avg", velocityAvgLocalized);
+    LOCALIZE_TOKEN(VelMax, "#MOM_Compare_Velocity_Max", velocityMaxLocalized);
+    LOCALIZE_TOKEN(VelEnter, "#MOM_Compare_Velocity_Enter", velocityStartLocalized);
+    LOCALIZE_TOKEN(VelExit, "#MOM_Compare_Velocity_Exit", velocityExitLocalized);
+    LOCALIZE_TOKEN(Sync1, "#MOM_Compare_Sync1", sync1Localized);
+    LOCALIZE_TOKEN(Sync2, "#MOM_Compare_Sync2", sync2Localized);
+    LOCALIZE_TOKEN(Jumps, "#MOM_Compare_Jumps", jumpsLocalized);
+    LOCALIZE_TOKEN(Strafes, "#MOM_Compare_Strafes", strafesLocalized);
 }
 
 void C_RunComparisons::LoadComparisons()

--- a/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
@@ -111,12 +111,6 @@ void CHudKeyPressDisplay::Init()
     wcscpy(m_pwRight, L"D");
     wcscpy(m_pwStrafe, L"O");
 
-    // localize jump and duck strings
-    FIND_LOCALIZATION(m_pwJump, "#MOM_Jump");
-    FIND_LOCALIZATION(m_pwDuck, "#MOM_Duck");
-    FIND_LOCALIZATION(m_pwM1, "#MOM_M1");
-    FIND_LOCALIZATION(m_pwM2, "#MOM_M2");
-
     m_fJumpColorUntil = m_fDuckColorUntil = 0;
 
     m_nButtons = 0;
@@ -308,6 +302,12 @@ void CHudKeyPressDisplay::Reset()
     m_nDisabledButtons = 0;
     m_fDuckColorUntil = 0;
     m_fJumpColorUntil = 0;
+
+    // localize jump and duck strings
+    FIND_LOCALIZATION(m_pwJump, "#MOM_Jump");
+    FIND_LOCALIZATION(m_pwDuck, "#MOM_Duck");
+    FIND_LOCALIZATION(m_pwM1, "#MOM_M1");
+    FIND_LOCALIZATION(m_pwM2, "#MOM_M2");
 }
 
 int CHudKeyPressDisplay::GetTextCenter(HFont font, wchar_t *wstring)

--- a/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
+++ b/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
@@ -83,8 +83,6 @@ C_MOMReplayUI::C_MOMReplayUI(IViewPort *pViewport) : Frame(nullptr, PANEL_REPLAY
     SetBounds(20, 100, GetScaledVal(280), GetScaledVal(150));
     SetTitle("#MOM_ReplayControls", true);
 
-    FIND_LOCALIZATION(m_pwReplayTime, "#MOM_ReplayTime");
-    FIND_LOCALIZATION(m_pwReplayTimeTick, "#MOM_ReplayTimeTick");
     m_pSpecGUI = nullptr;
 }
 
@@ -255,6 +253,8 @@ void C_MOMReplayUI::ShowPanel(bool state)
     if (pSpecUI && pSpecUI->IsVisible() && ipanel()->IsMouseInputEnabled(pSpecUI->GetVPanel()))
         SetMouseInputEnabled(true);
     if (state)
+        FIND_LOCALIZATION(m_pwReplayTime, "#MOM_ReplayTime");
+        FIND_LOCALIZATION(m_pwReplayTimeTick, "#MOM_ReplayTimeTick");
         MoveToFront();
     m_bWasClosed = false;
 }

--- a/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
+++ b/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
@@ -253,9 +253,11 @@ void C_MOMReplayUI::ShowPanel(bool state)
     if (pSpecUI && pSpecUI->IsVisible() && ipanel()->IsMouseInputEnabled(pSpecUI->GetVPanel()))
         SetMouseInputEnabled(true);
     if (state)
+    {
         FIND_LOCALIZATION(m_pwReplayTime, "#MOM_ReplayTime");
         FIND_LOCALIZATION(m_pwReplayTimeTick, "#MOM_ReplayTimeTick");
         MoveToFront();
+    }
     m_bWasClosed = false;
 }
 

--- a/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.cpp
+++ b/mp/src/game/client/momentum/ui/spectate/mom_spectator_gui.cpp
@@ -83,12 +83,6 @@ CMOMSpectatorGUI::CMOMSpectatorGUI(IViewPort *pViewPort) : EditablePanel(nullptr
 
     SetMouseInputEnabled(false);
     InvalidateLayout();
-
-    FIND_LOCALIZATION(m_pwGainControl, "#MOM_SpecGUI_GainControl");
-    FIND_LOCALIZATION(m_pwRunTime, "#MOM_MF_RunTime");
-    FIND_LOCALIZATION(m_pwSpecMap, "#Spec_Map");
-    FIND_LOCALIZATION(m_pwWatchingGhost, "#MOM_WatchingGhost");
-    FIND_LOCALIZATION(m_pwWatchingReplay, "#MOM_WatchingReplay");
 }
 
 //-----------------------------------------------------------------------------
@@ -209,9 +203,16 @@ void CMOMSpectatorGUI::ShowPanel(bool bShow)
 
     SetVisible(bShow);
 
-    if (!bShow)
+    if (bShow)
     {
-
+        FIND_LOCALIZATION(m_pwGainControl, "#MOM_SpecGUI_GainControl");
+        FIND_LOCALIZATION(m_pwRunTime, "#MOM_MF_RunTime");
+        FIND_LOCALIZATION(m_pwSpecMap, "#Spec_Map");
+        FIND_LOCALIZATION(m_pwWatchingGhost, "#MOM_WatchingGhost");
+        FIND_LOCALIZATION(m_pwWatchingReplay, "#MOM_WatchingReplay");
+    }
+    else
+    {
         if (m_pReplayControls)
         {
             m_pReplayControls->SetWasClosed(false);

--- a/mp/src/game/server/momentum/mom_ruler.cpp
+++ b/mp/src/game/server/momentum/mom_ruler.cpp
@@ -51,7 +51,7 @@ CMOMRulerTool::~CMOMRulerTool()
     m_pBeamConnector = nullptr;
 }
 
-void CMOMRulerTool::PostInit()
+void CMOMRulerTool::LevelInitPostEntity() 
 {
     FIND_LOCALIZATION(m_wDistanceFormat, "#MOM_Ruler_Distance");
 }

--- a/mp/src/game/server/momentum/mom_ruler.h
+++ b/mp/src/game/server/momentum/mom_ruler.h
@@ -46,7 +46,7 @@ public:
     CMOMRulerTool(const char* pName);
     ~CMOMRulerTool();
 
-    void PostInit() OVERRIDE;
+    void LevelInitPostEntity() OVERRIDE;
 
     void ConnectMarks();
     void Reset();


### PR DESCRIPTION
Closes #308 

This PR moves localization methods so it's possible to reload localization files without the need to restart the game.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->