### PR TITLE
Prevent stage enter speed from displaying on stage re-enter on linear maps

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.h
@@ -34,6 +34,8 @@ class CHudSpeedMeter : public CHudElement, public vgui::EditablePanel
     void ResetLabelOrder();
 
   private:
+    int m_iLastZone;
+
     SpeedometerLabel *m_pAbsSpeedoLabel, *m_pHorizSpeedoLabel, *m_pLastJumpVelLabel, *m_pStageEnterExitVelLabel;
 
     SpeedoLabelList m_LabelOrderList;


### PR DESCRIPTION
Stage enter speed displays when re-entering a stage we've already been in. This causes failing an rj or sj jump to display `0` or some low number as the enter speed.

This change stops stage enter speed from displaying when entering stages the player has already gone through. This change is only for linear maps, since staged ones display the speed on stage exit instead of enter, and those should display every time. 

Mainly only applies to jump gamemodes, assuming that re-entering a stage (checkpoint) on a linear surf map isn't really done.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review