### PR TITLE
Fixed large time comparison on map finished panel

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -103,7 +103,6 @@ void CHudMapFinishedDialog::FireGameEvent(IGameEvent* pEvent)
         m_bCanClose = true;
 
         SetRunSaved(pEvent->GetBool("save") && IsVisible());
-        SetCurrentPage(m_iCurrentPage);
         // MOM_TODO: There's a file name parameter as well, do we want to use it here?
     }
     else if (FStrEq(pEvent->GetName(), "run_submit"))

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -514,9 +514,9 @@ void CHudMapFinishedDialog::SetComparisonForPage(int iPage)
         return;
     }
 
-    int runTicks = iPage == 0 ? m_pRunData->m_iRunTime : m_pRunStats->GetZoneTicks(iPage);
+    int runTicks = iPage == 0 ? m_pRunData->m_iRunTime : static_cast<int>(m_pRunStats->GetZoneTicks(iPage));
 
-    float diff = float(runTicks - m_pPbRunStats.GetZoneTicks(iPage)) * m_pRunData->m_flTickRate;
+    float diff = static_cast<float>(runTicks - static_cast<int>(m_pPbRunStats.GetZoneTicks(iPage))) * m_pRunData->m_flTickRate;
 
     char diffString[BUFSIZETIME];
     Color diffColor;


### PR DESCRIPTION
Closes #780 

The value returned by `GetZoneTicks` is unsigned, and so sometimes wraps around to its upper bound, causing `diff` to be a very large number. Static casted these to signed ints to prevent that.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review