### PR TITLE
Prevent give_weapon command in credits & main menu

### DIFF
--- a/mp/src/game/server/client.cpp
+++ b/mp/src/game/server/client.cpp
@@ -906,6 +906,12 @@ CON_COMMAND_F_COMPLETION(give_weapon, "Gives the player a weapon.", 0, WeaponCom
 			return;
 		}
 
+        if (FStrEq(STRING(gpGlobals->mapname), "credits") || gpGlobals->eLoadType == MapLoad_Background)
+        {
+            Warning("Cannot give weapons in this map!");
+            return;
+        }
+
 		pPlayer->GiveWeapon(foundID);
 	}
 }


### PR DESCRIPTION
Closes #760

Simple catch that prevents users from giving themselves weapons in the main menu/credits.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review