### PR TITLE
Fixed momentum.fgd crashing hammer

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -171,7 +171,7 @@
         131072: "Prevent the player from jumping" : 0
         262144: "Prevent the player from crouching" : 0
         524288: "Prevent the player from bhopping" : 0
-        1048576‬: "Prevent the player from walking" : 0
+        1048576: "Prevent the player from walking" : 0
         2097152: "Prevent the player from sprinting" : 0
     ]
 ]


### PR DESCRIPTION
Closes #781 

Removing the walking/sprinting spawnflags on `trigger_momentum_limitmovement` fixed the crash, but we still want these added of course.

I fixed this by skipping 2^20 on those spawnflags and it magically worked. I do not know why this was happening nor how this fixed it.

They appear in hammer fine:
![image](https://user-images.githubusercontent.com/9014762/82765432-e12d8480-9dcb-11ea-838f-beb88344d8ac.png)

Also they work in game:
https://cdn.discordapp.com/attachments/549657950201970688/714230454110388274/2020-05-24_14-23-11.mp4

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review