### PR TITLE
Changed GameUI keyboard settings to apply instantly

### DIFF
--- a/mp/src/gameui/OptionsSubKeyboard.cpp
+++ b/mp/src/gameui/OptionsSubKeyboard.cpp
@@ -109,7 +109,6 @@ void COptionsSubKeyboard::OnCommand( const char *command )
 	}
 	else if ( !stricmp(command, "DefaultsOK"))
 	{
-		// Restore defaults from default keybindings file
 		FillInDefaultBindings();
 		m_pKeyBindList->RequestFocus();
 	}
@@ -191,12 +190,10 @@ void COptionsSubKeyboard::ParseActionDescriptions( void )
 				// Create a new: blank item
 				item = new KeyValues( "Item" );
 				
-				// fill in data
 				item->SetString("Action", szDescription);
 				item->SetString("Binding", szBinding);
 				item->SetString("Key", "");
 
-				// Add to list
 				m_pKeyBindList->AddItem(sectionIndex, item);
 				item->deleteThis();
 			}
@@ -280,7 +277,6 @@ void COptionsSubKeyboard::ClearBindItems( void )
 		if ( !item )
 			continue;
 
-		// Reset keys
 		item->SetString( "Key", "" );
 
 		m_pKeyBindList->InvalidateItem(i);
@@ -399,7 +395,6 @@ void COptionsSubKeyboard::FillInDefaultBindings( void )
 	if (fh == FILESYSTEM_INVALID_HANDLE)
 		return;
 
-	// L4D: also unbind other keys
 	engine->ClientCmd_Unrestricted( "unbindall\n" );
 
 	int size = g_pFullFileSystem->Size(fh) + 1;
@@ -410,12 +405,11 @@ void COptionsSubKeyboard::FillInDefaultBindings( void )
 	// NULL terminate!
 	((char*)buf.Base())[ size - 1 ] = '\0';
 
-	// Clear out all current bindings
 	ClearBindItems();
 
 	const char *data = (const char*)buf.Base();
 
-	// loop through all the binding
+	// loop through all the bindings
 	while ( data != NULL )
 	{
         char cmd[64];
@@ -425,22 +419,19 @@ void COptionsSubKeyboard::FillInDefaultBindings( void )
 
         if (!stricmp(cmd, "bind"))
         {
-            // Key name
             char szKeyName[256];
             data = engine->ParseFile(data, szKeyName, sizeof(szKeyName));
             if (strlen(szKeyName) <= 0)
-                break; // Error
+                break; 
 
             char szBinding[256];
             data = engine->ParseFile(data, szBinding, sizeof(szBinding));
             if (strlen(szKeyName) <= 0)
-                break; // Error
+                break; 
 
-            // Find item
             KeyValues *item = GetItemForBinding(szBinding);
             if (item)
             {
-                // Bind it
                 AddBinding(item, szKeyName);
             }
         }
@@ -452,13 +443,11 @@ void COptionsSubKeyboard::FillInDefaultBindings( void )
     KeyValues *item = GetItemForBinding( "toggleconsole" );
     if ( item )
     {
-        // Bind it
         AddBinding( item, "`" );
     }
     item = GetItemForBinding( "cancelselect" );
     if ( item )
     {
-        // Bind it
         AddBinding( item, "ESCAPE" );
     }
 }
@@ -537,8 +526,6 @@ void COptionsSubKeyboard::Finish( ButtonCode_t code )
 void COptionsSubKeyboard::OnThink()
 {
 	BaseClass::OnThink();
-
-	//m_pKeyBindList->GetScrollBar()->UseImages( "scroll_up", "scroll_down", "scroll_line", "scroll_box" );
 
 	if ( m_pKeyBindList->IsCapturing() )
 	{
@@ -627,7 +614,6 @@ void COptionsSubKeyboardAdvancedDlg::Activate()
 
 void COptionsSubKeyboardAdvancedDlg::OnApplyData()
 {
-	// apply data
     m_cvarConEnable.SetValue(GetControlInt("ConsoleCheck", 0));
 
 	m_cvarFastSwitch.SetValue(GetControlInt("FastSwitchCheck", 0));
@@ -637,7 +623,6 @@ void COptionsSubKeyboardAdvancedDlg::OnCommand(const char *command)
 {
 	if ( !stricmp(command, "OK") )
 	{
-		// apply the data
 		OnApplyData();
 		Close();
 	}
@@ -649,7 +634,6 @@ void COptionsSubKeyboardAdvancedDlg::OnCommand(const char *command)
 
 void COptionsSubKeyboardAdvancedDlg::OnKeyCodeTyped(KeyCode code)
 {
-	// force ourselves to be closed if the escape key it pressed
 	if (code == KEY_ESCAPE)
 	{
 		Close();

--- a/mp/src/gameui/OptionsSubKeyboard.cpp
+++ b/mp/src/gameui/OptionsSubKeyboard.cpp
@@ -735,79 +735,73 @@ void COptionsSubKeyboard::OnKeyCodePressed(vgui::KeyCode code)
 //-----------------------------------------------------------------------------
 // Purpose: advanced keyboard settings dialog
 //-----------------------------------------------------------------------------
-class COptionsSubKeyboardAdvancedDlg : public vgui::Frame
+COptionsSubKeyboardAdvancedDlg::COptionsSubKeyboardAdvancedDlg(vgui::VPANEL hParent) : BaseClass(NULL, NULL)
 {
-	DECLARE_CLASS_SIMPLE( COptionsSubKeyboardAdvancedDlg, vgui::Frame );
-public:
-	COptionsSubKeyboardAdvancedDlg( vgui::VPANEL hParent ) : BaseClass( NULL, NULL )
-	{
-		// parent is ignored, since we want look like we're steal focus from the parent (we'll become modal below)
+    // parent is ignored, since we want look like we're steal focus from the parent (we'll become modal below)
+    SetTitle("#GameUI_KeyboardAdvanced_Title", true);
+    SetSize(280, 140);
+    LoadControlSettings("resource/OptionsSubKeyboardAdvancedDlg.res");
+    MoveToCenterOfScreen();
+    SetSizeable(false);
+    SetDeleteSelfOnClose(true);
+}
 
-		SetTitle("#GameUI_KeyboardAdvanced_Title", true);
-		SetSize( 280, 140 );
-		LoadControlSettings( "resource/OptionsSubKeyboardAdvancedDlg.res" );
-		MoveToCenterOfScreen();
-		SetSizeable( false );
-		SetDeleteSelfOnClose( true );
+void COptionsSubKeyboardAdvancedDlg::Activate()
+{
+	BaseClass::Activate();
+
+	input()->SetAppModalSurface(GetVPanel());
+
+	// reset the data
+	ConVarRef con_enable( "con_enable" );
+	if ( con_enable.IsValid() )
+	{
+		SetControlInt("ConsoleCheck", con_enable.GetInt() ? 1 : 0);
 	}
 
-	virtual void Activate()
+	ConVarRef hud_fastswitch( "hud_fastswitch", true );
+	if ( hud_fastswitch.IsValid() )
 	{
-		BaseClass::Activate();
-
-		input()->SetAppModalSurface(GetVPanel());
-
-		// reset the data
-		ConVarRef con_enable( "con_enable" );
-		if ( con_enable.IsValid() )
-		{
-			SetControlInt("ConsoleCheck", con_enable.GetInt() ? 1 : 0);
-		}
-
-		ConVarRef hud_fastswitch( "hud_fastswitch", true );
-		if ( hud_fastswitch.IsValid() )
-		{
-			SetControlInt("FastSwitchCheck", hud_fastswitch.GetInt() ? 1 : 0);
-		}
+		SetControlInt("FastSwitchCheck", hud_fastswitch.GetInt() ? 1 : 0);
 	}
+}
 
-	virtual void OnApplyData()
+void COptionsSubKeyboardAdvancedDlg::OnApplyData()
+{
+	// apply data
+	ConVarRef con_enable( "con_enable" );
+	con_enable.SetValue( GetControlInt( "ConsoleCheck", 0 ) );
+
+	ConVarRef hud_fastswitch( "hud_fastswitch", true );
+	hud_fastswitch.SetValue( GetControlInt( "FastSwitchCheck", 0 ) );
+}
+
+void COptionsSubKeyboardAdvancedDlg::OnCommand(const char *command)
+{
+	if ( !stricmp(command, "OK") )
 	{
-		// apply data
-		ConVarRef con_enable( "con_enable" );
-		con_enable.SetValue( GetControlInt( "ConsoleCheck", 0 ) );
-
-		ConVarRef hud_fastswitch( "hud_fastswitch", true );
-		hud_fastswitch.SetValue( GetControlInt( "FastSwitchCheck", 0 ) );
+		// apply the data
+		OnApplyData();
+		Close();
 	}
-
-	virtual void OnCommand( const char *command )
+	else
 	{
-		if ( !stricmp(command, "OK") )
-		{
-			// apply the data
-			OnApplyData();
-			Close();
-		}
-		else
-		{
-			BaseClass::OnCommand( command );
-		}
+		BaseClass::OnCommand( command );
 	}
+}
 
-	void OnKeyCodeTyped(KeyCode code)
+void COptionsSubKeyboardAdvancedDlg::OnKeyCodeTyped(KeyCode code)
+{
+	// force ourselves to be closed if the escape key it pressed
+	if (code == KEY_ESCAPE)
 	{
-		// force ourselves to be closed if the escape key it pressed
-		if (code == KEY_ESCAPE)
-		{
-			Close();
-		}
-		else
-		{
-			BaseClass::OnKeyCodeTyped(code);
-		}
+		Close();
 	}
-};
+	else
+	{
+		BaseClass::OnKeyCodeTyped(code);
+	}
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: Open advanced keyboard options

--- a/mp/src/gameui/OptionsSubKeyboard.cpp
+++ b/mp/src/gameui/OptionsSubKeyboard.cpp
@@ -735,7 +735,8 @@ void COptionsSubKeyboard::OnKeyCodePressed(vgui::KeyCode code)
 //-----------------------------------------------------------------------------
 // Purpose: advanced keyboard settings dialog
 //-----------------------------------------------------------------------------
-COptionsSubKeyboardAdvancedDlg::COptionsSubKeyboardAdvancedDlg(vgui::VPANEL hParent) : BaseClass(NULL, NULL)
+COptionsSubKeyboardAdvancedDlg::COptionsSubKeyboardAdvancedDlg(vgui::VPANEL hParent) : BaseClass(NULL, NULL),
+    m_cvarConEnable("con_enable"), m_cvarFastSwitch("hud_fastswitch", true)
 {
     // parent is ignored, since we want look like we're steal focus from the parent (we'll become modal below)
     SetTitle("#GameUI_KeyboardAdvanced_Title", true);
@@ -753,27 +754,23 @@ void COptionsSubKeyboardAdvancedDlg::Activate()
 	input()->SetAppModalSurface(GetVPanel());
 
 	// reset the data
-	ConVarRef con_enable( "con_enable" );
-	if ( con_enable.IsValid() )
+	if ( m_cvarConEnable.IsValid() )
 	{
-		SetControlInt("ConsoleCheck", con_enable.GetInt() ? 1 : 0);
+        SetControlInt("ConsoleCheck", m_cvarConEnable.GetInt() ? 1 : 0);
 	}
 
-	ConVarRef hud_fastswitch( "hud_fastswitch", true );
-	if ( hud_fastswitch.IsValid() )
+	if ( m_cvarFastSwitch.IsValid() )
 	{
-		SetControlInt("FastSwitchCheck", hud_fastswitch.GetInt() ? 1 : 0);
+        SetControlInt("FastSwitchCheck", m_cvarFastSwitch.GetInt() ? 1 : 0);
 	}
 }
 
 void COptionsSubKeyboardAdvancedDlg::OnApplyData()
 {
 	// apply data
-	ConVarRef con_enable( "con_enable" );
-	con_enable.SetValue( GetControlInt( "ConsoleCheck", 0 ) );
+    m_cvarConEnable.SetValue(GetControlInt("ConsoleCheck", 0));
 
-	ConVarRef hud_fastswitch( "hud_fastswitch", true );
-	hud_fastswitch.SetValue( GetControlInt( "FastSwitchCheck", 0 ) );
+	m_cvarFastSwitch.SetValue(GetControlInt("FastSwitchCheck", 0));
 }
 
 void COptionsSubKeyboardAdvancedDlg::OnCommand(const char *command)

--- a/mp/src/gameui/OptionsSubKeyboard.h
+++ b/mp/src/gameui/OptionsSubKeyboard.h
@@ -40,32 +40,22 @@ public:
 	VControlsListPanel* GetControlsList( void ) { return m_pKeyBindList; }
 
 private:
-	void Finish( ButtonCode_t code );
+    void Finish( ButtonCode_t code );
 
-	virtual void	OnCommand( const char *command );
-
-	// Tell engine to bind/unbind a key
-	void			BindKey( const char *key, const char *binding );
-	void			UnbindKey( const char *key );
+    virtual void OnCommand( const char *command );
 
 	// Get column 0 action descriptions for all keys
-	void			ParseActionDescriptions( void );
+    void ParseActionDescriptions( void );
 
-	// Populate list of actions with current engine keybindings
-	void			FillInCurrentBindings( void );
-	// Remove all current bindings from list of bindings
-	void			ClearBindItems( void );
-	// Fill in bindings with mod-specified defaults
-	void			FillInDefaultBindings( void );
+    void BindKey(const char *key, const char *binding);
+    void UnbindKey(const char *key);
+    void FillInCurrentBindings( void );
+    void ClearBindItems( void );
+    void FillInDefaultBindings( void );
+    void AddBinding( KeyValues *item, const char *keyname );
+    void RemoveKeyFromBindItems( KeyValues *org_item, const char *key );
 
-	// Bind a key to the item
-	void			AddBinding( KeyValues *item, const char *keyname );
-
-	// Remove all instances of a key from all bindings
-	void			RemoveKeyFromBindItems( KeyValues *org_item, const char *key );
-
-	// Find item by binding name
-	KeyValues *GetItemForBinding( const char *binding );
+    KeyValues *GetItemForBinding( const char *binding );
 
 private:
 	void OpenKeyboardAdvancedDialog();

--- a/mp/src/gameui/OptionsSubKeyboard.h
+++ b/mp/src/gameui/OptionsSubKeyboard.h
@@ -117,6 +117,9 @@ class COptionsSubKeyboardAdvancedDlg : public vgui::Frame
     virtual void OnApplyData();
     virtual void OnCommand(const char *command);
     void OnKeyCodeTyped(vgui::KeyCode code);
+
+  private:
+    ConVarRef m_cvarConEnable, m_cvarFastSwitch;
 };
 
 

--- a/mp/src/gameui/OptionsSubKeyboard.h
+++ b/mp/src/gameui/OptionsSubKeyboard.h
@@ -28,7 +28,6 @@ class COptionsSubKeyboard : public vgui::PropertyPage
 
 public:
 	COptionsSubKeyboard(vgui::Panel *parent);
-	~COptionsSubKeyboard();
 
 	virtual void	OnResetData();
 	virtual void	OnApplyChanges();
@@ -43,26 +42,11 @@ public:
 private:
 	void Finish( ButtonCode_t code );
 
-	//-----------------------------------------------------------------------------
-	// Purpose: Used for saving engine keybindings in case user hits cancel button
-	//-----------------------------------------------------------------------------
-	struct KeyBinding
-	{
-		char *binding;
-	};
-
-	// Create the key binding list control
-	void			CreateKeyBindingList( void );
-
 	virtual void	OnCommand( const char *command );
 
 	// Tell engine to bind/unbind a key
 	void			BindKey( const char *key, const char *binding );
 	void			UnbindKey( const char *key );
-
-	// Save/restore/cleanup engine's current bindings ( for handling cancel button )
-	void			SaveCurrentBindings( void );
-	void			DeleteSavedBindings( void );
 
 	// Get column 0 action descriptions for all keys
 	void			ParseActionDescriptions( void );
@@ -73,8 +57,6 @@ private:
 	void			ClearBindItems( void );
 	// Fill in bindings with mod-specified defaults
 	void			FillInDefaultBindings( void );
-	// Copy bindings out of list and set them in the engine
-	void			ApplyAllBindings( void );
 
 	// Bind a key to the item
 	void			AddBinding( KeyValues *item, const char *keyname );
@@ -94,12 +76,6 @@ private:
 
 	vgui::Button *m_pSetBindingButton;
 	vgui::Button *m_pClearBindingButton;
-
-	// List of saved bindings for the keys
-	KeyBinding m_Bindings[ BUTTON_CODE_LAST ];
-
-	// List of all the keys that need to have their binding removed
-	CUtlVector<CUtlSymbol> m_KeysToUnbind;
 };
 
 

--- a/mp/src/gameui/OptionsSubKeyboard.h
+++ b/mp/src/gameui/OptionsSubKeyboard.h
@@ -14,6 +14,8 @@
 #include "tier1/utlvector.h"
 #include "tier1/utlsymbol.h"
 
+#include <vgui_controls/Panel.h>
+#include "vgui_controls/Frame.h"
 #include "vgui_controls/PropertyPage.h"
 class VControlsListPanel;
 
@@ -99,5 +101,23 @@ private:
 	// List of all the keys that need to have their binding removed
 	CUtlVector<CUtlSymbol> m_KeysToUnbind;
 };
+
+
+//-----------------------------------------------------------------------------
+// Purpose: advanced keyboard settings dialog
+//-----------------------------------------------------------------------------
+class COptionsSubKeyboardAdvancedDlg : public vgui::Frame
+{
+    DECLARE_CLASS_SIMPLE(COptionsSubKeyboardAdvancedDlg, vgui::Frame);
+
+  public:
+    COptionsSubKeyboardAdvancedDlg(vgui::VPANEL hParent);
+
+    virtual void Activate();
+    virtual void OnApplyData();
+    virtual void OnCommand(const char *command);
+    void OnKeyCodeTyped(vgui::KeyCode code);
+};
+
 
 #endif // OPTIONS_SUB_KEYBOARD_H


### PR DESCRIPTION
Now that the momentum settings changed to apply instantly, I'm attempting to make the same changes to the GameUI code - Issue #708 

Functionality:
- Once the key is bound/deleted, it instantly applies rather than applying after pressing OK/Apply.
- ApplyOK button is used to write settings to the config file.
    - My goal is to use the apply button to write the settings to the config & override the button's text to be "Write to config file". Could also write to file every time something is changed but that seems like it'd be costly.

Did this by
- Removing functions/fields related to resetting bindings when the "Close" button is pressed.
- Added `BindKey` and `UnbindKey` calls when a key is bound in the menu.
    - Edit & clear key buttons work with this as well.

Also:
- Moved the advanced dialog class to the header & moved its `ConVarRef`'s to its constructor.
     - As this is modal, didn't change it to apply instantly.
- Removed "duh" comments left in the code.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review