### PR TITLE
Converted ReplayUI fields to new CvarSlider/CvarTextEntry 

### DIFF
--- a/mp/game/momentum/resource/ui/ReplayUI.res
+++ b/mp/game/momentum/resource/ui/ReplayUI.res
@@ -327,7 +327,7 @@
     }
     "TimescaleEntry"
     {
-        "ControlName"		"TextEntry"
+        "ControlName"		"CvarTextEntry"
         "fieldName"		"TimescaleEntry"
         "xpos"		"0"
         "ypos"		"14"
@@ -341,6 +341,7 @@
         "textHidden"		"0"
         "editable"		"1"
         "maxchars"		"-1"
+        "cvar_name" "mom_replay_timescale"
         "NumericInputOnly"		"1"
         "unicode"		"0"
         "mouseinputenabled" "1"

--- a/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
+++ b/mp/src/game/client/momentum/ui/spectate/mom_replayui.cpp
@@ -63,13 +63,12 @@ C_MOMReplayUI::C_MOMReplayUI(IViewPort *pViewport) : Frame(nullptr, PANEL_REPLAY
     m_pGotoTick->SetAllowNumericInputOnly(true);
     m_pGotoTick->AddActionSignalTarget(this);
 
-    m_pTimescaleSlider = new CvarSlider(this, "TimescaleSlider", nullptr, 0.1f, 10.0f, "mom_replay_timescale");
+    m_pTimescaleSlider = new CvarSlider(this, "TimescaleSlider", nullptr, 0.1f, 10.0f, "mom_replay_timescale", false, true);
     m_pTimescaleSlider->AddActionSignalTarget(this);
     m_pTimescaleLabel = new Label(this, "TimescaleLabel", "#MOM_ReplayTimescale");
-    m_pTimescaleEntry = new TextEntry(this, "TimescaleEntry");
+    m_pTimescaleEntry = new CvarTextEntry(this, "TimescaleEntry", "mom_replay_timescale", "%.1f");
     m_pTimescaleEntry->SetAllowNumericInputOnly(true);
     m_pTimescaleEntry->AddActionSignalTarget(this);
-    SetLabelText();
 
     m_pProgress = new ScrubbableProgressBar(this, "ReplayProgress");
     m_pProgress->AddActionSignalTarget(this);
@@ -187,30 +186,6 @@ void C_MOMReplayUI::OnThink()
     }
 }
 
-void C_MOMReplayUI::OnControlModified(Panel *p)
-{
-    if (p == m_pTimescaleSlider && m_pTimescaleSlider->HasBeenModified())
-    {
-        SetLabelText();
-    }
-}
-
-void C_MOMReplayUI::OnTextChanged(Panel *p)
-{
-    if (p == m_pTimescaleEntry)
-    {
-        char buf[64];
-        m_pTimescaleEntry->GetText(buf, 64);
-
-        float fValue = V_atof(buf);
-        if (fValue >= 0.01f && fValue <= 10.0f)
-        {
-            m_pTimescaleSlider->SetSliderValue(fValue);
-            m_pTimescaleSlider->ApplyChanges();
-        }
-    }
-}
-
 void C_MOMReplayUI::OnNewProgress(float scale)
 {
     int tickToGo = static_cast<int>(scale * m_iTotalDuration);
@@ -221,20 +196,6 @@ void C_MOMReplayUI::OnNewProgress(float scale)
 }
 
 void C_MOMReplayUI::OnPBMouseWheeled(int delta) { OnCommand(delta > 0 ? "nextframe" : "prevframe"); }
-
-void C_MOMReplayUI::SetLabelText() const
-{
-    if (m_pTimescaleSlider && m_pTimescaleEntry)
-    {
-        char buf[64];
-        Q_snprintf(buf, sizeof(buf), "%.1f", m_pTimescaleSlider->GetSliderValue());
-        m_pTimescaleEntry->SetText(buf);
-
-        float newVal = V_atof(buf);
-        m_pTimescaleSlider->SetSliderValue(newVal);
-        m_pTimescaleSlider->ApplyChanges();
-    }
-}
 
 void C_MOMReplayUI::SetWasClosed(bool bWasClosed)
 {

--- a/mp/src/game/client/momentum/ui/spectate/mom_replayui.h
+++ b/mp/src/game/client/momentum/ui/spectate/mom_replayui.h
@@ -28,7 +28,6 @@ class C_MOMReplayUI : public vgui::Frame, public IViewPortPanel, public CGameEve
     // Command issued
     virtual void OnCommand(const char *command) OVERRIDE;
 
-    void SetLabelText() const;
     void SetWasClosed(bool bWasClosed);
     bool WasClosed() const;
 
@@ -49,12 +48,6 @@ class C_MOMReplayUI : public vgui::Frame, public IViewPortPanel, public CGameEve
     virtual void SetParent(vgui::VPANEL parent) OVERRIDE { BaseClass::SetParent(parent); };
 
   protected:
-    // When the slider changes, we want to update the text panel
-    MESSAGE_FUNC_PTR(OnControlModified, "ControlModified", panel);
-
-    // When the text entry updates, we want to update the slider
-    MESSAGE_FUNC_PTR(OnTextChanged, "TextChanged", panel);
-
     // When the user clicks (and potentially drags) on the Progress Bar
     MESSAGE_FUNC_FLOAT(OnNewProgress, "ScrubbedProgress", scale);
 
@@ -73,7 +66,7 @@ class C_MOMReplayUI : public vgui::Frame, public IViewPortPanel, public CGameEve
     vgui::Button *m_pGo;
 
     vgui::CvarSlider *m_pTimescaleSlider;
-    vgui::TextEntry *m_pTimescaleEntry;
+    vgui::CvarTextEntry *m_pTimescaleEntry;
     vgui::Label *m_pTimescaleLabel;
 
     vgui::ScrubbableProgressBar *m_pProgress;


### PR DESCRIPTION
Apart of #710

- Converted the timescale slider to use the auto apply flag.
- Converted timescale text entry to `CvarTextEntry`.
- Removed unneeded code that was updating the slider/textentries.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review