### PR TITLE
Enable Unicode for all Chat input

### DIFF
--- a/mp/game/momentum/resource/ui/BaseChat.res
+++ b/mp/game/momentum/resource/ui/BaseChat.res
@@ -12,6 +12,7 @@
 		"tall"	 		"210"
         "BgColor_Override" "MomGreydientStep3"
         "HistoryAlpha" "255"
+        "unicode"   "1"
 	}
 
 	"HudChatHistory"
@@ -31,6 +32,7 @@
 		"font"			"Default12"
 		"maxchars"		"-1"
         "BgColor_Override" "MomGreydientStep4"
+        "unicode"   "1"
 	}
 
     "ChatInputLine"
@@ -51,6 +53,7 @@
         "pin_to_sibling" "HudChatHistory"
 		"pin_corner_to_sibling"		"0"
 		"pin_to_sibling_corner"		"2"
+        "unicode"   "1"
     }
 
     "ChatFiltersButton"
@@ -76,6 +79,7 @@
         "pin_to_sibling" "ChatInputLine"
 		"pin_corner_to_sibling"		"1"
 		"pin_to_sibling_corner"		"3"
+        "unicode"   "1"
     }
 
     "TypingMembers"
@@ -92,5 +96,6 @@
         "paintbackground" "0"
         "font" "Default10"
         "fgcolor_override" "OffWhite"
+        "unicode"   "1"
     }
 }


### PR DESCRIPTION
Closes #851 

Enables unicode support in all Chat fields. This should be unrelated to localization files.

Initial reproduction - https://streamable.com/zaqrxr

Testing fix - https://streamable.com/fdfz05