### PR TITLE
Converted Paint Gun Panel to new CvarSlider/CvarTextEntry 

### DIFF
--- a/mp/game/momentum/resource/ui/PaintGunPanel.res
+++ b/mp/game/momentum/resource/ui/PaintGunPanel.res
@@ -65,7 +65,7 @@
     }
     "TextSliderScale"
     {
-        "ControlName"	"TextEntry"
+        "ControlName"	"CvarTextEntry"
         "fieldName"		"TextSliderScale"
         "xpos"		"0"
         "ypos"		"0"
@@ -79,6 +79,7 @@
         "textHidden"		"0"
         "editable"		"1"
         "maxchars"		"-1"
+        "cvar_name" "mom_paintgun_scale"
         "NumericInputOnly"		"1"
         "unicode"		"0"
         "mouseinputenabled" "1"

--- a/mp/src/game/client/momentum/ui/PaintGunPanel.cpp
+++ b/mp/src/game/client/momentum/ui/PaintGunPanel.cpp
@@ -4,6 +4,7 @@
 
 #include <vgui_controls/Button.h>
 #include <vgui_controls/CvarSlider.h>
+#include <vgui_controls/CvarTextEntry.h>
 #include <vgui_controls/CvarToggleCheckButton.h>
 #include "controls/ColorPicker.h"
 #include "clientmode_shared.h"
@@ -46,9 +47,9 @@ PaintGunPanel::PaintGunPanel() : BaseClass(g_pClientMode->GetViewport(), "PaintG
     m_pToggleSound->AddActionSignalTarget(this);
 
     m_pPickColorButton = new Button(this, "PickColorButton", "", this, "picker");
-    m_pSliderScale = new CvarSlider(this, "SliderScale");
+    m_pSliderScale = new CvarSlider(this, "SliderScale", "", 0.0f, 1.0f, "mom_paintgun_scale", false, true);
 
-    m_pTextSliderScale = new TextEntry(this, "TextSliderScale");
+    m_pTextSliderScale = new CvarTextEntry(this, "TextSliderScale", "mom_paintgun_scale", "%.2f");
     m_pTextSliderScale->AddActionSignalTarget(this);
     m_pTextSliderScale->SetAllowNumericInputOnly(true);
 
@@ -65,7 +66,6 @@ PaintGunPanel::PaintGunPanel() : BaseClass(g_pClientMode->GetViewport(), "PaintG
         m_pPickColorButton->SetSelectedColor(TextureColor, TextureColor);
     }
 
-    SetLabelText();
     m_pColorPicker = new ColorPicker(this, this);
     m_pColorPicker->SetAutoDelete(true);
 
@@ -74,50 +74,6 @@ PaintGunPanel::PaintGunPanel() : BaseClass(g_pClientMode->GetViewport(), "PaintG
 }
 
 PaintGunPanel::~PaintGunPanel() {}
-
-void PaintGunPanel::SetLabelText() const
-{
-    if (m_pSliderScale && m_pTextSliderScale)
-    {
-        mom_paintgun_scale.SetValue(m_pSliderScale->GetSliderValue());
-
-        char buf[64];
-        Q_snprintf(buf, sizeof(buf), "%.2f", m_pSliderScale->GetSliderValue());
-        m_pTextSliderScale->SetText(buf);
-
-        m_pSliderScale->ApplyChanges();
-    }
-}
-
-void PaintGunPanel::OnControlModified(Panel *p)
-{
-    if (p == m_pSliderScale && m_pSliderScale->HasBeenModified())
-    {
-        SetLabelText();
-    }
-    else if (p == m_pToggleViewmodel || p == m_pToggleSound)
-    {
-        m_pToggleViewmodel->ApplyChanges();
-        m_pToggleSound->ApplyChanges();
-    }
-}
-
-void PaintGunPanel::OnTextChanged(Panel *p)
-{
-    if (p == m_pTextSliderScale)
-    {
-        char buf[64];
-        m_pTextSliderScale->GetText(buf, 64);
-
-        float fValue = float(atof(buf));
-        float fMin, fMax;
-        if (mom_paintgun_scale.GetMin(fMin) && fValue >= fMin && mom_paintgun_scale.GetMax(fMax) && fValue <= fMax)
-        {
-            m_pSliderScale->SetSliderValue(fValue);
-            m_pSliderScale->ApplyChanges();
-        }
-    }
-}
 
 void PaintGunPanel::OnColorSelected(KeyValues *pKv)
 {

--- a/mp/src/game/client/momentum/ui/PaintGunPanel.h
+++ b/mp/src/game/client/momentum/ui/PaintGunPanel.h
@@ -23,20 +23,12 @@ class PaintGunPanel : public EditablePanel, public CGameEventListener
 
     void FireGameEvent(IGameEvent* event) OVERRIDE;
 
-    void SetLabelText() const;
-
     // From the color picker
     MESSAGE_FUNC_PARAMS(OnColorSelected, "ColorSelected", pKv);
 
-    // When the slider changes, we want to update the text panel
-    MESSAGE_FUNC_PTR(OnControlModified, "ControlModified", panel);
-
-    // When the text entry updates, we want to update the slider
-    MESSAGE_FUNC_PTR(OnTextChanged, "TextChanged", panel);
-
     ColorPicker *m_pColorPicker;
     CvarSlider *m_pSliderScale;
-    TextEntry *m_pTextSliderScale;
+    CvarTextEntry *m_pTextSliderScale;
     Label *m_pLabelSliderScale;
     Label *m_pLabelColorButton;
     CvarToggleCheckButton *m_pToggleViewmodel, *m_pToggleSound;


### PR DESCRIPTION
Apart of #710

- Decal scale slider now uses auto apply flag
- Converted decal scale text entry to `CvarTextEntry`
- Removed unneeded code used to update the slider/textentry as a result of this conversion.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review