### PR TITLE
Fix flashlight rendering

### DIFF
--- a/mp/src/game/client/clientshadowmgr.cpp
+++ b/mp/src/game/client/clientshadowmgr.cpp
@@ -933,9 +933,6 @@ private:
 	// Builds a list of active shadows requiring shadow depth renders
 	int		BuildActiveShadowDepthList( const CViewSetup &viewSetup, int nMaxDepthShadows, ClientShadowHandle_t *pActiveDepthShadows );
 
-	// Sets the view's active flashlight render state
-	void	SetViewFlashlightState( int nActiveFlashlightCount, ClientShadowHandle_t* pActiveFlashlights );
-
     //Dynamic RTT shadow angles
     void	UpdateDirtyShadow(ClientShadowHandle_t handle);
     void	UpdateShadowDirectionFromLocalLightSource(ClientShadowHandle_t shadowHandle);
@@ -3873,25 +3870,6 @@ int CClientShadowMgr::BuildActiveShadowDepthList( const CViewSetup &viewSetup, i
 	return nActiveDepthShadowCount;
 }
 
-
-//-----------------------------------------------------------------------------
-// Sets the view's active flashlight render state
-//-----------------------------------------------------------------------------
-void CClientShadowMgr::SetViewFlashlightState( int nActiveFlashlightCount, ClientShadowHandle_t* pActiveFlashlights )
-{
-	Assert( nActiveFlashlightCount<= 1 ); 
-	if ( nActiveFlashlightCount > 0 )
-	{
-		Assert( ( m_Shadows[ pActiveFlashlights[0] ].m_Flags & SHADOW_FLAGS_FLASHLIGHT ) != 0 );
-		shadowmgr->SetFlashlightRenderState( pActiveFlashlights[0] );
-	}
-	else
-	{
-		shadowmgr->SetFlashlightRenderState( SHADOW_HANDLE_INVALID );
-	}
-}
-
-
 //-----------------------------------------------------------------------------
 // Re-render shadow depth textures that lie in the leaf list
 //-----------------------------------------------------------------------------
@@ -3962,8 +3940,6 @@ void CClientShadowMgr::ComputeShadowDepthTextures( const CViewSetup &viewSetup )
 		// Associate the shadow depth texture and stencil bit with the flashlight for use during scene rendering
 		shadowmgr->SetFlashlightDepthTexture( shadow.m_ShadowHandle, shadowDepthTexture, 0 );
 	}
-
-	SetViewFlashlightState( nActiveDepthShadowCount, pActiveDepthShadows );
 }
 
 	
@@ -4113,7 +4089,6 @@ void CClientShadowMgr::UnlockAllShadowDepthTextures()
 	{
 		m_DepthTextureCacheLocks[i] = false;
 	}
-	SetViewFlashlightState( 0, NULL );
 }
 
 void CClientShadowMgr::SetFlashlightTarget( ClientShadowHandle_t shadowHandle, EHANDLE targetEntity )


### PR DESCRIPTION
Regression from 59ff4cd (sorry)

r_flashlight_version2 assumed single pass flashlight rendering. Some of the code that got removed in 59ff4cd was an early-exit for non-single pass flashlight rendering, which changed the behaviour of that function.

In this PR I removed the function entirely since it's exclusively used for single pass flashlight rendering.

### Checklist
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->