### PR TITLE
Fix player getting stuck when closing settings panel

### DIFF
--- a/mp/src/vgui2/vgui_controls/Menu.cpp
+++ b/mp/src/vgui2/vgui_controls/Menu.cpp
@@ -1268,6 +1268,7 @@ void Menu::OnKeyCodeTyped(KeyCode keycode)
 		{
 			// hide the menu on ESC
 			SetVisible(false);
+            BaseClass::OnKeyCodeTyped(keycode);
 			break;
 		}
 		// arrow keys scroll through items on the list.


### PR DESCRIPTION
Closes #850 

This seemed to happen only when a combobox had a menu open while the player hit escape to close the settings. The menu on the comboboxes eat escape key input, causing the `OnClose()` for the settings panel to not execute. Added a baseclass call there to prevent it from eating input.

Tested this with the other panels (zone menu & map selector) and they act the same with or without the change.

Also added the prevent/allow escape to show on the settings panel as I figure it should be there, though it change doesn't change anything. Without the menu input fix, it softlocks the game (cannot press escape to show menu nor move nor open console). Can drop that commit if we don't really need.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review