### PR TITLE
Prevented escape key from clearing comboboxes

### DIFF
--- a/mp/src/vgui2/vgui_controls/ComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/ComboBox.cpp
@@ -842,7 +842,10 @@ void ComboBox::OnKeyCodeTyped(KeyCode code)
 //-----------------------------------------------------------------------------
 void ComboBox::OnKeyTyped(wchar_t unichar)
 {
-	if ( IsEditable() || unichar == '\t') // don't play with key presses in edit mode
+    // don't play with key presses in edit mode
+    // x1b = escape key. This is needed as escape conflicts with hiding settings in game
+    // (combobox was being reset to first item when settings are hidden)
+	if ( IsEditable() || unichar == '\t' || unichar == '\x1b') 
 	{
 		BaseClass::OnKeyTyped( unichar );
 		return;


### PR DESCRIPTION
While in a map with settings open, pressing escape while a combobox is selected resets it back to the first item. This is because it calls `SelectMenuItem` with a negative value here. Escape should be used to toggle the main menu/settings and the game, not on comboboxes.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review