### PR TITLE
SilentSetSelected method for CheckButtons

### DIFF
--- a/mp/src/public/vgui_controls/CheckButton.h
+++ b/mp/src/public/vgui_controls/CheckButton.h
@@ -65,7 +65,8 @@ public:
 	~CheckButton();
 
 	// Check the button
-	virtual void SetSelected(bool state );
+    virtual void SetSelected(bool state);
+    virtual void SilentSetSelected(bool state);
 
 	// sets whether or not the state of the check can be changed
 	// if this is set to false, then no input in the code or by the user can change it's state
@@ -95,6 +96,8 @@ protected:
 
 
 private:
+    void SetSelected(bool state, bool bPostActionSignal);
+
 	int m_iCheckInset;
 	bool m_bCheckButtonCheckable;
 	CheckImage *_checkBoxImage;

--- a/mp/src/vgui2/vgui_controls/CheckButton.cpp
+++ b/mp/src/vgui2/vgui_controls/CheckButton.cpp
@@ -137,15 +137,34 @@ IBorder *CheckButton::GetBorder(bool depressed, bool armed, bool selected, bool 
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: Check the button
+// Purpose: Checks the button
 //-----------------------------------------------------------------------------
-void CheckButton::SetSelected(bool state )
+void CheckButton::SetSelected(bool state)
+{
+    SetSelected(state, true);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Checks the button without posting an action signal
+//-----------------------------------------------------------------------------
+void CheckButton::SilentSetSelected(bool state)
+{
+    SetSelected(state, false);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Checks the button & fires an action signal if bPostActionSignal is true
+//-----------------------------------------------------------------------------
+void CheckButton::SetSelected(bool state, bool bPostActionSignal)
 {
 	if (m_bCheckButtonCheckable)
 	{
-		// send a message saying we've been checked
-		KeyValues *msg = new KeyValues("CheckButtonChecked", "state", (int)state);
-		PostActionSignal(msg);
+        if (bPostActionSignal)
+        {
+            // send a message saying we've been checked
+            KeyValues *msg = new KeyValues("CheckButtonChecked", "state", (int)state);
+            PostActionSignal(msg);
+        }
 		
 		BaseClass::SetSelected(state);
 	}


### PR DESCRIPTION
Another useful VGUI function.

`SilentSetSelected` sets the `CheckButton` selection state without posting an action signal, akin to the `SilentActivateItem` function for `ComboBox`'s. 

Useful for loading settings from file (can differentiate between user clicking check and settings load). To do this currently you need to surround with `SetSilentMode` calls.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review