### PR TITLE
Fix for map change related crash

### DIFF
--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -449,7 +449,8 @@ bool CMomentumLobbySystem::IsInSameMapAs(const CSteamID &other)
     const char *pMapName = gpGlobals->mapname.ToCStr();
     const char *pOtherMap = SteamMatchmaking()->GetLobbyMemberData(m_sLobbyID, other, LOBBY_DATA_MAP);
 
-    return pMapName && pMapName[0] && gpGlobals->eLoadType != MapLoad_Background && !FStrEq(pMapName, "credits") && FStrEq(pMapName, pOtherMap);
+    return pMapName && pMapName[0] && pOtherMap && gpGlobals->eLoadType != MapLoad_Background && 
+           !FStrEq(pMapName, "credits") && FStrEq(pMapName, pOtherMap);
 }
 
 bool CMomentumLobbySystem::IsInLobby(const CSteamID &other)


### PR DESCRIPTION
As reported by @xen-000 , `pOtherMap` was able to be null here which has caused at least one crash. This fix just catches the case where it is null.

Not sure if this is being solved elsewhere. If so, can just close this.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review