### PR TITLE
Disable library/favorites header sorting inside Map Selector

### DIFF
--- a/mp/src/game/client/momentum/ui/MapSelection/BaseMapsPage.cpp
+++ b/mp/src/game/client/momentum/ui/MapSelection/BaseMapsPage.cpp
@@ -156,6 +156,8 @@ CBaseMapsPage::CBaseMapsPage(vgui::Panel *parent, const char *name) : PropertyPa
     m_pMapList->SetColumnTextAlignment(HEADER_BEST_TIME, Label::a_center);
 
     // Sort Functions
+    m_pMapList->SetColumnSortable(HEADER_MAP_IN_LIBRARY, false);
+    m_pMapList->SetColumnSortable(HEADER_MAP_IN_FAVORITES, false);
     m_pMapList->SetSortFunc(HEADER_MAP_NAME, MapNameSortFunc);
     m_pMapList->SetSortFunc(HEADER_WORLD_RECORD, MapWorldRecordSortFunc);
     m_pMapList->SetSortFunc(HEADER_BEST_TIME, MapPersonalBestSortFunc);


### PR DESCRIPTION
Closes #774 

In the map selector, the library and favorites tabs were able to be clicked on to sort, and defaulted to sorting by the name of the map. This should be disabled because there's already the library and favorites tabs to sort by anyways.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->