### PR TITLE
Actually default to the original tonemapping algorithm

### DIFF
--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -829,8 +829,8 @@ void CLuminanceHistogramSystem::UpdateLuminanceRanges( void )
 		s_bFirstTime = false;
 
 		// This seems like a bad idea but it's fine for now
-		const char *sModsForOriginalAlgorithm[] = { "dod", "cstrike", "lostcoast", "hl1" };
-		for ( int i=0; i<3; i++ )
+		const char *sModsForOriginalAlgorithm[] = { "dod", "cstrike", "lostcoast", "hl1", "momentum" };
+		for ( int i=0; i<5; i++ )
 		{
 			if ( strlen( engine->GetGameDirectory() ) >= strlen( sModsForOriginalAlgorithm[i] ) )
 			{


### PR DESCRIPTION
As mat_tonemap_algorithm is also defined in materialsystem with 1 as default, we have to resort to using Valve's "bad idea for now".

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->