### PR TITLE
Map finish time comparison

### DIFF
--- a/mp/game/momentum/resource/ui/MapFinishedDialog.res
+++ b/mp/game/momentum/resource/ui/MapFinishedDialog.res
@@ -487,4 +487,27 @@
         "auto_wide_tocontents" "0"
         "auto_tall_tocontents" "1"
     }
+    
+    "ComparisonLabel"
+    {
+        "ControlName" "Label"
+        "fieldName"  "ComparisonLabel"
+        "font"          "Default"//Set by "TextFont" 
+        "xpos"          "0"
+        "ypos"          "0"
+        "wide"          "100"
+        "tall"          "10"//Set by font size
+        "autoResize"    "1"
+        "pinCorner"     "1"
+        "visible"       "1"
+        "enabled"       "1"
+        "textAlignment" "west"
+        "dulltext"      "0"
+        "brighttext"    "0"
+        "pin_to_sibling" "Zone_Overall_Time"
+        "pin_corner_to_sibling" "0"
+        "pin_to_sibling_corner" "1"
+        "auto_wide_tocontents" "1"
+        "UnpinnedCornerOffsetX" "3"
+    }
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
@@ -20,6 +20,7 @@ public:
     void Reset() OVERRIDE;
     void SetVisible(bool) OVERRIDE;
     void FireGameEvent(IGameEvent*) OVERRIDE;
+    void LevelInitPostEntity() OVERRIDE;
     void LevelShutdown() OVERRIDE;
     void OnThink() OVERRIDE;
     void Paint() OVERRIDE;
@@ -33,6 +34,7 @@ public:
     void SetCurrentPage(int pageNum);
     void LoadPlayerBestTime();
     void GetDiffString(float diff, char *compareString, Color *compareColorOut);
+    void SetComparisonForPage(int iPage);
 
     void SetRunSaved(bool bState);
     void SetRunUploaded(bool bState);
@@ -89,15 +91,11 @@ private:
     vgui::Label *m_pXPGainCosmetic, *m_pXPGainRank, *m_pLevelGain;
     vgui::Label *m_pComparisonLabel;
 
-    Color m_cGain, m_cLoss;
+    Color m_cGain, m_cLoss, m_cTie;
 
     CMomRunStats* m_pRunStats;
-    CMomRunStats* m_pPbRunStats;
+    CMomRunStats m_pPbRunStats;
     C_MomRunEntityData *m_pRunData;
-
-    float m_flPbOverallTime;
-    float m_flOverallDiff;
-    bool m_bPbNeedUpdate;
 
     bool m_bIsGhost;
     bool m_bCanClose;

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.h
@@ -31,6 +31,8 @@ public:
     void ApplySchemeSettings(vgui::IScheme *pScheme) OVERRIDE;
 
     void SetCurrentPage(int pageNum);
+    void LoadPlayerBestTime();
+    void GetDiffString(float diff, char *compareString, Color *compareColorOut);
 
     void SetRunSaved(bool bState);
     void SetRunUploaded(bool bState);
@@ -85,9 +87,17 @@ private:
     vgui::Label *m_pRunSaveStatus;
     vgui::Label *m_pRunUploadStatus;
     vgui::Label *m_pXPGainCosmetic, *m_pXPGainRank, *m_pLevelGain;
+    vgui::Label *m_pComparisonLabel;
+
+    Color m_cGain, m_cLoss;
 
     CMomRunStats* m_pRunStats;
+    CMomRunStats* m_pPbRunStats;
     C_MomRunEntityData *m_pRunData;
+
+    float m_flPbOverallTime;
+    float m_flOverallDiff;
+    bool m_bPbNeedUpdate;
 
     bool m_bIsGhost;
     bool m_bCanClose;

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -298,7 +298,8 @@ void CMomentumReplaySystem::SetReplayHeaderAndStats()
     // Stats
     CMomRunStats *stats = m_pRecordingReplay->CreateRunStats(pPlayer->m_RunStats.GetTotalZones());
     stats->FullyCopyFrom(pPlayer->m_RunStats);
-    // MOM_TODO uncomment: stats->SetZoneTime(0, m_pRecordingReplay->GetRunTime());
+    // Store Overall Time at iZoneTicks[0]
+    stats->SetZoneTicks(0, (m_pRecordingReplay->GetStopTick() - m_pRecordingReplay->GetStartTick()));
 }
 
 void CMomentumReplaySystem::SetTeleportedThisFrame()


### PR DESCRIPTION
Closes #299

This PR Adds a label that shows the player a time difference between his best run and the run just finished.

1. Overall Time
![mapfinish1](https://user-images.githubusercontent.com/42438863/80327047-25e7ef00-8811-11ea-807a-8bee2917f42d.PNG)

1. Zone Time
![mapfinish2](https://user-images.githubusercontent.com/42438863/80327056-313b1a80-8811-11ea-8195-264b24f6414f.PNG)


### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->