### PR TITLE
Changed GameUI audio settings to apply instantly

### DIFF
--- a/mp/src/gameui/OptionsSubAudio.cpp
+++ b/mp/src/gameui/OptionsSubAudio.cpp
@@ -83,110 +83,124 @@ COptionsSubAudio::~COptionsSubAudio()
 //-----------------------------------------------------------------------------
 void COptionsSubAudio::OnResetData()
 {
-	m_bRequireRestart = false;
-    m_pMuteLoseFocus->Reset();
+    ResetCloseCaption();
+    ResetSpeakerSetup();
+    ResetSoundQuality();
+    ResetSpokenLanguage();
+}
 
-	// reset the combo boxes
-
-	// close captions
+void COptionsSubAudio::ResetCloseCaption()
+{
     if (m_cvarCloseCaption.GetBool())
-	{
-		if (m_cvarSubtitles.GetBool())
-		{
-			m_pCloseCaptionCombo->ActivateItem(2);
-		}
-		else
-		{
-			m_pCloseCaptionCombo->ActivateItem(1);
-		}
-	}
-	else
-	{
-		m_pCloseCaptionCombo->ActivateItem(0);
-	}
+    {
+        if (m_cvarSubtitles.GetBool())
+        {
+            m_pCloseCaptionCombo->ActivateItem(2);
+        }
+        else
+        {
+            m_pCloseCaptionCombo->ActivateItem(1);
+        }
+    }
+    else
+    {
+        m_pCloseCaptionCombo->ActivateItem(0);
+    }
+}
 
-	// speakers
-	int speakers = m_cvarSndSurroundSpeakers.GetInt();
-	{for (int itemID = 0; itemID < m_pSpeakerSetupCombo->GetItemCount(); itemID++)
-	{
-		KeyValues *kv = m_pSpeakerSetupCombo->GetItemUserData(itemID);
-		if (kv && kv->GetInt("speakers") == speakers)
-		{
-			m_pSpeakerSetupCombo->ActivateItem(itemID);
-		}
-	}}
-	
-	// sound quality is made up from several cvars
-	int quality = SOUNDQUALITY_LOW;
-	if (m_cvarDSPSlowCPU.GetBool() == false)
-	{
-		quality = SOUNDQUALITY_MEDIUM;
-	}
-	if (m_cvarSndPitchQuality.GetBool())
-	{
-		quality = SOUNDQUALITY_HIGH;
-	}
-	// find the item in the list and activate it
-	{for (int itemID = 0; itemID < m_pSoundQualityCombo->GetItemCount(); itemID++)
-	{
-		KeyValues *kv = m_pSoundQualityCombo->GetItemUserData(itemID);
-		if (kv && kv->GetInt("quality") == quality)
-		{
-			m_pSoundQualityCombo->ActivateItem(itemID);
-		}
-	}}
+void COptionsSubAudio::ResetSpokenLanguage()
+{
+    char szCurrentLanguage[50] = "";
+    char szAvailableLanguages[512] = "";
+    szAvailableLanguages[0] = NULL;
 
-   //
-   // Audio Languages
-   //
-   char szCurrentLanguage[50] = "";
-   char szAvailableLanguages[512] = "";
-   szAvailableLanguages[0] = NULL;
+    // Fallback to current engine language
+    engine->GetUILanguage(szCurrentLanguage, sizeof(szCurrentLanguage));
 
-   // Fallback to current engine language
-   engine->GetUILanguage( szCurrentLanguage, sizeof( szCurrentLanguage ));
-
-   // In a Steam environment we get the current language 
-#if !defined( NO_STEAM )
-   // When Steam isn't running we can't get the language info... 
-   if ( SteamApps() )
-   {
-       Q_strncpy(szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage));
-       Q_strncpy(szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages));
-   }
+    // In a Steam environment we get the current language
+#if !defined(NO_STEAM)
+    // When Steam isn't running we can't get the language info...
+    if (SteamApps())
+    {
+        Q_strncpy(szCurrentLanguage, SteamApps()->GetCurrentGameLanguage(), sizeof(szCurrentLanguage));
+        Q_strncpy(szAvailableLanguages, SteamApps()->GetAvailableGameLanguages(), sizeof(szAvailableLanguages));
+    }
 #endif
 
-   // Get the spoken language and store it for comparison purposes
-   m_nCurrentAudioLanguage = PchLanguageToELanguage( szCurrentLanguage );
+    // Get the spoken language and store it for comparison purposes
+    m_nCurrentAudioLanguage = PchLanguageToELanguage(szCurrentLanguage);
 
-   // Check to see if we have a list of languages from Steam
-   if ( V_strlen( szAvailableLanguages ) )
-   {
-      // Populate the combo box with each available language
-      CSplitString languagesList( szAvailableLanguages, "," );
+    // Check to see if we have a list of languages from Steam
+    if (V_strlen(szAvailableLanguages))
+    {
+        // Populate the combo box with each available language
+        CSplitString languagesList(szAvailableLanguages, ",");
 
-      for ( int i=0; i < languagesList.Count(); i++ )
-      {
-         const ELanguage languageCode = PchLanguageToELanguage( languagesList[i] );
-         m_pSpokenLanguageCombo->AddItem( GetLanguageVGUILocalization( languageCode ), new KeyValues ("Audio Languages", "language", languageCode) );
-      }
-   }
-   else
-   {
-      // Add the current language to the combo
-      m_pSpokenLanguageCombo->AddItem( GetLanguageVGUILocalization( m_nCurrentAudioLanguage ), new KeyValues ("Audio Languages", "language", m_nCurrentAudioLanguage) );
-   }
+        for (int i = 0; i < languagesList.Count(); i++)
+        {
+            const ELanguage languageCode = PchLanguageToELanguage(languagesList[i]);
+            m_pSpokenLanguageCombo->AddItem(GetLanguageVGUILocalization(languageCode),
+                                            new KeyValues("Audio Languages", "language", languageCode));
+        }
+    }
+    else
+    {
+        // Add the current language to the combo
+        m_pSpokenLanguageCombo->AddItem(GetLanguageVGUILocalization(m_nCurrentAudioLanguage),
+                                        new KeyValues("Audio Languages", "language", m_nCurrentAudioLanguage));
+    }
 
-   // Activate the current language in the combo
-   {for (int itemID = 0; itemID < m_pSpokenLanguageCombo->GetItemCount(); itemID++)
-   {
-      KeyValues *kv = m_pSpokenLanguageCombo->GetItemUserData( itemID );
-      if ( kv && kv->GetInt( "language" ) == m_nCurrentAudioLanguage )
-      {
-         m_pSpokenLanguageCombo->ActivateItem( itemID );
-         break;
-      }
-   }}
+    // Activate the current language in the combo
+    {
+        for (int itemID = 0; itemID < m_pSpokenLanguageCombo->GetItemCount(); itemID++)
+        {
+            KeyValues *kv = m_pSpokenLanguageCombo->GetItemUserData(itemID);
+            if (kv && kv->GetInt("language") == m_nCurrentAudioLanguage)
+            {
+                m_pSpokenLanguageCombo->ActivateItem(itemID);
+                break;
+            }
+        }
+    }
+}
+
+void COptionsSubAudio::ResetSoundQuality()
+{
+    int quality = SOUNDQUALITY_LOW;
+    if (m_cvarDSPSlowCPU.GetBool() == false)
+    {
+        quality = SOUNDQUALITY_MEDIUM;
+    }
+    if (m_cvarSndPitchQuality.GetBool())
+    {
+        quality = SOUNDQUALITY_HIGH;
+    }
+    // find the item in the list and activate it
+    {
+        for (int itemID = 0; itemID < m_pSoundQualityCombo->GetItemCount(); itemID++)
+        {
+            KeyValues *kv = m_pSoundQualityCombo->GetItemUserData(itemID);
+            if (kv && kv->GetInt("quality") == quality)
+            {
+                m_pSoundQualityCombo->ActivateItem(itemID);
+            }
+        }
+    }
+}
+
+void COptionsSubAudio::ResetSpeakerSetup()
+{
+    int speakers = m_cvarSndSurroundSpeakers.GetInt();
+    {
+        for (int itemID = 0; itemID < m_pSpeakerSetupCombo->GetItemCount(); itemID++)
+        {
+            KeyValues *kv = m_pSpeakerSetupCombo->GetItemUserData(itemID);
+            if (kv && kv->GetInt("speakers") == speakers)
+            {
+                m_pSpeakerSetupCombo->ActivateItem(itemID);
+            }
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -194,111 +208,123 @@ void COptionsSubAudio::OnResetData()
 //-----------------------------------------------------------------------------
 void COptionsSubAudio::OnControlModified(Panel *panel)
 {
-	PostActionSignal(new KeyValues("ApplyButtonEnable"));
-
     if (panel == m_pCloseCaptionCombo)
     {
-        // Tracker 28933:  Note we can't do this because closecaption is marked
-        //  FCVAR_USERINFO and it won't get sent to server is we direct set it, we
-        //  need to pass it along to the engine parser!!!
-        // ConVar *closecaption = (ConVar *)cvar->FindVar("closecaption");
-        int closecaption_value = 0;
-
-        switch (m_pCloseCaptionCombo->GetActiveItem())
-        {
-        default:
-        case 0:
-            closecaption_value = 0;
-            m_cvarSubtitles.SetValue(0);
-            break;
-        case 1:
-            closecaption_value = 1;
-            m_cvarSubtitles.SetValue(0);
-            break;
-        case 2:
-            closecaption_value = 1;
-            m_cvarSubtitles.SetValue(1);
-            break;
-        }
-
-        // Stuff the close caption change to the console so that it can be
-        //  sent to the server (FCVAR_USERINFO) so that you don't have to restart
-        //  the level for the change to take effect.
-        char cmd[64];
-        Q_snprintf(cmd, sizeof(cmd), "closecaption %i\n", closecaption_value);
-        engine->ClientCmd_Unrestricted(cmd);
+        ApplyCloseCaption();
     }
     else if (panel == m_pSoundQualityCombo)
     {
-        int speakers = m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers");
-        int quality = m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality");
-        switch (quality)
-        {
-        case SOUNDQUALITY_LOW:
-            m_cvarDSPSlowCPU.SetValue(true);
-            m_cvarSndPitchQuality.SetValue(false);
-            break;
-        case SOUNDQUALITY_MEDIUM:
-            m_cvarDSPSlowCPU.SetValue(false);
-            m_cvarSndPitchQuality.SetValue(false);
-            break;
-        default:
-            Assert("Undefined sound quality setting.");
-        case SOUNDQUALITY_HIGH:
-            m_cvarDSPSlowCPU.SetValue(false);
-            m_cvarSndPitchQuality.SetValue(true);
-            break;
-        };
-
-        // headphones at high quality get enhanced stereo turned on
-        if (speakers == 0 && quality == SOUNDQUALITY_HIGH)
-        {
-            m_cvarDSPEnhanceStereo.SetValue(1);
-        }
-        else
-        {
-            m_cvarDSPEnhanceStereo.SetValue(0);
-        }
+        ApplySoundQuality();
     }
     else if (panel == m_pSpeakerSetupCombo)
     {
-        int speakers = m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers");
-        int quality = m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality");
-        m_cvarSndSurroundSpeakers.SetValue(speakers);
-
-        // headphones at high quality get enhanced stereo turned on
-        if (speakers == 0 && quality == SOUNDQUALITY_HIGH)
-        {
-            m_cvarDSPEnhanceStereo.SetValue(1);
-        }
-        else
-        {
-            m_cvarDSPEnhanceStereo.SetValue(0);
-        }
+        ApplySpeakerSetup();
     }
     else if (panel == m_pSpokenLanguageCombo)
     {
-        // Audio spoken language
-        KeyValues *kv = m_pSpokenLanguageCombo->GetItemUserData(m_pSpokenLanguageCombo->GetActiveItem());
-        const ELanguage nUpdatedAudioLanguage = (ELanguage)(kv ? kv->GetInt("language") : k_Lang_English);
+        ApplySpokenLanguage();
+    }
+}
 
-        if (nUpdatedAudioLanguage != m_nCurrentAudioLanguage)
+void COptionsSubAudio::ApplyCloseCaption()
+{
+    // Tracker 28933:  Note we can't do this because closecaption is marked
+    //  FCVAR_USERINFO and it won't get sent to server is we direct set it, we
+    //  need to pass it along to the engine parser!!!
+    // ConVar *closecaption = (ConVar *)cvar->FindVar("closecaption");
+    int closecaption_value = 0;
+
+    switch (m_pCloseCaptionCombo->GetActiveItem())
+    {
+    default:
+    case 0:
+        closecaption_value = 0;
+        m_cvarSubtitles.SetValue(0);
+        break;
+    case 1:
+        closecaption_value = 1;
+        m_cvarSubtitles.SetValue(0);
+        break;
+    case 2:
+        closecaption_value = 1;
+        m_cvarSubtitles.SetValue(1);
+        break;
+    }
+
+    // Stuff the close caption change to the console so that it can be
+    //  sent to the server (FCVAR_USERINFO) so that you don't have to restart
+    //  the level for the change to take effect.
+    char cmd[64];
+    Q_snprintf(cmd, sizeof(cmd), "closecaption %i\n", closecaption_value);
+    engine->ClientCmd_Unrestricted(cmd);
+}
+
+void COptionsSubAudio::ApplySpokenLanguage()
+{
+    // Audio spoken language
+    KeyValues *kv = m_pSpokenLanguageCombo->GetItemUserData(m_pSpokenLanguageCombo->GetActiveItem());
+    const ELanguage nUpdatedAudioLanguage = (ELanguage)(kv ? kv->GetInt("language") : k_Lang_English);
+
+    if (nUpdatedAudioLanguage != m_nCurrentAudioLanguage)
+    {
+        // Store new language in static member so that it can be accessed during shutdown when this instance is gone
+        m_pchUpdatedAudioLanguage = (char *)GetLanguageShortName(nUpdatedAudioLanguage);
+
+        // Inform user that they need to restart in order change language at this time
+        QueryBox *qb = new QueryBox("#GameUI_ChangeLanguageRestart_Title", "#GameUI_ChangeLanguageRestart_Info",
+                                    GetParent()->GetParent()->GetParent());
+        if (qb != NULL)
         {
-            // Store new language in static member so that it can be accessed during shutdown when this instance is gone
-            m_pchUpdatedAudioLanguage = (char *)GetLanguageShortName(nUpdatedAudioLanguage);
-
-            // Inform user that they need to restart in order change language at this time
-            QueryBox *qb = new QueryBox("#GameUI_ChangeLanguageRestart_Title", "#GameUI_ChangeLanguageRestart_Info",
-                                        GetParent()->GetParent()->GetParent());
-            if (qb != NULL)
-            {
-                qb->SetOKCommand(new KeyValues("Command", "command", "RestartWithNewLanguage"));
-                qb->SetOKButtonText("#GameUI_ChangeLanguageRestart_OkButton");
-                qb->SetCancelButtonText("#GameUI_ChangeLanguageRestart_CancelButton");
-                qb->AddActionSignalTarget(GetParent()->GetParent()->GetParent());
-                qb->DoModal();
-            }
+            qb->SetOKCommand(new KeyValues("Command", "command", "RestartWithNewLanguage"));
+            qb->SetOKButtonText("#GameUI_ChangeLanguageRestart_OkButton");
+            qb->SetCancelButtonText("#GameUI_ChangeLanguageRestart_CancelButton");
+            qb->AddActionSignalTarget(GetParent()->GetParent()->GetParent());
+            qb->DoModal();
         }
+    }
+}
+
+void COptionsSubAudio::ApplySoundQuality()
+{
+    switch (m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality"))
+    {
+    case SOUNDQUALITY_LOW:
+        m_cvarDSPSlowCPU.SetValue(true);
+        m_cvarSndPitchQuality.SetValue(false);
+        break;
+    case SOUNDQUALITY_MEDIUM:
+        m_cvarDSPSlowCPU.SetValue(false);
+        m_cvarSndPitchQuality.SetValue(false);
+        break;
+    default:
+        Assert("Undefined sound quality setting.");
+    case SOUNDQUALITY_HIGH:
+        m_cvarDSPSlowCPU.SetValue(false);
+        m_cvarSndPitchQuality.SetValue(true);
+        break;
+    };
+
+    ApplyEnhanceStereo();
+}
+
+void COptionsSubAudio::ApplySpeakerSetup()
+{
+    m_cvarSndSurroundSpeakers.SetValue(m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers"));
+    ApplyEnhanceStereo();
+}
+
+void COptionsSubAudio::ApplyEnhanceStereo()
+{
+    int speakers = m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers");
+    int quality = m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality");
+    // headphones at high quality get enhanced stereo turned on
+    if (speakers == 0 && quality == SOUNDQUALITY_HIGH)
+    {
+        m_cvarDSPEnhanceStereo.SetValue(1);
+    }
+    else
+    {
+        m_cvarDSPEnhanceStereo.SetValue(0);
     }
 }
 

--- a/mp/src/gameui/OptionsSubAudio.cpp
+++ b/mp/src/gameui/OptionsSubAudio.cpp
@@ -38,7 +38,9 @@ enum SoundQuality_e
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
-COptionsSubAudio::COptionsSubAudio(vgui::Panel *parent) : PropertyPage(parent, NULL)
+COptionsSubAudio::COptionsSubAudio(vgui::Panel *parent) : PropertyPage(parent, NULL), m_cvarSubtitles("cc_subtitles"), m_cvarCloseCaption("closecaption"),
+      m_cvarSndSurroundSpeakers("Snd_Surround_Speakers"), m_cvarSndPitchQuality("Snd_PitchQuality"),
+      m_cvarDSPSlowCPU("dsp_slow_cpu"), m_cvarDSPEnhanceStereo("dsp_enhance_stereo")
 {
     SetSize(20, 20);
 
@@ -87,11 +89,9 @@ void COptionsSubAudio::OnResetData()
 	// reset the combo boxes
 
 	// close captions
-	ConVarRef closecaption("closecaption");
-	ConVarRef cc_subtitles("cc_subtitles");
-	if (closecaption.GetBool())
+    if (m_cvarCloseCaption.GetBool())
 	{
-		if (cc_subtitles.GetBool())
+		if (m_cvarSubtitles.GetBool())
 		{
 			m_pCloseCaptionCombo->ActivateItem(2);
 		}
@@ -106,8 +106,7 @@ void COptionsSubAudio::OnResetData()
 	}
 
 	// speakers
-	ConVarRef snd_surround_speakers("Snd_Surround_Speakers");
-	int speakers = snd_surround_speakers.GetInt();
+	int speakers = m_cvarSndSurroundSpeakers.GetInt();
 	{for (int itemID = 0; itemID < m_pSpeakerSetupCombo->GetItemCount(); itemID++)
 	{
 		KeyValues *kv = m_pSpeakerSetupCombo->GetItemUserData(itemID);
@@ -118,14 +117,12 @@ void COptionsSubAudio::OnResetData()
 	}}
 	
 	// sound quality is made up from several cvars
-	ConVarRef Snd_PitchQuality("Snd_PitchQuality");
-	ConVarRef dsp_slow_cpu("dsp_slow_cpu");
 	int quality = SOUNDQUALITY_LOW;
-	if (dsp_slow_cpu.GetBool() == false)
+	if (m_cvarDSPSlowCPU.GetBool() == false)
 	{
 		quality = SOUNDQUALITY_MEDIUM;
 	}
-	if (Snd_PitchQuality.GetBool())
+	if (m_cvarSndPitchQuality.GetBool())
 	{
 		quality = SOUNDQUALITY_HIGH;
 	}
@@ -207,21 +204,20 @@ void COptionsSubAudio::OnControlModified(Panel *panel)
         // ConVar *closecaption = (ConVar *)cvar->FindVar("closecaption");
         int closecaption_value = 0;
 
-        ConVarRef cc_subtitles("cc_subtitles");
         switch (m_pCloseCaptionCombo->GetActiveItem())
         {
         default:
         case 0:
             closecaption_value = 0;
-            cc_subtitles.SetValue(0);
+            m_cvarSubtitles.SetValue(0);
             break;
         case 1:
             closecaption_value = 1;
-            cc_subtitles.SetValue(0);
+            m_cvarSubtitles.SetValue(0);
             break;
         case 2:
             closecaption_value = 1;
-            cc_subtitles.SetValue(1);
+            m_cvarSubtitles.SetValue(1);
             break;
         }
 
@@ -234,56 +230,50 @@ void COptionsSubAudio::OnControlModified(Panel *panel)
     }
     else if (panel == m_pSoundQualityCombo)
     {
-        ConVarRef Snd_PitchQuality("Snd_PitchQuality");
-        ConVarRef dsp_slow_cpu("dsp_slow_cpu");
-        ConVarRef snd_surround_speakers("Snd_Surround_Speakers");
         int speakers = m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers");
         int quality = m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality");
         switch (quality)
         {
         case SOUNDQUALITY_LOW:
-            dsp_slow_cpu.SetValue(true);
-            Snd_PitchQuality.SetValue(false);
+            m_cvarDSPSlowCPU.SetValue(true);
+            m_cvarSndPitchQuality.SetValue(false);
             break;
         case SOUNDQUALITY_MEDIUM:
-            dsp_slow_cpu.SetValue(false);
-            Snd_PitchQuality.SetValue(false);
+            m_cvarDSPSlowCPU.SetValue(false);
+            m_cvarSndPitchQuality.SetValue(false);
             break;
         default:
             Assert("Undefined sound quality setting.");
         case SOUNDQUALITY_HIGH:
-            dsp_slow_cpu.SetValue(false);
-            Snd_PitchQuality.SetValue(true);
+            m_cvarDSPSlowCPU.SetValue(false);
+            m_cvarSndPitchQuality.SetValue(true);
             break;
         };
 
         // headphones at high quality get enhanced stereo turned on
-        ConVarRef dsp_enhance_stereo("dsp_enhance_stereo");
         if (speakers == 0 && quality == SOUNDQUALITY_HIGH)
         {
-            dsp_enhance_stereo.SetValue(1);
+            m_cvarDSPEnhanceStereo.SetValue(1);
         }
         else
         {
-            dsp_enhance_stereo.SetValue(0);
+            m_cvarDSPEnhanceStereo.SetValue(0);
         }
     }
     else if (panel == m_pSpeakerSetupCombo)
     {
-        ConVarRef snd_surround_speakers("Snd_Surround_Speakers");
         int speakers = m_pSpeakerSetupCombo->GetActiveItemUserData()->GetInt("speakers");
         int quality = m_pSoundQualityCombo->GetActiveItemUserData()->GetInt("quality");
-        snd_surround_speakers.SetValue(speakers);
+        m_cvarSndSurroundSpeakers.SetValue(speakers);
 
         // headphones at high quality get enhanced stereo turned on
-        ConVarRef dsp_enhance_stereo("dsp_enhance_stereo");
         if (speakers == 0 && quality == SOUNDQUALITY_HIGH)
         {
-            dsp_enhance_stereo.SetValue(1);
+            m_cvarDSPEnhanceStereo.SetValue(1);
         }
         else
         {
-            dsp_enhance_stereo.SetValue(0);
+            m_cvarDSPEnhanceStereo.SetValue(0);
         }
     }
     else if (panel == m_pSpokenLanguageCombo)

--- a/mp/src/gameui/OptionsSubAudio.h
+++ b/mp/src/gameui/OptionsSubAudio.h
@@ -48,7 +48,6 @@ private:
 	vgui::CvarSlider					*m_pSFXSlider;
 	vgui::CvarSlider					*m_pMusicSlider;
 	vgui::ComboBox				*m_pCloseCaptionCombo;
-	bool						   m_bRequireRestart;
    
    vgui::ComboBox				*m_pSpokenLanguageCombo;
    MESSAGE_FUNC( OpenThirdPartySoundCreditsDialog, "OpenThirdPartySoundCreditsDialog" );
@@ -59,6 +58,18 @@ private:
     vgui::CvarToggleCheckButton *m_pMuteLoseFocus;
 
     ConVarRef m_cvarSubtitles, m_cvarCloseCaption, m_cvarSndSurroundSpeakers, m_cvarSndPitchQuality, m_cvarDSPSlowCPU, m_cvarDSPEnhanceStereo;
+
+    // helper functions
+    void ResetCloseCaption();
+    void ResetSpeakerSetup();
+    void ResetSoundQuality();
+    void ResetSpokenLanguage();
+
+    void ApplyCloseCaption();
+    void ApplySpeakerSetup();
+    void ApplySoundQuality();
+    void ApplySpokenLanguage();
+    void ApplyEnhanceStereo();
 };
 
 

--- a/mp/src/gameui/OptionsSubAudio.h
+++ b/mp/src/gameui/OptionsSubAudio.h
@@ -31,16 +31,14 @@ public:
 	~COptionsSubAudio();
 
 	virtual void OnResetData();
-	virtual void OnApplyChanges();
 	virtual void OnCommand( const char *command );
-	bool RequiresRestart();
-   static char* GetUpdatedAudioLanguage() { return m_pchUpdatedAudioLanguage; }
+    static char* GetUpdatedAudioLanguage() { return m_pchUpdatedAudioLanguage; }
 
 private:
-	MESSAGE_FUNC( OnControlModified, "ControlModified" );
-	MESSAGE_FUNC( OnTextChanged, "TextChanged" )
+	MESSAGE_FUNC_PTR( OnControlModified, "ControlModified", panel );
+	MESSAGE_FUNC_PTR( OnTextChanged, "TextChanged", panel )
 	{
-		OnControlModified();
+		OnControlModified(panel);
 	}
 
 	MESSAGE_FUNC( RunTestSpeakers, "RunTestSpeakers" );

--- a/mp/src/gameui/OptionsSubAudio.h
+++ b/mp/src/gameui/OptionsSubAudio.h
@@ -57,6 +57,8 @@ private:
    static char             *m_pchUpdatedAudioLanguage;
 
     vgui::CvarToggleCheckButton *m_pMuteLoseFocus;
+
+    ConVarRef m_cvarSubtitles, m_cvarCloseCaption, m_cvarSndSurroundSpeakers, m_cvarSndPitchQuality, m_cvarDSPSlowCPU, m_cvarDSPEnhanceStereo;
 };
 
 


### PR DESCRIPTION
Now that the momentum settings changed to apply instantly, I'm attempting to make the same changes to the GameUI code - Issue #708 

Changed a few things:

- Changed the two `CvarSlider`'s to auto apply.
- Moved the code in `OnApplyChanges()` to `OnControlModified`.
    - Changed `OnControlModfiied` to include the particular panel calling it. 
- Moved all the `ConVarRef` calls to the constructor.
- Separated out the apply/reset code for each combobox into helper functions to ease readability.
    - Before there was many comments explaining what combobox is being updated.

The popup dialogs (the 3rd party reference & spoken language change) still work with these changes.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review