### PR TITLE
Fix weapons casting shadows while in spectator mode

### DIFF
--- a/mp/src/game/client/c_basecombatweapon.cpp
+++ b/mp/src/game/client/c_basecombatweapon.cpp
@@ -196,7 +196,7 @@ bool C_BaseCombatWeapon::IsCarrierAlive() const
 //-----------------------------------------------------------------------------
 ShadowType_t C_BaseCombatWeapon::ShadowCastType()
 {
-	if ( IsEffectActive( /*EF_NODRAW |*/ EF_NOSHADOW ) )
+	if ( IsEffectActive( EF_NODRAW | EF_NOSHADOW ) )
 		return SHADOWS_NONE;
 
 	if (!IsBeingCarried())

--- a/mp/src/game/client/c_baseviewmodel.cpp
+++ b/mp/src/game/client/c_baseviewmodel.cpp
@@ -39,10 +39,6 @@ MAKE_TOGGLE_CONVAR_CV(cl_righthand, "1", FCVAR_ARCHIVE, "Use right-handed view m
 
 MAKE_CONVAR(r_viewmodel_opacity, "1", FCVAR_ARCHIVE, "Set the opacity of view models. MIN = 0.01, MAX = 1.\n", 0.01f, 1.0f);
 
-#ifdef TF_CLIENT_DLL
-	ConVar cl_flipviewmodels( "cl_flipviewmodels", "0", FCVAR_USERINFO | FCVAR_ARCHIVE | FCVAR_NOT_CONNECTED, "Flip view models." );
-#endif
-
 void PostToolMessage( HTOOLHANDLE hEntity, KeyValues *msg );
 
 void FormatViewModelAttachment( Vector &vOrigin, bool bInverse )
@@ -200,14 +196,6 @@ bool C_BaseViewModel::ShouldFlipViewModel()
 		const auto pInfo = pWeapon->GetWeaponScript();
 		return pInfo->bAllowFlipping && pInfo->bBuiltRightHanded != cl_righthand.GetBool();
 	}
-
-#ifdef TF_CLIENT_DLL
-	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();
-	if ( pWeapon )
-	{
-		return pWeapon->m_bFlipViewModel != cl_flipviewmodels.GetBool();
-	}
-#endif
 
 	return false;
 }

--- a/mp/src/game/client/c_vguiscreen.cpp
+++ b/mp/src/game/client/c_vguiscreen.cpp
@@ -583,9 +583,13 @@ int	C_VGuiScreen::DrawModel( int flags )
 		return 0;
 
     // Are we attached to a viewmodel that's hidden?
-    if (IsAttachedToViewModel() && pLocalPlayer && pLocalPlayer->GetViewModel(0, false) && 
-        pLocalPlayer->GetViewModel(0, false)->IsEffectActive(EF_NODRAW))
-        return 0;
+	if (IsAttachedToViewModel())
+	{
+		const auto pViewModel = pLocalPlayer->GetViewModel(0, false);
+
+		if (pViewModel && pViewModel->IsEffectActive(EF_NODRAW))
+			return 0;
+	}
 
 	// Recompute the panel-to-world center
 	// FIXME: Can this be cached off?

--- a/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/ComparisonsSettingsPage.cpp
@@ -114,6 +114,7 @@ void ComparisonsSettingsPage::InitBogusComparePanel()
     m_pBogusComparisonsPanel->SetPaintBackgroundEnabled(true);
     m_pBogusComparisonsPanel->SetPaintBackgroundType(2);
     m_pBogusComparisonsPanel->Init();
+    m_pBogusComparisonsPanel->Reset();
     int x, y, wid, tal;
     m_pComparisonsFrame->GetClientArea(x, y, wid, tal);
     m_pBogusComparisonsPanel->SetBounds(x, y, wid, tal);

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -909,6 +909,9 @@ void CMomentumLobbySystem::SetSpectatorTarget(const CSteamID &ghostTarget, bool 
     CHECK_STEAM_API(SteamMatchmaking());
     CHECK_STEAM_API(SteamUser());
 
+    if (!LobbyValid())
+        return;
+
     SpectateMessageType_t type;
     if (bStartedSpectating)
     {


### PR DESCRIPTION
Closes #646

This branch fixes weapons casting shadows when in spectate, as well as fixes some things left over from previous merges like lobby spec messages happening while not in a lobby, and the bogus comparison panel in the momentum settings panel not having strings.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->