### PR TITLE
Prevent softlock when chat is opened and cl_drawhud is 0

### DIFF
--- a/mp/src/game/client/clientmode_shared.cpp
+++ b/mp/src/game/client/clientmode_shared.cpp
@@ -700,6 +700,11 @@ void ClientModeShared::StartMessageMode( int iMessageModeType )
 	{
 		return;
 	}*/
+
+    // avoid softlock of starting message mode when hud/viewport isn't visible
+    if ( !m_pViewport->IsVisible() )
+        return;
+
 	if ( m_pChatElement )
 	{
 		m_pChatElement->StartMessageMode( iMessageModeType );


### PR DESCRIPTION
Closes #737 

Early returned the `StartMessageMode` function when the viewport isn't visible (effectively when `cl_drawhud = 0`).

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review