### PR TITLE
Removed Cancel/Apply buttons on GameUI options dialog

### DIFF
--- a/mp/src/gameui/OptionsDialog.cpp
+++ b/mp/src/gameui/OptionsDialog.cpp
@@ -47,7 +47,10 @@ COptionsDialog::COptionsDialog(vgui::Panel *parent) : PropertyDialog(parent, "Op
 //	double s5 = system()->GetCurrentTime();
 //	Msg("COptionsDialog::COptionsDialog(): %.3fms\n", (float)(s5 - s4) * 1000.0f);
 
-	SetApplyButtonVisible(true);
+    SetOKButtonVisible(false);
+    SetCancelButtonVisible(true);
+    SetApplyButtonVisible(false);
+    SetCancelButtonText("Write settings to config file");
 	GetPropertySheet()->SetTabWidth(84);
 }
 
@@ -59,12 +62,17 @@ COptionsDialog::~COptionsDialog()
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: Brings the dialog to the fore
+// Purpose: Writes users config to file
 //-----------------------------------------------------------------------------
-void COptionsDialog::Activate()
+void COptionsDialog::OnCancel()
 {
-	BaseClass::Activate();
-	EnableApplyButton(false);
+    engine->ClientCmd_Unrestricted("exec userconfig.cfg\nhost_writeconfig\n");
+}
+
+void COptionsDialog::OnClose()
+{ 
+    OnCancel();
+    BaseClass::OnClose();
 }
 
 //-----------------------------------------------------------------------------

--- a/mp/src/gameui/OptionsDialog.h
+++ b/mp/src/gameui/OptionsDialog.h
@@ -26,8 +26,9 @@ public:
 	~COptionsDialog();
 
 	void Run();
-	virtual void Activate();
 	void OpenGammaDialog();
+    virtual void OnCancel() OVERRIDE;
+    virtual void OnClose() OVERRIDE;
 
 	MESSAGE_FUNC( OnGameUIHidden, "GameUIHidden" );	// called when the GameUI is hidden
 

--- a/mp/src/gameui/OptionsSubKeyboard.cpp
+++ b/mp/src/gameui/OptionsSubKeyboard.cpp
@@ -71,15 +71,6 @@ void COptionsSubKeyboard::OnResetData()
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: saves out keybinding changes
-//-----------------------------------------------------------------------------
-void COptionsSubKeyboard::OnApplyChanges()
-{
-    // Now exec their custom bindings
-    engine->ClientCmd_Unrestricted("exec userconfig.cfg\nhost_writeconfig\n");
-}
-
-//-----------------------------------------------------------------------------
 // Purpose: binds double-clicking or hitting enter in the keybind list to changing the key
 //-----------------------------------------------------------------------------
 void COptionsSubKeyboard::OnKeyCodeTyped(vgui::KeyCode code)
@@ -436,8 +427,6 @@ void COptionsSubKeyboard::FillInDefaultBindings( void )
             }
         }
 	}
-	
-	PostActionSignal(new KeyValues("ApplyButtonEnable"));
 
 	// Make sure console and escape key are always valid
     KeyValues *item = GetItemForBinding( "toggleconsole" );
@@ -510,7 +499,6 @@ void COptionsSubKeyboard::Finish( ButtonCode_t code )
 		{
 			// Bind the named key
 			AddBinding( item, g_pInputSystem->ButtonCodeToString( code ) );
-			PostActionSignal( new KeyValues( "ApplyButtonEnable" ) );	
 		}
 
 		m_pKeyBindList->InvalidateItem(r);
@@ -566,7 +554,6 @@ void COptionsSubKeyboard::OnKeyCodePressed(vgui::KeyCode code)
 
 				m_pClearBindingButton->SetEnabled(false);
 				m_pKeyBindList->InvalidateItem(r);
-				PostActionSignal(new KeyValues("ApplyButtonEnable"));
 
 				// message handled, don't pass on
 				return;

--- a/mp/src/gameui/OptionsSubKeyboard.h
+++ b/mp/src/gameui/OptionsSubKeyboard.h
@@ -30,7 +30,6 @@ public:
 	COptionsSubKeyboard(vgui::Panel *parent);
 
 	virtual void	OnResetData();
-	virtual void	OnApplyChanges();
 	virtual void	OnKeyCodePressed( vgui::KeyCode code );
 	virtual void	OnThink();
 

--- a/mp/src/public/vgui_controls/PropertyDialog.h
+++ b/mp/src/public/vgui_controls/PropertyDialog.h
@@ -72,6 +72,8 @@ protected:
 	void EnableApplyButton(bool bEnable);
 	
 private:
+    void UpdateButtonPositions();
+
 	PropertySheet *_propertySheet;
 	Button *_okButton;
 	Button *_cancelButton;

--- a/mp/src/vgui2/vgui_controls/PropertyDialog.cpp
+++ b/mp/src/vgui2/vgui_controls/PropertyDialog.cpp
@@ -33,7 +33,6 @@ PropertyDialog::PropertyDialog(Panel *parent, const char *panelName) : Frame(par
     _okButton->SetAutoWide(true);
     _okButton->SetAutoTall(true);
     _okButton->SetContentAlignment(Label::a_center);
-    _okButton->SetPos(5, 0);
     _okButton->SetTextInset(10, 0);
 	GetFocusNavGroup().SetDefaultButton(_okButton);
 
@@ -42,7 +41,6 @@ PropertyDialog::PropertyDialog(Panel *parent, const char *panelName) : Frame(par
     _cancelButton->SetAutoWide(true);
     _cancelButton->SetAutoTall(true);
     _cancelButton->SetContentAlignment(Label::a_center);
-    _cancelButton->SetPos(5, 0);
     _cancelButton->SetTextInset(10, 0);
 
 	_applyButton = new Button(this, "ApplyButton", "#PropertyDialog_Apply", this, "Apply");
@@ -51,13 +49,8 @@ PropertyDialog::PropertyDialog(Panel *parent, const char *panelName) : Frame(par
     _applyButton->SetEnabled(false);        // default to not enabled
     _applyButton->SetAutoWide(true);
     _applyButton->SetAutoTall(true);
-    _applyButton->SetPos(0, 5);
     _applyButton->SetTextInset(10, 0);
     _applyButton->SetContentAlignment(Label::a_center);
-
-    _applyButton->PinToSibling("Sheet", PIN_TOPRIGHT, PIN_BOTTOMRIGHT);
-    _cancelButton->PinToSibling("ApplyButton", PIN_TOPRIGHT, PIN_TOPLEFT);
-    _okButton->PinToSibling("CancelButton", PIN_TOPRIGHT, PIN_TOPLEFT);
 
 	SetSizeable(false);
 }
@@ -117,6 +110,8 @@ void PropertyDialog::ApplyChanges()
 void PropertyDialog::PerformLayout()
 {
 	BaseClass::PerformLayout();
+
+    UpdateButtonPositions();
 
 	int iBottom = m_iSheetInsetBottom;
 	if ( IsProportional() )
@@ -309,6 +304,54 @@ void PropertyDialog::ApplySchemeSettings(IScheme* pScheme)
             _okButton->SetFont(font);
             _applyButton->SetFont(font);
             _cancelButton->SetFont(font);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Updates pinning & positions of OK/Cancel/Apply buttons based on their visibility
+//-----------------------------------------------------------------------------
+void PropertyDialog::UpdateButtonPositions()
+{
+    if (_applyButton->IsVisible())
+    {
+        _applyButton->PinToSibling("Sheet", PIN_TOPRIGHT, PIN_BOTTOMRIGHT);
+        _applyButton->SetPos(0, 5);
+    }
+
+    if (_cancelButton->IsVisible())
+    {
+        if (!_applyButton->IsVisible())
+        {
+            _cancelButton->PinToSibling("Sheet", PIN_TOPRIGHT, PIN_BOTTOMRIGHT);
+            _cancelButton->SetPos(0, 5);
+        }
+        else
+        {
+            _cancelButton->PinToSibling("ApplyButton", PIN_TOPRIGHT, PIN_TOPLEFT);
+            _cancelButton->SetPos(5, 0);
+        }
+    }
+
+    if (_okButton->IsVisible())
+    {
+        if (_cancelButton->IsVisible())
+        {
+            _okButton->PinToSibling("CancelButton", PIN_TOPRIGHT, PIN_TOPLEFT);
+            _okButton->SetPos(5, 0);
+        }
+        else
+        {
+            if (_applyButton->IsVisible())
+            {
+                _okButton->PinToSibling("ApplyButton", PIN_TOPRIGHT, PIN_TOPLEFT);
+                _okButton->SetPos(5, 0);
+            }
+            else
+            {
+                _okButton->PinToSibling("Sheet", PIN_TOPRIGHT, PIN_BOTTOMRIGHT);
+                _okButton->SetPos(0, 5);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #708 

- Changed the GameUIs property dialog to only have OK button which writes the player's config to file. This button does not close the dialog and has its text set to "write settings to config file".
- Removed unneeded apply button code. (`ApplyButtonEnable` action signals & `OnApplyChanges()` overrides).
- Added code to the `PropertyDialog` class that dynamically changes the position of the OK/Cancel/Apply buttons based on which are visible.
    - Before, setting the cancel button to be not visible created a gap between the OK/Apply buttons. Since the cancel/apply buttons were set to not visible on the options dialog, the OK button was near the middle of the panel and not aligned.

May not be 100% useful given the options dialog stuff is gunna be thrown into the momentum settings dialog soon.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review