### PR TITLE
Fixed map finished panel not being closable when replay file can't be written

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -80,6 +80,7 @@ CHudMapFinishedDialog::CHudMapFinishedDialog(const char *pElementName) : CHudEle
     m_pPrevZoneButton->InstallMouseHandler(this);
     m_pPlayReplayButton->SetMouseInputEnabled(true);
     m_pPlayReplayButton->InstallMouseHandler(this);
+    m_pPlayReplayButton->SetEnabled(false); // enabled upon replay save event
     m_pRepeatButton->SetMouseInputEnabled(true);
     m_pRepeatButton->InstallMouseHandler(this);
     m_pClosePanelButton->SetMouseInputEnabled(true);
@@ -223,6 +224,7 @@ void CHudMapFinishedDialog::SetRunSaved(bool bState)
 {
     m_pRunSaveStatus->SetText(bState ? "#MOM_MF_RunSaved" : "#MOM_MF_RunNotSaved");
     m_pRunSaveStatus->SetFgColor(bState ? COLOR_GREEN : COLOR_RED);
+    m_pPlayReplayButton->SetEnabled(bState);
 }
 
 void CHudMapFinishedDialog::SetRunUploaded(bool bState)
@@ -291,7 +293,7 @@ void CHudMapFinishedDialog::OnMousePressed(MouseCode code)
     if (code == MOUSE_LEFT)
     {
         const auto panelOver = input()->GetMouseOver();
-        if (panelOver == m_pPlayReplayButton->GetVPanel())
+        if (panelOver == m_pPlayReplayButton->GetVPanel() && m_pPlayReplayButton->IsEnabled())
         {
             engine->ClientCmd_Unrestricted("mom_replay_play_loaded\n");
             ClosePanel();
@@ -345,6 +347,7 @@ void CHudMapFinishedDialog::Reset()
     SetRunSaved(false);
     SetRunUploaded(false);
     m_bCanClose = false;
+    m_pPlayReplayButton->SetEnabled(false);
     SetAlpha(255);
 
     // --- cache localization tokens ---

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -157,7 +157,9 @@ void CMomentumReplaySystem::FinishRecording()
 
     if (bStoredReplay)
     {
-        Log("Recording Stopped! Ticks: %i\n", m_pRecordingReplay->GetFrameCount());
+        char szRuntime[BUFSIZETIME];
+        MomUtil::FormatTime(m_pRecordingReplay->GetRunTime(), szRuntime);
+        Log("Recording Stopped! Ticks: %i | Time: %s\n", m_pRecordingReplay->GetFrameCount(), szRuntime);
         UnloadPlayback();
         m_pPlaybackReplay = m_pRecordingReplay;
         LoadReplayGhost();

--- a/mp/src/game/server/momentum/mom_replay_system.cpp
+++ b/mp/src/game/server/momentum/mom_replay_system.cpp
@@ -144,20 +144,20 @@ void CMomentumReplaySystem::FinishRecording()
     SetReplayHeaderAndStats();
 
     char newRecordingPath[MAX_PATH];
-    if (StoreReplay(newRecordingPath, MAX_PATH))
+    bool bStoredReplay = StoreReplay(newRecordingPath, MAX_PATH);
+
+    const auto pReplaySavedEvent = gameeventmanager->CreateEvent("replay_save");
+    if (pReplaySavedEvent)
+    {
+        pReplaySavedEvent->SetBool("save", bStoredReplay);
+        pReplaySavedEvent->SetString("filepath", newRecordingPath);
+        pReplaySavedEvent->SetInt("time", static_cast<int>(m_pRecordingReplay->GetRunTime() * 1000.0f));
+        gameeventmanager->FireEvent(pReplaySavedEvent);
+    }
+
+    if (bStoredReplay)
     {
         Log("Recording Stopped! Ticks: %i\n", m_pRecordingReplay->GetFrameCount());
-
-        const auto pReplaySavedEvent = gameeventmanager->CreateEvent("replay_save");
-        if (pReplaySavedEvent)
-        {
-            pReplaySavedEvent->SetBool("save", true);
-            // replaySavedEvent->SetString("filename", newRecordingName);
-            pReplaySavedEvent->SetString("filepath", newRecordingPath);
-            pReplaySavedEvent->SetInt("time", static_cast<int>(m_pRecordingReplay->GetRunTime() * 1000.0f));
-            gameeventmanager->FireEvent(pReplaySavedEvent);
-        }
-
         UnloadPlayback();
         m_pPlaybackReplay = m_pRecordingReplay;
         LoadReplayGhost();


### PR DESCRIPTION
Closes #793 - Added the issue to the 0.8.5 release as well since it's hud related. Apologies if I shouldn't have done this.

Fixed this issue by fixing up some relevant code.

The `replay_save` event was not fired when the replay file was unable to be written to, despite it having a boolean `save` field that specifies whether it succeeded or not. This means every time `replay_save` is fired it's `save` field is `true`.
Every catching of this event checks whether `save` is `true`:
- `mom_run_poster.cpp`
- `hud_comparisons.cpp`
- `hud_mapfinished.cpp`
- `ClientTimesDisplay.cpp`

So having it fire regardless of whether saving succeeded has no repercussions.

Made the replay save button on the map finished panel disabled until the `replay_save` event is fired with a `save` field of `true`. Without this, clicking the play replay button when the replay fails to save prevents the panel from closing. This shouldn't be clickable anyways until the replay is saved.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review