### PR TITLE
Stopped sticky charge sound on weapon switch

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -90,6 +90,7 @@ void CMomentumStickybombLauncher::Precache()
 bool CMomentumStickybombLauncher::Holster(CBaseCombatWeapon *pSwitchingTo)
 {
     m_flChargeBeginTime = 0;
+    StopWeaponSound(GetWeaponSound("charge"));
 
     return BaseClass::Holster(pSwitchingTo);
 }


### PR DESCRIPTION
Issue reported by cowboyana: "In SJ, swapping weapon while charging will cause the charge sound effect to continue to play for its full duration, and every time you shoot the whole charge sound will restart and play again until you wait for it to fully end"

Fixed by just stopping the charge sound when holstering.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review