### PR TITLE
Add Linux to GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,10 +39,35 @@ jobs:
     - name: Upload bin artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: bin_${{ env.short_commit_sha }}
+        name: bin_${{ runner.os }}-${{ env.short_commit_sha }}
         path: artifacts\bin
     - name: Upload pdb artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: pdb_${{ env.short_commit_sha }}
+        name: pdb_${{ runner.os }}-${{ env.short_commit_sha }}
         path: artifacts\pdb
+
+  build-linux:
+    runs-on: ubuntu-latest
+    container: gocnak/steam-runtime-i386:momentum
+    env:
+      USING_DOCKER: true
+    steps:
+      - uses: actions/checkout@v1
+      - name: Creating game project files
+        working-directory: mp/src
+        run: ./creategameprojects
+      - name: Building the game
+        working-directory: mp/src
+        run: make -j$(nproc --all) -f games.mak
+      - name: Prepare artifacts
+        shell: bash
+        run: |
+          mkdir -v artifacts
+          shopt -s extglob
+          mv -v mp/game/bin/!(*.dbg) mp/game/momentum/bin/!(*.dbg|*.dll) artifacts
+          echo "::set-env name=short_commit_sha::$(git rev-parse --short HEAD)"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: bin_${{ runner.os }}-${{ env.short_commit_sha }}
+          path: artifacts


### PR DESCRIPTION
Can't use checkout/upload-artifact v2: https://github.com/Margen67/game/runs/687711323
This might be because the Docker image doesn't have node/git(?)

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review