### PR TITLE
Method to get currently shown item in combobox

### DIFF
--- a/mp/src/public/vgui_controls/ComboBox.h
+++ b/mp/src/public/vgui_controls/ComboBox.h
@@ -101,6 +101,7 @@ public:
 	void SilentActivateItemByRow(int row);	// Sets the menu to the appropriate row without sending a TextChanged message
 
 	int GetActiveItem();
+    int GetCurrentItem();
 	KeyValues *GetActiveItemUserData();
 	KeyValues *GetItemUserData(int itemID);
 	void GetItemText( int itemID, OUT_Z_BYTECAP(bufLenInBytes) wchar_t *text, int bufLenInBytes );

--- a/mp/src/vgui2/vgui_controls/ComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/ComboBox.cpp
@@ -376,6 +376,16 @@ int ComboBox::GetActiveItem()
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: return the index of the current item. Returns the highlighted item unless
+// no item is highlighted, in which case returns the active item.
+//-----------------------------------------------------------------------------
+int ComboBox::GetCurrentItem()
+{
+    int iHLItem = m_pDropDown->GetCurrentlyHighlightedItem();
+    return iHLItem >= 0 ? iHLItem : m_pDropDown->GetActiveItem();
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 KeyValues *ComboBox::GetActiveItemUserData()


### PR DESCRIPTION
Comboboxes can get into a state where the value shown in their TextEntry is not the active item (when using up/down keys mainly). This is because the item isn't active but it is highlighted. 

This method gets the current item shown in the TextEntry by returning the currently highlighted item unless no item is highlighted, in which case it returns the active item.

Tested this with comboboxes in the advanced video settings. Changing say vsync to enabled through just arrow keys, then pressing OK. With `GetActiveItem()`, `mat_vsync` is still 0, but with `GetCurrentItem()`, it is 1.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review