### PR TITLE
Allow toolsnpcclip or %compileNonSolid buttons to be +used

### DIFF
--- a/mp/src/game/shared/baseplayer_shared.cpp
+++ b/mp/src/game/shared/baseplayer_shared.cpp
@@ -945,7 +945,7 @@ CBaseEntity *CBasePlayer::FindUseEntity()
 
     // Some debris objects are +usable, and clip brushes can be made into
     // +usable entities.
-    int usableContents = MASK_SOLID | CONTENTS_DEBRIS | CONTENTS_PLAYERCLIP;
+    int usableContents = MASK_SOLID | CONTENTS_DEBRIS | CONTENTS_PLAYERCLIP | CONTENTS_OPAQUE | CONTENTS_MONSTERCLIP;
 
     // However, we occasionally need to ignore clip brushes so that objects
     // inside of or beyond them can be +used.


### PR DESCRIPTION
<!-- Describe what your pull request is doing here -->

In CS:S, maps can have buttons textured with `tools/toolsnpcclip` or a material with `%compileNonSolid 1` so the players don't collide with them but can still +use. This PR adds the necessary flags for such buttons to function in momentum as well.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->