### PR TITLE
Add airborne_only flag to func_nogrenades

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -7,7 +7,7 @@
 // -----------------------------------------------------------------------
 @SolidClass base(Targetname, EnableDisable, Toggle) = func_nogrenades : "Rockets and grenades will not detonate inside this area." 
 [
-    airborne_only(choices) : "Remove airborne explosions only" : 0 = 
+    airborne_only(choices) : "Prevent airborne explosions only" : 0 = 
     [
         0 : "False"
         1 : "True"

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -5,7 +5,14 @@
 // TF2 COMPATIBILITY
 //
 // -----------------------------------------------------------------------
-@SolidClass base(Targetname, EnableDisable, Toggle) = func_nogrenades : "Rockets and grenades will not detonate inside this area." []
+@SolidClass base(Targetname, EnableDisable, Toggle) = func_nogrenades : "Rockets and grenades will not detonate inside this area." 
+[
+    airborne_only(choices) : "Remove airborne explosions only" : 0 = 
+    [
+        0 : "False"
+        1 : "True"
+    ]
+]
 
 @PointClass base(Targetname,Studiomodel,Origin,Angles) studioprop() = momentum_generic_bomb : "Generic Bomb"
 [

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1473,8 +1473,8 @@ static CUtlVector<CNoGrenadesZone *> s_vecNoGrenadeZones;
 LINK_ENTITY_TO_CLASS(func_nogrenades, CNoGrenadesZone);
 
 BEGIN_DATADESC(CNoGrenadesZone)
-    DEFINE_KEYFIELD(m_bAirborneOnly, FIELD_BOOLEAN, "airborne_only")
-END_DATADESC()
+DEFINE_KEYFIELD(m_bAirborneOnly, FIELD_BOOLEAN, "airborne_only")
+END_DATADESC();
 
 CNoGrenadesZone::~CNoGrenadesZone()
 {
@@ -1502,15 +1502,18 @@ bool CNoGrenadesZone::IsInsideNoGrenadesZone(CBaseEntity *pOther)
 {
     if ( pOther )
     {
-        CMomStickybomb* pSticky = dynamic_cast<CMomStickybomb*>(pOther);
+        const auto pSticky = dynamic_cast<CMomStickybomb*>(pOther);
         FOR_EACH_VEC(s_vecNoGrenadeZones, i)
         {
             const auto pNoGrenadeZone = s_vecNoGrenadeZones[i];
 
-            bool bLandedStickyInWallpogoNonades = pSticky ? (pSticky->GetUseImpactNormal() && pNoGrenadeZone->m_bAirborneOnly) : false;
+            if (pNoGrenadeZone->m_bDisabled || !pNoGrenadeZone->PointIsWithin(pOther->GetAbsOrigin()))
+                continue;
 
-            if (!pNoGrenadeZone->m_bDisabled && pNoGrenadeZone->PointIsWithin(pOther->GetAbsOrigin()) && !bLandedStickyInWallpogoNonades)
-                return true;
+            if (!pSticky)
+                return true; // This is a rocket in a nonade zone and should fizzle
+
+            return !pNoGrenadeZone->m_bAirborneOnly || !pSticky->DidHitWorld();
         }
     }
 

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -6,6 +6,7 @@
 #include "mom_replay_entity.h"
 #include "mom_system_gamemode.h"
 #include "mom_system_progress.h"
+#include "mom_stickybomb.h"
 #include "fmtstr.h"
 #include "mom_timer.h"
 #include "mom_modulecomms.h"
@@ -1471,6 +1472,10 @@ static CUtlVector<CNoGrenadesZone *> s_vecNoGrenadeZones;
 
 LINK_ENTITY_TO_CLASS(func_nogrenades, CNoGrenadesZone);
 
+BEGIN_DATADESC(CNoGrenadesZone)
+    DEFINE_KEYFIELD(m_bAirborneOnly, FIELD_BOOLEAN, "airborne_only")
+END_DATADESC()
+
 CNoGrenadesZone::~CNoGrenadesZone()
 {
     s_vecNoGrenadeZones.FindAndFastRemove(this);
@@ -1497,10 +1502,14 @@ bool CNoGrenadesZone::IsInsideNoGrenadesZone(CBaseEntity *pOther)
 {
     if ( pOther )
     {
+        CMomStickybomb* pSticky = dynamic_cast<CMomStickybomb*>(pOther);
         FOR_EACH_VEC(s_vecNoGrenadeZones, i)
         {
             const auto pNoGrenadeZone = s_vecNoGrenadeZones[i];
-            if (!pNoGrenadeZone->m_bDisabled && pNoGrenadeZone->PointIsWithin(pOther->GetAbsOrigin()))
+
+            bool bLandedStickyInWallpogoNonades = pSticky ? (pSticky->GetUseImpactNormal() && pNoGrenadeZone->m_bAirborneOnly) : false;
+
+            if (!pNoGrenadeZone->m_bDisabled && pNoGrenadeZone->PointIsWithin(pOther->GetAbsOrigin()) && !bLandedStickyInWallpogoNonades)
                 return true;
         }
     }

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -664,6 +664,7 @@ class CNoGrenadesZone : public CBaseTrigger
 {
 public:
     DECLARE_CLASS(CNoGrenadesZone, CBaseTrigger);
+    DECLARE_DATADESC();
 
     ~CNoGrenadesZone();
 
@@ -675,4 +676,6 @@ public:
     void InputToggle(inputdata_t &inputdata) override { m_bDisabled = !m_bDisabled; }
 
     static bool IsInsideNoGrenadesZone(CBaseEntity *pOther);
+
+    bool m_bAirborneOnly;
 };

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -56,7 +56,7 @@ CMomStickybomb::CMomStickybomb()
 #ifdef GAME_DLL
     m_bFizzle = false;
     m_flCreationTime = 0.0f;
-    m_bUseImpactNormal = false;
+    m_bDidHitWorld = false;
     m_vecImpactNormal.Init();
 #else
     m_bPulsed = false;
@@ -198,10 +198,6 @@ EXPOSE_INTERFACE(CStickybombArmTimeProxy, IMaterialProxy, "ArmTime" IMATERIAL_PR
 
 #else
 
-bool CMomStickybomb::GetUseImpactNormal() {
-    return m_bUseImpactNormal;
-}
-
 CMomStickybomb *CMomStickybomb::Create(const Vector &position, const QAngle &angles, const Vector &velocity, CBaseEntity *pOwner)
 {
     const auto pStickybomb = dynamic_cast<CMomStickybomb *>(CreateNoSpawn("momentum_stickybomb", position, angles, pOwner));
@@ -276,7 +272,7 @@ void CMomStickybomb::Explode(trace_t *pTrace, CBaseEntity *pOther)
     Vector vecOrigin = GetAbsOrigin();
     CPVSFilter filter(vecOrigin);
 
-    const Vector vecNormal = m_bUseImpactNormal ? m_vecImpactNormal : pTrace->plane.normal;
+    const Vector vecNormal = m_bDidHitWorld ? m_vecImpactNormal : pTrace->plane.normal;
     TE_TFExplosion(filter, vecOrigin, vecNormal, WEAPON_STICKYLAUNCHER);
 
     const auto pOwner = GetOwnerEntity();
@@ -324,7 +320,7 @@ void CMomStickybomb::VPhysicsCollision(int index, gamevcollisionevent_t *pEvent)
         g_PostSimulationQueue.QueueCall(VPhysicsGetObject(), &IPhysicsObject::EnableMotion, false);
 
         // Save impact data for explosions.
-        m_bUseImpactNormal = true;
+        m_bDidHitWorld = true;
         pEvent->pInternalData->GetSurfaceNormal(m_vecImpactNormal);
         m_vecImpactNormal.Negate();
     }

--- a/mp/src/game/shared/momentum/mom_stickybomb.cpp
+++ b/mp/src/game/shared/momentum/mom_stickybomb.cpp
@@ -198,6 +198,10 @@ EXPOSE_INTERFACE(CStickybombArmTimeProxy, IMaterialProxy, "ArmTime" IMATERIAL_PR
 
 #else
 
+bool CMomStickybomb::GetUseImpactNormal() {
+    return m_bUseImpactNormal;
+}
+
 CMomStickybomb *CMomStickybomb::Create(const Vector &position, const QAngle &angles, const Vector &velocity, CBaseEntity *pOwner)
 {
     const auto pStickybomb = dynamic_cast<CMomStickybomb *>(CreateNoSpawn("momentum_stickybomb", position, angles, pOwner));

--- a/mp/src/game/shared/momentum/mom_stickybomb.h
+++ b/mp/src/game/shared/momentum/mom_stickybomb.h
@@ -41,7 +41,7 @@ class CMomStickybomb : public CMomExplosive
     void Detonate();
     void VPhysicsCollision(int index, gamevcollisionevent_t *pEvent) OVERRIDE;
 
-    bool GetUseImpactNormal();
+    bool DidHitWorld() const { return m_bDidHitWorld; }
 #endif
 
   private:
@@ -50,7 +50,7 @@ class CMomStickybomb : public CMomExplosive
     bool m_bPulsed;
 #else
     bool m_bFizzle;
-    bool m_bUseImpactNormal;
+    bool m_bDidHitWorld;
     Vector m_vecImpactNormal;
     float m_flCreationTime;
 #endif

--- a/mp/src/game/shared/momentum/mom_stickybomb.h
+++ b/mp/src/game/shared/momentum/mom_stickybomb.h
@@ -40,6 +40,8 @@ class CMomStickybomb : public CMomExplosive
     void Fizzle();
     void Detonate();
     void VPhysicsCollision(int index, gamevcollisionevent_t *pEvent) OVERRIDE;
+
+    bool GetUseImpactNormal();
 #endif
 
   private:


### PR DESCRIPTION
Closes #694 
<!-- Describe what your pull request is doing here -->
This PR adds a flag to the func_nogrenades trigger which determines whether stickies that have landed should fizzle or not.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->