### PR TITLE
Prevent teleport when holding jump in practice mode

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -852,7 +852,13 @@ void CMomentumPlayer::CheckChatText(char *p, int bufsize) { g_pMomentumGhostClie
 // Overrides Teleport() so we can take care of the trail
 void CMomentumPlayer::Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
 {
-    if (!m_bAllowUserTeleports || (m_Data.m_bMapFinished && !m_cvarMapFinMoveEnable.GetBool()))
+    if (!m_bAllowUserTeleports)
+        return;
+
+    if (m_Data.m_bMapFinished && !m_cvarMapFinMoveEnable.GetBool())
+        return;
+
+    if (m_bHasPracticeMode && (m_nButtons & IN_JUMP))
         return;
 
     // No need to remove the trail here, CreateTrail() already does it for us


### PR DESCRIPTION
Closes #775 

Small change that early returns the `Teleport` function in `mom_player.cpp` when practice mode is enabled & jump is held.

Can easily lock this behind a cvar if people want that.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review