### PR TITLE
Fix for up/down arrow key presses on CvarComboBox 

### DIFF
--- a/mp/src/public/vgui_controls/CvarComboBox.h
+++ b/mp/src/public/vgui_controls/CvarComboBox.h
@@ -20,6 +20,7 @@ class CvarComboBox : public ComboBox
     void ApplyChanges();
     bool HasBeenModified();
 
+    void OnKeyCodeTyped(KeyCode code) OVERRIDE;
     void OnThink() OVERRIDE;
     void ApplySettings(KeyValues *inResourceData) OVERRIDE;
     void GetSettings(KeyValues *outResources) OVERRIDE;

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -71,13 +71,13 @@ void CvarComboBox::Reset()
     if (!m_cvar.IsValid())
         return;
 
-    m_iStartValue = m_cvar.GetInt();
-    ActivateItemByRow(m_iStartValue - m_iCvarMin);
+    m_iStartValue = m_cvar.GetInt() - m_iCvarMin;
+    ActivateItemByRow(m_iStartValue);
 }
 
 bool CvarComboBox::HasBeenModified()
 {
-    return GetActiveItem() != m_iStartValue - m_iCvarMin;
+    return GetActiveItem() != m_iStartValue;
 }
 
 void CvarComboBox::OnTextChanged()

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -85,8 +85,8 @@ void CvarComboBox::OnTextChanged()
     if (HasBeenModified())
     {
         PostActionSignal(new KeyValues("ControlModified"));
+        ApplyChanges();
     }
-    ApplyChanges();
 }
 
 void CvarComboBox::ApplySettings(KeyValues *inResourceData)

--- a/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarComboBox.cpp
@@ -43,6 +43,25 @@ int CvarComboBox::AddItem(const char* itemText, const KeyValues* userData)
     return iRtnVal;
 }
 
+void CvarComboBox::OnKeyCodeTyped(KeyCode code)
+{
+    BaseClass::OnKeyCodeTyped(code);
+    // updates cvar to text in combobox when up/down keys are used
+    int activeItem = GetActiveItem();
+    if (code == KEY_DOWN)
+    {
+        activeItem++;
+        activeItem %= GetItemCount();
+    }
+    else if (code == KEY_UP)
+    {
+        activeItem--;
+        if (activeItem < 0)
+            activeItem = GetItemCount() - 1;
+    }
+    ActivateItemByRow(activeItem);
+}
+
 void CvarComboBox::OnThink()
 {
     if (m_cvar.IsValid())


### PR DESCRIPTION
The new CvarComboBox implementation failed to account for using up/down arrow keys to change the combobox selection. When using them the cvar isn't instantly updated, which makes the text displayed in the combobox not match what the actual cvar value is.

This fix overrides the `OnKeyCodeTyped` function to change the combobox's active item & apply that to the cvar via `ApplyChanges()`.

There are two other changes:

- Fixed `m_iStartValue` not being set correctly, causing extra `ApplyChanges()` calls.
- When the `OnTextChanged()` override is called, `ApplyChanges()` is now called only if there has been a modification.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review