### PR TITLE
Changed GameUI mouse settings to apply instantly

### DIFF
--- a/mp/game/momentum/resource/optionssubmouse.res
+++ b/mp/game/momentum/resource/optionssubmouse.res
@@ -33,6 +33,7 @@
 	{
 		"ControlName"		"CvarToggleCheckButton"
 		"fieldName"		"MouseFilter"
+        "cvar_name"     "m_filter"
 		"xpos"		"200"
 		"ypos"		"10"
 		"tooltiptext"		"#GameUI_MouseFilterLabel"
@@ -62,6 +63,7 @@
 	{
 		"ControlName"		"CvarToggleCheckButton"
 		"fieldName"		"MouseRaw"
+        "cvar_name"     "m_rawinput"
 		"xpos"		"30"
 		"ypos"		"70"
 		"tooltiptext"		"#GameUI_MouseRaw_Hint"
@@ -121,6 +123,7 @@
 	{
 		"ControlName"		"CvarSlider"
 		"fieldName"		"Slider"
+        "cvar_name"     "sensitivity"
 		"xpos"		"200"
 		"ypos"		"40"
 		"wide"		"200"
@@ -138,8 +141,9 @@
 	}
 	"SensitivityLabel"
 	{
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"SensitivityLabel"
+		"cvar_name"     "sensitivity"
 		"xpos"		"400"
 		"ypos"		"40"
 		"wide"		"50"
@@ -162,6 +166,7 @@
 	{
 		"ControlName"		"CvarSlider"
 		"fieldName"		"MouseAccelerationSlider"
+        "cvar_name"     "m_customaccel_exponent"
 		"xpos"		"200"
 		"ypos"		"100"
 		"tooltiptext"		"#GameUI_MouseAccelerationAmount_Hint"
@@ -181,8 +186,9 @@
 	}
 	"MouseAccelerationLabel"
 	{
-		"ControlName"		"TextEntry"
+		"ControlName"		"CvarTextEntry"
 		"fieldName"		"MouseAccelerationLabel"
+        "cvar_name"     "m_customaccel_exponent"
 		"xpos"		"400"
 		"ypos"		"100"
 		"tooltiptext"		"#GameUI_MouseAccelerationAmount_Hint"
@@ -200,7 +206,7 @@
 		"textHidden"		"0"
 		"editable"		"1"
 		"maxchars"		"-1"
-		"NumericInputOnly"		"0"
+		"NumericInputOnly"		"1"
 		"unicode"		"0"
 	}
 	"Label3"

--- a/mp/src/gameui/CvarNegateCheckButton.cpp
+++ b/mp/src/gameui/CvarNegateCheckButton.cpp
@@ -120,5 +120,6 @@ void CvarNegateCheckButton::OnButtonChecked()
 	if (HasBeenModified())
 	{
 		PostActionSignal(new KeyValues("ControlModified"));
+        ApplyChanges();
 	}
 }

--- a/mp/src/gameui/OptionsSubMouse.cpp
+++ b/mp/src/gameui/OptionsSubMouse.cpp
@@ -23,7 +23,7 @@
 
 using namespace vgui;
 
-COptionsSubMouse::COptionsSubMouse(vgui::Panel *parent) : PropertyPage(parent, NULL)
+COptionsSubMouse::COptionsSubMouse(vgui::Panel *parent) : PropertyPage(parent, NULL), m_cvarCustomAccel("m_customaccel")
 {
     SetSize(20, 20);
 
@@ -75,7 +75,7 @@ void COptionsSubMouse::OnResetData()
 {
 	m_pReverseMouseCheckBox->Reset();
 
-    m_pMouseAccelToggle->SetSelected(ConVarRef("m_customaccel").GetInt() == 3);
+    m_pMouseAccelToggle->SetSelected(m_cvarCustomAccel.GetInt() == 3);
 
     bool bEnabled = m_pMouseAccelToggle->IsSelected();
     m_pMouseAccelSlider->SetEnabled(bEnabled);
@@ -90,7 +90,7 @@ void COptionsSubMouse::OnCheckButtonChecked(Panel *panel)
     if (panel == m_pMouseAccelToggle)
     {
         bool bMouseAccelEnabled = m_pMouseAccelToggle->IsSelected();
-        ConVarRef("m_customaccel").SetValue(bMouseAccelEnabled ? 3 : 0);
+        m_cvarCustomAccel.SetValue(bMouseAccelEnabled ? 3 : 0);
         m_pMouseAccelSlider->SetEnabled(bMouseAccelEnabled);
         m_pMouseAccelLabel->SetEnabled(bMouseAccelEnabled);
     }

--- a/mp/src/gameui/OptionsSubMouse.cpp
+++ b/mp/src/gameui/OptionsSubMouse.cpp
@@ -17,7 +17,7 @@
 #include <vgui/IScheme.h>
 #include "tier1/convar.h"
 #include <stdio.h>
-#include <vgui_controls/TextEntry.h>
+#include <vgui_controls/CvarTextEntry.h>
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
@@ -46,37 +46,19 @@ COptionsSubMouse::COptionsSubMouse(vgui::Panel *parent) : PropertyPage(parent, N
         "m_rawinput");
 
 	m_pMouseSensitivitySlider = new CvarSlider( this, "Slider", "#GameUI_MouseSensitivity",
-        0.0001f, 20.0f, "sensitivity", true);
+        0.0001f, 20.0f, "sensitivity", true, true);
 
-    m_pMouseSensitivityLabel = new TextEntry(this, "SensitivityLabel");
+    m_pMouseSensitivityLabel = new CvarTextEntry(this, "SensitivityLabel", "sensitivity", "%.3f");
     m_pMouseSensitivityLabel->AddActionSignalTarget(this);
+    m_pMouseSensitivityLabel->SetAllowNumericInputOnly(true);
 
-    m_pMouseAccelLabel = new TextEntry(this, "MouseAccelerationLabel");
+    m_pMouseAccelLabel = new CvarTextEntry(this, "MouseAccelerationLabel", "m_customaccel_exponent", "%.3f");
     m_pMouseAccelLabel->AddActionSignalTarget(this);
+    m_pMouseAccelLabel->SetAllowNumericInputOnly(true);
     m_pMouseAccelToggle = new CheckButton(this, "MouseAccelerationCheckbox", "#GameUI_MouseAcceleration");
-    m_pMouseAccelSlider = new CvarSlider(this, "MouseAccelerationSlider", "#GameUI_MouseAcceleration", 1.0f, 20.0f, "m_customaccel_exponent", true);
+    m_pMouseAccelSlider = new CvarSlider(this, "MouseAccelerationSlider", "#GameUI_MouseAcceleration", 1.0f, 20.0f, "m_customaccel_exponent", true, true);
 
 	LoadControlSettings("resource/optionssubmouse.res");
-
-    //float sensitivity = engine->pfnGetCvarFloat( "sensitivity" );
-	ConVarRef var( "sensitivity" );
-	if ( var.IsValid() )
-	{
-		float sensitivity = var.GetFloat();
-
-		char buf[64];
-		Q_snprintf(buf, sizeof(buf), "%.3f", sensitivity);
-		m_pMouseSensitivityLabel->SetText(buf);
-	}
-    ConVarRef accel("m_customaccel_exponent");
-    if (accel.IsValid())
-    {
-        float acc = accel.GetFloat();
-
-        char buf[64];
-        Q_snprintf(buf, sizeof(buf), "%.3f", acc);
-        m_pMouseAccelLabel->SetText(buf);
-    }
 }
 
 //-----------------------------------------------------------------------------
@@ -92,10 +74,6 @@ COptionsSubMouse::~COptionsSubMouse()
 void COptionsSubMouse::OnResetData()
 {
 	m_pReverseMouseCheckBox->Reset();
-	m_pMouseFilterCheckBox->Reset();
-    m_pMouseRawCheckbox->Reset();
-	m_pMouseSensitivitySlider->Reset();
-    m_pMouseAccelSlider->Reset();
 
     m_pMouseAccelToggle->SetSelected(ConVarRef("m_customaccel").GetInt() == 3);
 
@@ -105,98 +83,15 @@ void COptionsSubMouse::OnResetData()
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: 
+// Purpose:
 //-----------------------------------------------------------------------------
-void COptionsSubMouse::OnApplyChanges()
+void COptionsSubMouse::OnCheckButtonChecked(Panel *panel)
 {
-	m_pReverseMouseCheckBox->ApplyChanges();
-	m_pMouseFilterCheckBox->ApplyChanges();
-    m_pMouseRawCheckbox->ApplyChanges();
-	m_pMouseSensitivitySlider->ApplyChanges();
-    m_pMouseAccelSlider->ApplyChanges();
-
-    bool bMouseAccelEnabled = m_pMouseAccelToggle->IsSelected();
-    ConVarRef("m_customaccel").SetValue(bMouseAccelEnabled ? 3 : 0);
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: sets background color & border
-//-----------------------------------------------------------------------------
-void COptionsSubMouse::ApplySchemeSettings(IScheme *pScheme)
-{
-	BaseClass::ApplySchemeSettings(pScheme);
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void COptionsSubMouse::OnControlModified(Panel *panel)
-{
-	PostActionSignal(new KeyValues("ApplyButtonEnable"));
-
-    // the HasBeenModified() check is so that if the value is outside of the range of the
-    // slider, it won't use the slider to determine the display value but leave the
-    // real value that we determined in the constructor
-    if (panel == m_pMouseSensitivitySlider && m_pMouseSensitivitySlider->HasBeenModified())
+    if (panel == m_pMouseAccelToggle)
     {
-        UpdateSensitivityLabel();
+        bool bMouseAccelEnabled = m_pMouseAccelToggle->IsSelected();
+        ConVarRef("m_customaccel").SetValue(bMouseAccelEnabled ? 3 : 0);
+        m_pMouseAccelSlider->SetEnabled(bMouseAccelEnabled);
+        m_pMouseAccelLabel->SetEnabled(bMouseAccelEnabled);
     }
-    else if (panel == m_pMouseAccelSlider && m_pMouseAccelSlider->HasBeenModified())
-    {
-        UpdateAccelLabel();
-    }
-    else if (panel == m_pMouseAccelToggle)
-    {
-        bool bEnabled = m_pMouseAccelToggle->IsSelected();
-        m_pMouseAccelSlider->SetEnabled(bEnabled);
-        m_pMouseAccelLabel->SetEnabled(bEnabled);
-    }
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void COptionsSubMouse::OnTextChanged(Panel *panel)
-{
-    if (panel == m_pMouseSensitivityLabel)
-    {
-        char buf[64];
-        m_pMouseSensitivityLabel->GetText(buf, 64);
-
-        float fValue = Q_atof(buf);
-        if (fValue >= 0.0001f)
-        {
-            m_pMouseSensitivitySlider->SetSliderValue(fValue);
-            PostActionSignal(new KeyValues("ApplyButtonEnable"));
-        }
-    }
-    else if (panel == m_pMouseAccelLabel)
-    {
-        char buf[64];
-        m_pMouseAccelLabel->GetText(buf, 64);
-
-        float fVal = Q_atof(buf);
-        if (fVal > 1.0f)
-        {
-            m_pMouseAccelSlider->SetSliderValue(fVal);
-            PostActionSignal(new KeyValues("ApplyButtonEnable"));
-        }
-    }
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void COptionsSubMouse::UpdateSensitivityLabel()
-{
-    char buf[64];
-    Q_snprintf(buf, sizeof( buf ), "%.3f", m_pMouseSensitivitySlider->GetSliderValue());
-    m_pMouseSensitivityLabel->SetText(buf);
-}
-
-void COptionsSubMouse::UpdateAccelLabel()
-{
-    char buf[64];
-    Q_snprintf(buf, sizeof(buf), "%.3f", m_pMouseAccelSlider->GetSliderValue());
-    m_pMouseAccelLabel->SetText(buf);
 }

--- a/mp/src/gameui/OptionsSubMouse.cpp
+++ b/mp/src/gameui/OptionsSubMouse.cpp
@@ -48,13 +48,13 @@ COptionsSubMouse::COptionsSubMouse(vgui::Panel *parent) : PropertyPage(parent, N
 	m_pMouseSensitivitySlider = new CvarSlider( this, "Slider", "#GameUI_MouseSensitivity",
         0.0001f, 20.0f, "sensitivity", true, true);
 
-    m_pMouseSensitivityLabel = new CvarTextEntry(this, "SensitivityLabel", "sensitivity", "%.3f");
-    m_pMouseSensitivityLabel->AddActionSignalTarget(this);
-    m_pMouseSensitivityLabel->SetAllowNumericInputOnly(true);
+    m_pMouseSensitivityEntry = new CvarTextEntry(this, "SensitivityLabel", "sensitivity", "%.3f");
+    m_pMouseSensitivityEntry->AddActionSignalTarget(this);
+    m_pMouseSensitivityEntry->SetAllowNumericInputOnly(true);
 
-    m_pMouseAccelLabel = new CvarTextEntry(this, "MouseAccelerationLabel", "m_customaccel_exponent", "%.3f");
-    m_pMouseAccelLabel->AddActionSignalTarget(this);
-    m_pMouseAccelLabel->SetAllowNumericInputOnly(true);
+    m_pMouseAccelEntry = new CvarTextEntry(this, "MouseAccelerationLabel", "m_customaccel_exponent", "%.3f");
+    m_pMouseAccelEntry->AddActionSignalTarget(this);
+    m_pMouseAccelEntry->SetAllowNumericInputOnly(true);
     m_pMouseAccelToggle = new CheckButton(this, "MouseAccelerationCheckbox", "#GameUI_MouseAcceleration");
     m_pMouseAccelSlider = new CvarSlider(this, "MouseAccelerationSlider", "#GameUI_MouseAcceleration", 1.0f, 20.0f, "m_customaccel_exponent", true, true);
 
@@ -79,7 +79,7 @@ void COptionsSubMouse::OnResetData()
 
     bool bEnabled = m_pMouseAccelToggle->IsSelected();
     m_pMouseAccelSlider->SetEnabled(bEnabled);
-    m_pMouseAccelLabel->SetEnabled(bEnabled);
+    m_pMouseAccelEntry->SetEnabled(bEnabled);
 }
 
 //-----------------------------------------------------------------------------
@@ -92,6 +92,6 @@ void COptionsSubMouse::OnCheckButtonChecked(Panel *panel)
         bool bMouseAccelEnabled = m_pMouseAccelToggle->IsSelected();
         m_cvarCustomAccel.SetValue(bMouseAccelEnabled ? 3 : 0);
         m_pMouseAccelSlider->SetEnabled(bMouseAccelEnabled);
-        m_pMouseAccelLabel->SetEnabled(bMouseAccelEnabled);
+        m_pMouseAccelEntry->SetEnabled(bMouseAccelEnabled);
     }
 }

--- a/mp/src/gameui/OptionsSubMouse.h
+++ b/mp/src/gameui/OptionsSubMouse.h
@@ -36,31 +36,19 @@ public:
 	~COptionsSubMouse();
 
 	virtual void OnResetData();
-	virtual void OnApplyChanges();
-
-protected:
-    virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
 
 private:
-	MESSAGE_FUNC_PTR( OnControlModified, "ControlModified", panel );
-    MESSAGE_FUNC_PTR( OnTextChanged, "TextChanged", panel );
-	MESSAGE_FUNC_PTR( OnCheckButtonChecked, "CheckButtonChecked", panel )
-	{
-		OnControlModified( panel );
-	}
-
-    void UpdateSensitivityLabel();
-    void UpdateAccelLabel();
+	MESSAGE_FUNC_PTR( OnCheckButtonChecked, "CheckButtonChecked", panel );
 
 	CvarNegateCheckButton		*m_pReverseMouseCheckBox;
 	vgui::CvarToggleCheckButton	*m_pMouseFilterCheckBox , *m_pMouseRawCheckbox;
 
     vgui::CvarSlider					*m_pMouseSensitivitySlider;
-    vgui::TextEntry             *m_pMouseSensitivityLabel;
+    vgui::CvarTextEntry             *m_pMouseSensitivityLabel;
 
     vgui::CheckButton *m_pMouseAccelToggle;
     vgui::CvarSlider *m_pMouseAccelSlider;
-    vgui::TextEntry *m_pMouseAccelLabel;
+    vgui::CvarTextEntry *m_pMouseAccelLabel;
 };
 
 

--- a/mp/src/gameui/OptionsSubMouse.h
+++ b/mp/src/gameui/OptionsSubMouse.h
@@ -44,11 +44,11 @@ private:
 	vgui::CvarToggleCheckButton	*m_pMouseFilterCheckBox , *m_pMouseRawCheckbox;
 
     vgui::CvarSlider					*m_pMouseSensitivitySlider;
-    vgui::CvarTextEntry             *m_pMouseSensitivityLabel;
+    vgui::CvarTextEntry             *m_pMouseSensitivityEntry;
 
     vgui::CheckButton *m_pMouseAccelToggle;
     vgui::CvarSlider *m_pMouseAccelSlider;
-    vgui::CvarTextEntry *m_pMouseAccelLabel;
+    vgui::CvarTextEntry *m_pMouseAccelEntry;
 
     ConVarRef m_cvarCustomAccel;
 };

--- a/mp/src/gameui/OptionsSubMouse.h
+++ b/mp/src/gameui/OptionsSubMouse.h
@@ -49,6 +49,8 @@ private:
     vgui::CheckButton *m_pMouseAccelToggle;
     vgui::CvarSlider *m_pMouseAccelSlider;
     vgui::CvarTextEntry *m_pMouseAccelLabel;
+
+    ConVarRef m_cvarCustomAccel;
 };
 
 

--- a/mp/src/public/vgui_controls/CvarTextEntry.h
+++ b/mp/src/public/vgui_controls/CvarTextEntry.h
@@ -15,7 +15,7 @@ namespace vgui
         DECLARE_CLASS_SIMPLE(CvarTextEntry, vgui::TextEntry);
 
     public:
-        CvarTextEntry(Panel *parent, const char *panelName, char const *cvarname);
+        CvarTextEntry(Panel *parent, const char *panelName, char const *cvarname, const char *numberFormat = "%g");
 
         MESSAGE_FUNC(OnTextChanged, "TextChanged");
         MESSAGE_FUNC(OnApplyChanges, "ApplyChanges");
@@ -34,5 +34,6 @@ namespace vgui
     private:
         ConVarRef m_cvarRef;
         char m_pszStartValue[64];
+        char m_szNumberFormat[8];
     };
 }

--- a/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
+++ b/mp/src/vgui2/vgui_controls/CvarTextEntry.cpp
@@ -18,11 +18,12 @@ static const int MAX_CVAR_TEXT = 64;
 
 DECLARE_BUILD_FACTORY_DEFAULT_TEXT(CvarTextEntry, "");
 
-CvarTextEntry::CvarTextEntry(Panel *parent, const char *panelName, char const *cvarname)
+CvarTextEntry::CvarTextEntry(Panel *parent, const char *panelName, char const *cvarname, const char *numberFormat)
     : TextEntry(parent, panelName), m_cvarRef(cvarname, true)
 {
     InitSettings();
     m_pszStartValue[0] = 0;
+    Q_strncpy(m_szNumberFormat, numberFormat, sizeof(m_szNumberFormat));
 
     if (m_cvarRef.IsValid())
     {
@@ -78,7 +79,7 @@ void CvarTextEntry::SetText(const char* text)
         {
             // making sure the formatting is correct (removing trailing zeros via %g)
             char newText[MAX_CVAR_TEXT];
-            Q_snprintf(newText, MAX_CVAR_TEXT, "%g", atof(text));
+            Q_snprintf(newText, MAX_CVAR_TEXT, m_szNumberFormat, atof(text));
             BaseClass::SetText(newText);
         }
     }


### PR DESCRIPTION
Now that the momentum settings changed to apply instantly, I'm attempting to make the same changes to the GameUI code.

A couple of changes here:

- Changed `CvarTextEntry` to receive an optional number format override. This is useful as there are some cvars where it makes sense to use `%.3f`, `%.2f` etc. as with the mouse settings.
- Changed `CvarNegateCheckButton` to apply instantly as was done with `CvarToggleCheckButton`. 
    - The GameUI's mouse options is the only place where this vgui element is used.
- Changed the mouse settings page's fields to apply instantly:
    - Added the auto apply changes flag to the `CvarSlider`'s.
    - Converted the `TextEntry`'s to `CvarTextEntry` & set the allow numeric input only flag.
    - Removed a lot of unneeded overrides as a result of these changes.
- Renamed some of the elements. 
    - Eg. `m_pMouseAccelLabel` is quite misleading as it is a text entry. Changed to `m_pMouseAccelEntry`.

Had to keep the code for the mouse accel toggle check button as it has different behavior (when checked, the value is set to 3, when unchecked it is 0). Moved the ConVarRef call to the constructor.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review