### PR TITLE
Converted Zone Menu to new CvarSlider/CvarTextEntry

### DIFF
--- a/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.cpp
+++ b/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.cpp
@@ -67,8 +67,8 @@ C_MomZoneMenu::C_MomZoneMenu() : Frame(g_pClientMode->GetViewport(), "ZoneMenu")
     m_pZoneTypeCombo->ActivateItemByRow(0);
 
     m_pGridSizeLabel = new Label(this, "GridSizeLabel", "");
-    m_pGridSizeSlider = new CvarSlider(this, "GridSizeSlider");
-    m_pGridSizeTextEntry = new CvarTextEntry(this, "GridSizeTextEntry", "mom_zone_grid");
+    m_pGridSizeSlider = new CvarSlider(this, "GridSizeSlider", "", 0.0f, 1.0f, "mom_zone_grid", false, true, true);
+    m_pGridSizeTextEntry = new CvarTextEntry(this, "GridSizeTextEntry", "mom_zone_grid", "%.0f");
     m_pGridSizeTextEntry->SetAllowNumericInputOnly(true);
     m_bUpdateGridSizeSlider = false;
 
@@ -197,44 +197,9 @@ void C_MomZoneMenu::OnClose()
     BaseClass::OnClose();
 }
 
-void C_MomZoneMenu::OnControlModified(Panel *pPanel)
-{
-    if (pPanel == m_pGridSizeSlider)
-    {
-        // Don't retrigger the cvar change if it was already updated by textentry
-        if (!m_bUpdateGridSizeSlider)
-        {
-            m_bUpdateGridSizeSlider = true;
-            return;
-        }
-
-        // Round val to whole number, because no one wants to align to 6.1238765426
-        float flVal = roundf(m_pGridSizeSlider->GetSliderValue());
-        m_pGridSizeSlider->SetSliderValue(flVal);
-        m_pGridSizeSlider->ApplyChanges();
-        // update textentry control
-        char szVal[32];
-        Q_snprintf(szVal, sizeof(szVal), "%.0f", flVal);
-        m_pGridSizeTextEntry->SetText(szVal);
-    }
-    else if (pPanel == m_pToggleZoneEdit)
-        m_pToggleZoneEdit->ApplyChanges();
-    else if (pPanel == m_pToggleUsePointMethod)
-        m_pToggleUsePointMethod->ApplyChanges();
-}
-
 void C_MomZoneMenu::OnTextChanged(Panel *pPanel)
 {
-    if (pPanel == m_pGridSizeTextEntry)
-    {
-        m_bUpdateGridSizeSlider = false;
-        m_pGridSizeTextEntry->ApplyChanges();
-    }
-    else if (pPanel == m_pTrackNumberEntry)
-        m_pTrackNumberEntry->ApplyChanges();
-    else if (pPanel == m_pZoneNumberEntry)
-        m_pZoneNumberEntry->ApplyChanges();
-    else if (pPanel == m_pZoneTypeCombo)
+    if (pPanel == m_pZoneTypeCombo)
     {
         static ConVarRef mom_zone_type("mom_zone_type");
 

--- a/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.h
+++ b/mp/src/game/client/momentum/ui/ZoneMenu/ZoneMenu.h
@@ -9,7 +9,6 @@ class C_MomZoneMenu : public vgui::Frame
   public: // vgui::Frame
     C_MomZoneMenu();
 
-    MESSAGE_FUNC_PTR(OnControlModified, "ControlModified", panel);
     MESSAGE_FUNC_PTR(OnTextChanged, "TextChanged", panel);
     MESSAGE_FUNC_PTR_INT(OnButtonChecked, "CheckButtonChecked", panel, state);
 

--- a/mp/src/public/vgui_controls/CvarSlider.h
+++ b/mp/src/public/vgui_controls/CvarSlider.h
@@ -11,11 +11,11 @@ namespace vgui
     public:
         CvarSlider(Panel *parent, const char *panelName);
         CvarSlider(Panel *parent, const char *panelName, char const *caption, float minValue, float maxValue,
-            char const *cvarname, bool bAllowOutOfRange = false, bool bAutoApplyChanges = false);
+            char const *cvarname, bool bAllowOutOfRange = false, bool bAutoApplyChanges = false, bool bOnlyIntegers = false);
         ~CvarSlider();
 
         void SetupSlider(float minValue, float maxValue, const char *cvarname, bool bAllowOutOfRange,
-                         bool bAutoApplyChanges);
+                         bool bAutoApplyChanges, bool bOnlyIntegers);
 
         void SetCVarName(char const *cvarname);
         void SetMinMaxValues(float minValue, float maxValue, bool bSetTickdisplay = true);
@@ -29,6 +29,8 @@ namespace vgui
 
         bool ShouldAutoApplyChanges() const { return m_bAutoApplyChanges; }
         void SetAutoApplyChanges(bool val) { m_bAutoApplyChanges = val; }
+        bool IsOnlyIntegers() const { return m_bOnlyIntegers; }
+        void SetOnlyIntegers(bool val) { m_bOnlyIntegers = val; }
 
         void ApplyChanges();
         float GetSliderValue();
@@ -50,6 +52,7 @@ namespace vgui
         ConVarRef m_cvar;
 
         bool m_bAutoApplyChanges;
+        bool m_bOnlyIntegers;
         bool m_bCreatedInCode;
         float m_flMinValue;
         float m_flMaxValue;


### PR DESCRIPTION
Apart of #710 

- Added an integer only flag to `CvarSlider` for sliders that need to set cvar values as whole instead of floating point numbers. 
- Converted the grid size slider to use this flag and also the auto apply flag. 
- Removed unneeded code that was updating the slider/textentries.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review