### PR TITLE
Fix Duck Reset Camera Bug

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_mapinfo.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapinfo.cpp
@@ -69,6 +69,7 @@ C_HudMapInfo::C_HudMapInfo(const char *pElementName): CHudElement(pElementName),
     ListenForGameEvent("spec_stop");
     ListenForGameEvent("player_spawn");
     ListenForGameEvent("mapfinished_panel_closed");
+    ListenForGameEvent( "saveloc_upd8" );
 
     m_pMainStatusLabel = new Label(this, "MainStatusLabel", "");
     m_pMapNameLabel = new Label(this, "MapNameLabel", "");

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -527,7 +527,7 @@ void CMomentumLobbySystem::OnLobbyMemberLeave(const CSteamID &member)
     const auto lobbyMemberID = member.ConvertToUint64();
 
     // Remove them if they're a requester
-    g_pMOMSavelocSystem->RequesterLeft(lobbyMemberID);
+    g_pSavelocSystem->RequesterLeft(lobbyMemberID);
 
     const auto findIndex = m_mapLobbyGhosts.Find(lobbyMemberID);
 
@@ -800,12 +800,12 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                 {
                 case SAVELOC_REQ_STAGE_COUNT_REQ:
                     {
-                        if (!g_pMOMSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64()))
+                        if (!g_pSavelocSystem->AddSavelocRequester(fromWho.ConvertToUint64()))
                             break;
 
                         SavelocReqPacket response;
                         response.stage = SAVELOC_REQ_STAGE_COUNT_ACK;
-                        response.saveloc_count = g_pMOMSavelocSystem->GetSavelocCount();
+                        response.saveloc_count = g_pSavelocSystem->GetSavelocCount();
 
                         SendPacket(&response, fromWho, k_EP2PSendReliable);
                     }
@@ -823,13 +823,13 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                         SavelocReqPacket response;
                         response.stage = SAVELOC_REQ_STAGE_SAVELOC_ACK;
 
-                        if (g_pMOMSavelocSystem->WriteRequestedSavelocs(&saveloc, &response, fromWho.ConvertToUint64()))
+                        if (g_pSavelocSystem->WriteRequestedSavelocs(&saveloc, &response, fromWho.ConvertToUint64()))
                             SendPacket(&response, fromWho, k_EP2PSendReliable);
                     }
                     break;
                 case SAVELOC_REQ_STAGE_SAVELOC_ACK:
                     {
-                        if (g_pMOMSavelocSystem->ReadReceivedSavelocs(&saveloc, fromWho.ConvertToUint64()))
+                        if (g_pSavelocSystem->ReadReceivedSavelocs(&saveloc, fromWho.ConvertToUint64()))
                         {
                             SavelocReqPacket response;
                             response.stage = SAVELOC_REQ_STAGE_DONE;
@@ -844,7 +844,7 @@ void CMomentumLobbySystem::SendAndReceiveP2PPackets()
                     break;
                 case SAVELOC_REQ_STAGE_DONE:
                     {
-                        g_pMOMSavelocSystem->RequesterLeft(fromWho.ConvertToUint64());
+                        g_pSavelocSystem->RequesterLeft(fromWho.ConvertToUint64());
                     }
                     break;
                 case SAVELOC_REQ_STAGE_INVALID:

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -747,10 +747,9 @@ void CMomentumPlayer::CreateStartMark()
     {
         ClearStartMark(m_Data.m_iCurrentTrack);
 
-        m_pStartZoneMarks[m_Data.m_iCurrentTrack] = g_pMOMSavelocSystem->CreateSaveloc();
+        m_pStartZoneMarks[m_Data.m_iCurrentTrack] = g_pSavelocSystem->CreateSaveloc(SAVELOC_POS | SAVELOC_ANG);
         if (m_pStartZoneMarks[m_Data.m_iCurrentTrack])
         {
-            m_pStartZoneMarks[m_Data.m_iCurrentTrack]->vel = vec3_origin; // Rid the velocity
             DevLog("Successfully created a starting mark!\n");
         }
         else

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1145,7 +1145,7 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
         }
         // g_pMomentumTimer->CalculateTickIntervalOffset(this, ZONE_TYPE_START, 1);
         g_pMomentumTimer->TryStart(this, true);
-        if (m_bShouldLimitPlayerSpeed && !m_bHasPracticeMode && !g_pMOMSavelocSystem->IsUsingSaveLocMenu())
+        if (m_bShouldLimitPlayerSpeed && !m_bHasPracticeMode && !g_pSavelocSystem->IsUsingSaveLocMenu())
         {
             const auto pStart = static_cast<CTriggerTimerStart*>(pTrigger);
 

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -19,6 +19,7 @@ MAKE_TOGGLE_CONVAR(mom_saveloc_save_between_sessions, "1", FCVAR_ARCHIVE, "Defin
 
 SavedLocation_t::SavedLocation_t() : m_bCrouched(false), m_vecPos(vec3_origin), m_vecVel(vec3_origin), m_qaAng(vec3_angle),
                                      m_fGravityScale(1.0f), m_fMovementLagScale(1.0f), m_iDisabledButtons(0), m_savedComponents(SAVELOC_NONE),
+                                     m_iZone(-1), m_iTrack(-1)
 {
     m_szTargetName[0] = '\0';
     m_szTargetClassName[0] = '\0';
@@ -55,6 +56,12 @@ SavedLocation_t::SavedLocation_t(CMomentumPlayer* pPlayer, int components /*= SA
     if ( components & SAVELOC_DISABLED_BTNS )
         m_iDisabledButtons = pPlayer->m_afButtonDisabled.Get();
 
+    if ( components & SAVELOC_TRACK )
+        m_iTrack = pPlayer->m_Data.m_iCurrentTrack;
+
+    if ( components & SAVELOC_ZONE )
+        m_iZone = pPlayer->m_Data.m_iCurrentZone;
+
     if ( components & SAVELOC_EVENT_QUEUE )
         g_EventQueue.SaveForTarget(pPlayer, entEventsState);
 }
@@ -90,6 +97,12 @@ void SavedLocation_t::Save(KeyValues* kvCP) const
     if ( m_savedComponents & SAVELOC_DISABLED_BTNS )
         kvCP->SetInt("disabledButtons", m_iDisabledButtons);
 
+    if ( m_savedComponents & SAVELOC_TRACK )
+        kvCP->SetInt( "track", m_iTrack );
+
+    if ( m_savedComponents & SAVELOC_ZONE )
+        kvCP->SetInt( "zone", m_iZone );
+
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         entEventsState.SaveToKeyValues(kvCP);
 }
@@ -106,6 +119,8 @@ void SavedLocation_t::Load(KeyValues* pKv)
     m_fGravityScale = pKv->GetFloat("gravityScale", 1.0f);
     m_fMovementLagScale = pKv->GetFloat("movementLagScale", 1.0f);
     m_iDisabledButtons = pKv->GetInt("disabledButtons");
+    m_iTrack = pKv->GetInt( "track", -1 );
+    m_iZone = pKv->GetInt( "zone", -1 );
     entEventsState.LoadFromKeyValues(pKv);
 }
 
@@ -141,6 +156,12 @@ void SavedLocation_t::Teleport(CMomentumPlayer* pPlayer)
 
     if ( m_savedComponents & SAVELOC_MOVEMENTLAG )
         pPlayer->SetLaggedMovementValue(m_fMovementLagScale);
+
+    if ( m_savedComponents & SAVELOC_TRACK && m_iTrack > -1 )
+        pPlayer->m_Data.m_iCurrentTrack = m_iTrack;
+
+    if ( m_savedComponents & SAVELOC_ZONE && m_iZone > -1 )
+        pPlayer->m_Data.m_iCurrentZone = m_iZone;
 
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         g_EventQueue.RestoreForTarget(pPlayer, entEventsState);

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -165,7 +165,7 @@ bool SavedLocation_t::Write(CUtlBuffer &mem)
     return write->WriteAsBinary(mem);
 }
 
-CMOMSaveLocSystem::CMOMSaveLocSystem(const char* pName): CAutoGameSystem(pName)
+CSaveLocSystem::CSaveLocSystem(const char* pName): CAutoGameSystem(pName)
 {
     m_pSavedLocsKV = new KeyValues(pName);
     m_iRequesting = 0;
@@ -173,19 +173,19 @@ CMOMSaveLocSystem::CMOMSaveLocSystem(const char* pName): CAutoGameSystem(pName)
     m_bUsingSavelocMenu = false;
 }
 
-CMOMSaveLocSystem::~CMOMSaveLocSystem()
+CSaveLocSystem::~CSaveLocSystem()
 {
     if (m_pSavedLocsKV)
         m_pSavedLocsKV->deleteThis();
     m_pSavedLocsKV = nullptr;
 }
 
-void CMOMSaveLocSystem::PostInit()
+void CSaveLocSystem::PostInit()
 {
-    g_pModuleComms->ListenForEvent("req_savelocs", UtlMakeDelegate(this, &CMOMSaveLocSystem::OnSavelocRequestEvent));
+    g_pModuleComms->ListenForEvent("req_savelocs", UtlMakeDelegate(this, &CSaveLocSystem::OnSavelocRequestEvent));
 }
 
-void CMOMSaveLocSystem::LevelInitPreEntity()
+void CSaveLocSystem::LevelInitPreEntity()
 {
     // We don't check mom_savelocs_save_between_sessions because we want to be able to load savelocs from friends
     DevLog("Loading savelocs from %s ...\n", SAVELOC_FILE_NAME);
@@ -229,7 +229,7 @@ void CMOMSaveLocSystem::LevelInitPreEntity()
     }
 }
 
-void CMOMSaveLocSystem::LevelShutdownPreEntity()
+void CSaveLocSystem::LevelShutdownPreEntity()
 {
     if (CMomentumPlayer::GetLocalPlayer() && m_pSavedLocsKV && mom_saveloc_save_between_sessions.GetBool())
     {
@@ -275,7 +275,7 @@ void CMOMSaveLocSystem::LevelShutdownPreEntity()
     RemoveAllSavelocs();
 }
 
-void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
+void CSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
 {
     int stage = pKv->GetInt("stage", SAVELOC_REQ_STAGE_INVALID);
     CSteamID target(pKv->GetUint64("target"));
@@ -310,7 +310,7 @@ void CMOMSaveLocSystem::OnSavelocRequestEvent(KeyValues* pKv)
     }
 }
 
-bool CMOMSaveLocSystem::AddSavelocRequester(const uint64& newReq)
+bool CSaveLocSystem::AddSavelocRequester(const uint64& newReq)
 {
     if (m_vecRequesters.HasElement(newReq))
         return false;
@@ -319,7 +319,7 @@ bool CMOMSaveLocSystem::AddSavelocRequester(const uint64& newReq)
     return true;
 }
 
-void CMOMSaveLocSystem::RequesterLeft(const uint64& requester)
+void CSaveLocSystem::RequesterLeft(const uint64& requester)
 {
     // The person we are requesting savelocs from just left
     if (requester == m_iRequesting)
@@ -336,7 +336,7 @@ void CMOMSaveLocSystem::RequesterLeft(const uint64& requester)
     m_vecRequesters.FindAndFastRemove(requester);
 }
 
-void CMOMSaveLocSystem::SetRequestingSavelocsFrom(const uint64& from)
+void CSaveLocSystem::SetRequestingSavelocsFrom(const uint64& from)
 {
     if (m_iRequesting && from != 0)
     {
@@ -347,7 +347,7 @@ void CMOMSaveLocSystem::SetRequestingSavelocsFrom(const uint64& from)
     m_iRequesting = from;
 }
 
-bool CMOMSaveLocSystem::WriteRequestedSavelocs(SavelocReqPacket *input, SavelocReqPacket *output, const uint64 &requester)
+bool CSaveLocSystem::WriteRequestedSavelocs(SavelocReqPacket *input, SavelocReqPacket *output, const uint64 &requester)
 {
     if (!m_vecRequesters.HasElement(requester))
         return false;
@@ -377,7 +377,7 @@ bool CMOMSaveLocSystem::WriteRequestedSavelocs(SavelocReqPacket *input, SavelocR
     return true;
 }
 
-bool CMOMSaveLocSystem::ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender)
+bool CSaveLocSystem::ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender)
 {
     if (sender != m_iRequesting)
         return false;
@@ -407,13 +407,13 @@ bool CMOMSaveLocSystem::ReadReceivedSavelocs(SavelocReqPacket *input, const uint
     return false;
 }
 
-SavedLocation_t* CMOMSaveLocSystem::CreateSaveloc(int components /*= SAVELOC_ALL*/)
+SavedLocation_t* CSaveLocSystem::CreateSaveloc(int components /*= SAVELOC_ALL*/)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
     return pPlayer ? new SavedLocation_t(pPlayer, components) : nullptr;
 }
 
-void CMOMSaveLocSystem::CreateAndSaveLocation()
+void CSaveLocSystem::CreateAndSaveLocation()
 {
     SavedLocation_t *created = CreateSaveloc();
     if (created)
@@ -424,7 +424,7 @@ void CMOMSaveLocSystem::CreateAndSaveLocation()
     }
 }
 
-void CMOMSaveLocSystem::AddSaveloc(SavedLocation_t* saveloc)
+void CSaveLocSystem::AddSaveloc(SavedLocation_t* saveloc)
 {
     if (!saveloc)
         return;
@@ -439,7 +439,7 @@ void CMOMSaveLocSystem::AddSaveloc(SavedLocation_t* saveloc)
     FireUpdateEvent();
 }
 
-void CMOMSaveLocSystem::RemoveCurrentSaveloc()
+void CSaveLocSystem::RemoveCurrentSaveloc()
 {
     if (m_rcSavelocs.IsEmpty())
         return;
@@ -455,7 +455,7 @@ void CMOMSaveLocSystem::RemoveCurrentSaveloc()
     UpdateRequesters();
 }
 
-void CMOMSaveLocSystem::RemoveAllSavelocs()
+void CSaveLocSystem::RemoveAllSavelocs()
 {
     m_rcSavelocs.PurgeAndDeleteElements();
     m_iCurrentSavelocIndx = -1;
@@ -464,7 +464,7 @@ void CMOMSaveLocSystem::RemoveAllSavelocs()
     UpdateRequesters();
 }
 
-void CMOMSaveLocSystem::GotoNextSaveloc()
+void CSaveLocSystem::GotoNextSaveloc()
 {
     auto count = GetSavelocCount();
     if (count > 0)
@@ -474,7 +474,7 @@ void CMOMSaveLocSystem::GotoNextSaveloc()
     }
 }
 
-void CMOMSaveLocSystem::GotoFirstSaveloc()
+void CSaveLocSystem::GotoFirstSaveloc()
 {
     if (!m_rcSavelocs.IsEmpty())
     {
@@ -483,7 +483,7 @@ void CMOMSaveLocSystem::GotoFirstSaveloc()
     }
 }
 
-void CMOMSaveLocSystem::GotoLastSaveloc()
+void CSaveLocSystem::GotoLastSaveloc()
 {
     auto count = GetSavelocCount();
     if (count > 0)
@@ -493,7 +493,7 @@ void CMOMSaveLocSystem::GotoLastSaveloc()
     }
 }
 
-void CMOMSaveLocSystem::GotoPrevSaveloc()
+void CSaveLocSystem::GotoPrevSaveloc()
 {
     auto count = GetSavelocCount();
     if (count > 0)
@@ -503,7 +503,7 @@ void CMOMSaveLocSystem::GotoPrevSaveloc()
     }
 }
 
-void CMOMSaveLocSystem::TeleportToSavelocIndex(int indx)
+void CSaveLocSystem::TeleportToSavelocIndex(int indx)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
     if (indx < 0 || indx > m_rcSavelocs.Count() || !pPlayer || !pPlayer->AllowUserTeleports())
@@ -513,7 +513,7 @@ void CMOMSaveLocSystem::TeleportToSavelocIndex(int indx)
     m_rcSavelocs[indx]->Teleport(pPlayer);
 }
 
-void CMOMSaveLocSystem::TeleportToCurrentSaveloc()
+void CSaveLocSystem::TeleportToCurrentSaveloc()
 {
     if (g_pRunSafeguards->IsSafeguarded(RUN_SAFEGUARD_SAVELOC_TELE))
         return; 
@@ -522,13 +522,13 @@ void CMOMSaveLocSystem::TeleportToCurrentSaveloc()
     FireUpdateEvent();
 }
 
-void CMOMSaveLocSystem::SetUsingSavelocMenu(bool bIsUsingSLMenu)
+void CSaveLocSystem::SetUsingSavelocMenu(bool bIsUsingSLMenu)
 {
     m_bUsingSavelocMenu = bIsUsingSLMenu;
     FireUpdateEvent();
 }
 
-void CMOMSaveLocSystem::CheckTimer()
+void CSaveLocSystem::CheckTimer()
 {
     if (g_pMomentumTimer->IsRunning())
     {
@@ -543,7 +543,7 @@ void CMOMSaveLocSystem::CheckTimer()
     m_bUsingSavelocMenu = true;
 }
 
-void CMOMSaveLocSystem::FireUpdateEvent() const
+void CSaveLocSystem::FireUpdateEvent() const
 {
     const auto pEvent = gameeventmanager->CreateEvent("saveloc_upd8");
     if (pEvent)
@@ -555,7 +555,7 @@ void CMOMSaveLocSystem::FireUpdateEvent() const
     }
 }
 
-void CMOMSaveLocSystem::UpdateRequesters()
+void CSaveLocSystem::UpdateRequesters()
 {
     if (m_vecRequesters.IsEmpty())
         return;
@@ -610,5 +610,5 @@ CON_COMMAND_F(mom_saveloc_close, "Closes the saveloc menu.\n", FCVAR_CLIENTCMD_C
 }
 
 //Expose this to the DLL
-static CMOMSaveLocSystem s_MOMSavelocSystem("MOMSavelocSystem");
-CMOMSaveLocSystem *g_pSavelocSystem = &s_MOMSavelocSystem;
+static CSaveLocSystem s_MOMSavelocSystem("MOMSavelocSystem");
+CSaveLocSystem *g_pSavelocSystem = &s_MOMSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -574,41 +574,41 @@ void CMOMSaveLocSystem::UpdateRequesters()
 
 CON_COMMAND_F(mom_saveloc_create, "Creates a saveloc that saves a player's state.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->CreateAndSaveLocation();
+    g_pSavelocSystem->CreateAndSaveLocation();
 }
 CON_COMMAND_F(mom_saveloc_current, "Teleports the player to their current saved location.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->TeleportToCurrentSaveloc();
+    g_pSavelocSystem->TeleportToCurrentSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_nav_next, "Goes forwards through the saveloc list, while teleporting the player to each.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->GotoNextSaveloc();
+    g_pSavelocSystem->GotoNextSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_nav_prev, "Goes backwards through the saveloc list, while teleporting the player to each.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->GotoPrevSaveloc();
+    g_pSavelocSystem->GotoPrevSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_nav_first, "Goes to the first saveloc in the list, teleporting the player to it.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->GotoFirstSaveloc();
+    g_pSavelocSystem->GotoFirstSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_nav_last, "Goes to the last saveloc in the list, teleporting the player to it.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->GotoLastSaveloc();
+    g_pSavelocSystem->GotoLastSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_remove_current, "Removes the current saveloc.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->RemoveCurrentSaveloc();
+    g_pSavelocSystem->RemoveCurrentSaveloc();
 }
 CON_COMMAND_F(mom_saveloc_remove_all, "Removes all of the created savelocs for this map.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->RemoveAllSavelocs();
+    g_pSavelocSystem->RemoveAllSavelocs();
 }
 CON_COMMAND_F(mom_saveloc_close, "Closes the saveloc menu.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
-    g_pMOMSavelocSystem->SetUsingSavelocMenu(false);
+    g_pSavelocSystem->SetUsingSavelocMenu(false);
 }
 
 //Expose this to the DLL
 static CMOMSaveLocSystem s_MOMSavelocSystem("MOMSavelocSystem");
-CMOMSaveLocSystem *g_pMOMSavelocSystem = &s_MOMSavelocSystem;
+CMOMSaveLocSystem *g_pSavelocSystem = &s_MOMSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -17,11 +17,11 @@
 
 MAKE_TOGGLE_CONVAR(mom_saveloc_save_between_sessions, "1", FCVAR_ARCHIVE, "Defines if savelocs should be saved between sessions of the same map.\n");
 
-SavedLocation_t::SavedLocation_t(): crouched(false), pos(vec3_origin), vel(vec3_origin), ang(vec3_angle),
-                                    gravityScale(1.0f), movementLagScale(1.0f), disabledButtons(0), m_savedComponents(SAVELOC_NONE)
+SavedLocation_t::SavedLocation_t() : m_bCrouched(false), m_vecPos(vec3_origin), m_vecVel(vec3_origin), m_qaAng(vec3_angle),
+                                     m_fGravityScale(1.0f), m_fMovementLagScale(1.0f), m_iDisabledButtons(0), m_savedComponents(SAVELOC_NONE),
 {
-    targetName[0] = '\0';
-    targetClassName[0] = '\0';
+    m_szTargetName[0] = '\0';
+    m_szTargetClassName[0] = '\0';
 }
 
 SavedLocation_t::SavedLocation_t(CMomentumPlayer* pPlayer, int components /*= SAVELOC_ALL*/) : SavedLocation_t()
@@ -29,31 +29,31 @@ SavedLocation_t::SavedLocation_t(CMomentumPlayer* pPlayer, int components /*= SA
     m_savedComponents = components;
 
     if ( components & SAVELOC_TARGETNAME )
-        Q_strncpy(targetName, pPlayer->GetEntityName().ToCStr(), sizeof(targetName));
+        Q_strncpy(m_szTargetName, pPlayer->GetEntityName().ToCStr(), sizeof(m_szTargetName));
 
     if ( components & SAVELOC_CLASSNAME )
-        Q_strncpy(targetClassName, pPlayer->GetClassname(), sizeof(targetClassName));
+        Q_strncpy(m_szTargetClassName, pPlayer->GetClassname(), sizeof(m_szTargetClassName));
 
     if ( components & SAVELOC_VEL )
-        vel = pPlayer->GetAbsVelocity();
+        m_vecVel = pPlayer->GetAbsVelocity();
 
     if ( components & SAVELOC_POS )
-        pos = pPlayer->GetAbsOrigin();
+        m_vecPos = pPlayer->GetAbsOrigin();
 
     if ( components & SAVELOC_ANG )
-        ang = pPlayer->GetAbsAngles();
+        m_qaAng = pPlayer->GetAbsAngles();
 
     if ( components & SAVELOC_DUCKED )
-        crouched = pPlayer->m_Local.m_bDucked || pPlayer->m_Local.m_bDucking;
+        m_bCrouched = pPlayer->m_Local.m_bDucked || pPlayer->m_Local.m_bDucking;
 
     if ( components & SAVELOC_GRAVITY )
-        gravityScale = pPlayer->GetGravity();
+        m_fGravityScale = pPlayer->GetGravity();
 
     if ( components & SAVELOC_MOVEMENTLAG )
-        movementLagScale = pPlayer->GetLaggedMovementValue();
+        m_fMovementLagScale = pPlayer->GetLaggedMovementValue();
 
     if ( components & SAVELOC_DISABLED_BTNS )
-        disabledButtons = pPlayer->m_afButtonDisabled.Get();
+        m_iDisabledButtons = pPlayer->m_afButtonDisabled.Get();
 
     if ( components & SAVELOC_EVENT_QUEUE )
         g_EventQueue.SaveForTarget(pPlayer, entEventsState);
@@ -64,31 +64,31 @@ void SavedLocation_t::Save(KeyValues* kvCP) const
     kvCP->SetInt( "components", m_savedComponents );
 
     if ( m_savedComponents & SAVELOC_TARGETNAME )
-        kvCP->SetString("targetName", targetName);
+        kvCP->SetString("targetName", m_szTargetName);
 
     if ( m_savedComponents & SAVELOC_CLASSNAME )
-        kvCP->SetString("targetClassName", targetClassName);
+        kvCP->SetString("targetClassName", m_szTargetClassName);
 
     if ( m_savedComponents & SAVELOC_VEL )
-        MomUtil::Save3DToKeyValues( kvCP, "vel", vel );
+        MomUtil::Save3DToKeyValues( kvCP, "vel", m_vecVel );
 
     if ( m_savedComponents & SAVELOC_POS )
-        MomUtil::Save3DToKeyValues( kvCP, "pos", pos );
+        MomUtil::Save3DToKeyValues( kvCP, "pos", m_vecPos );
 
     if ( m_savedComponents & SAVELOC_ANG )
-        MomUtil::Save3DToKeyValues( kvCP, "ang", ang );
+        MomUtil::Save3DToKeyValues( kvCP, "ang", m_qaAng );
 
     if ( m_savedComponents & SAVELOC_DUCKED )
-        kvCP->SetBool("crouched", crouched);
+        kvCP->SetBool("crouched", m_bCrouched);
 
     if ( m_savedComponents & SAVELOC_GRAVITY )
-        kvCP->SetFloat("gravityScale", gravityScale);
+        kvCP->SetFloat("gravityScale", m_fGravityScale);
 
     if ( m_savedComponents & SAVELOC_MOVEMENTLAG )
-        kvCP->SetFloat("movementLagScale", movementLagScale);
+        kvCP->SetFloat("movementLagScale", m_fMovementLagScale);
 
     if ( m_savedComponents & SAVELOC_DISABLED_BTNS )
-        kvCP->SetInt("disabledButtons", disabledButtons);
+        kvCP->SetInt("disabledButtons", m_iDisabledButtons);
 
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         entEventsState.SaveToKeyValues(kvCP);
@@ -97,50 +97,50 @@ void SavedLocation_t::Save(KeyValues* kvCP) const
 void SavedLocation_t::Load(KeyValues* pKv)
 {
     m_savedComponents = pKv->GetInt( "components", SAVELOC_ALL );
-    Q_strncpy(targetName, pKv->GetString("targetName"), sizeof(targetName));
-    Q_strncpy(targetClassName, pKv->GetString("targetClassName"), sizeof(targetClassName));
-    MomUtil::Load3DFromKeyValues( pKv, "pos", pos );
-    MomUtil::Load3DFromKeyValues( pKv, "vel", vel );
-    MomUtil::Load3DFromKeyValues( pKv, "ang", ang );
-    crouched = pKv->GetBool("crouched");
-    gravityScale = pKv->GetFloat("gravityScale", 1.0f);
-    movementLagScale = pKv->GetFloat("movementLagScale", 1.0f);
-    disabledButtons = pKv->GetInt("disabledButtons");
+    Q_strncpy(m_szTargetName, pKv->GetString("targetName"), sizeof(m_szTargetName));
+    Q_strncpy(m_szTargetClassName, pKv->GetString("targetClassName"), sizeof(m_szTargetClassName));
+    MomUtil::Load3DFromKeyValues( pKv, "pos", m_vecPos );
+    MomUtil::Load3DFromKeyValues( pKv, "vel", m_vecVel );
+    MomUtil::Load3DFromKeyValues( pKv, "ang", m_qaAng );
+    m_bCrouched = pKv->GetBool("crouched");
+    m_fGravityScale = pKv->GetFloat("gravityScale", 1.0f);
+    m_fMovementLagScale = pKv->GetFloat("movementLagScale", 1.0f);
+    m_iDisabledButtons = pKv->GetInt("disabledButtons");
     entEventsState.LoadFromKeyValues(pKv);
 }
 
 void SavedLocation_t::Teleport(CMomentumPlayer* pPlayer)
 {
     if ( m_savedComponents & SAVELOC_TARGETNAME )
-        pPlayer->SetName(MAKE_STRING(targetName));
+        pPlayer->SetName(MAKE_STRING(m_szTargetName));
 
     if ( m_savedComponents & SAVELOC_CLASSNAME )
-        pPlayer->SetClassname(targetClassName);
+        pPlayer->SetClassname(m_szTargetClassName);
 
     if ( m_savedComponents & SAVELOC_DUCKED )
     {
-        if ( crouched && !pPlayer->m_Local.m_bDucked )
+        if ( m_bCrouched && !pPlayer->m_Local.m_bDucked )
         {
             pPlayer->ToggleDuckThisFrame( true );
         }
-        else if ( !crouched && pPlayer->m_Local.m_bDucked )
+        else if ( !m_bCrouched && pPlayer->m_Local.m_bDucked )
         {
             pPlayer->ToggleDuckThisFrame( false );
         }
     }
 
-    pPlayer->Teleport(&pos,
-                      m_savedComponents & SAVELOC_ANG ? &ang : nullptr,
-                      m_savedComponents & SAVELOC_VEL ? &vel : nullptr);
+    pPlayer->Teleport(&m_vecPos,
+                      m_savedComponents & SAVELOC_ANG ? &m_qaAng : nullptr,
+                      m_savedComponents & SAVELOC_VEL ? &m_vecVel : nullptr);
 
     if ( m_savedComponents & SAVELOC_GRAVITY )
-        pPlayer->SetGravity(gravityScale);
+        pPlayer->SetGravity(m_fGravityScale);
 
     if ( m_savedComponents & SAVELOC_DISABLED_BTNS )
-        pPlayer->DisableButtons(disabledButtons);
+        pPlayer->DisableButtons(m_iDisabledButtons);
 
     if ( m_savedComponents & SAVELOC_MOVEMENTLAG )
-        pPlayer->SetLaggedMovementValue(movementLagScale);
+        pPlayer->SetLaggedMovementValue(m_fMovementLagScale);
 
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         g_EventQueue.RestoreForTarget(pPlayer, entEventsState);

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -130,4 +130,4 @@ private:
     bool m_bUsingSavelocMenu;
 };
 
-extern CMOMSaveLocSystem *g_pMOMSavelocSystem;
+extern CMOMSaveLocSystem *g_pSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -5,6 +5,24 @@
 class CMomentumPlayer;
 class SavelocReqPacket;
 
+enum SavedLocationComponent_t
+{
+    SAVELOC_NONE = 0,
+
+    SAVELOC_POS = 1 << 0,
+    SAVELOC_VEL = 1 << 1,
+    SAVELOC_ANG = 1 << 2,
+    SAVELOC_TARGETNAME = 1 << 3,
+    SAVELOC_CLASSNAME = 1 << 4,
+    SAVELOC_GRAVITY = 1 << 5,
+    SAVELOC_MOVEMENTLAG = 1 << 6,
+    SAVELOC_DISABLED_BTNS = 1 << 7,
+    SAVELOC_EVENT_QUEUE = 1 << 8,
+    SAVELOC_DUCKED = 1 << 9,
+
+    SAVELOC_ALL = ~SAVELOC_NONE,
+};
+
 // Saved Location used in the "Saveloc menu"
 struct SavedLocation_t
 {
@@ -19,10 +37,12 @@ struct SavedLocation_t
     int disabledButtons;
     CEventQueueState entEventsState;
 
+    int m_savedComponents;
+
     SavedLocation_t();
 
     // Called when the player creates a checkpoint
-    SavedLocation_t(CMomentumPlayer* pPlayer);
+    SavedLocation_t(CMomentumPlayer* pPlayer, int components = SAVELOC_ALL);
 
     // Called when saving the checkpoint to file
     void Save(KeyValues* kvCP) const;
@@ -65,7 +85,7 @@ public:
     // Is the player currently using the saveloc menu?
     bool IsUsingSaveLocMenu() const { return m_bUsingSavelocMenu; }
     // Creates a saveloc on the location of the player
-    SavedLocation_t *CreateSaveloc();
+    SavedLocation_t *CreateSaveloc(int components = SAVELOC_ALL);
     // Creates and saves a checkpoint to the saveloc menu
     void CreateAndSaveLocation();
     // Add a Saveloc to the list

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -56,11 +56,11 @@ struct SavedLocation_t
     bool Write(CUtlBuffer &mem);
 };
 
-class CMOMSaveLocSystem : public CAutoGameSystem
+class CSaveLocSystem : public CAutoGameSystem
 {
 public:
-    CMOMSaveLocSystem(const char* pName);
-    ~CMOMSaveLocSystem();
+    CSaveLocSystem(const char* pName);
+    ~CSaveLocSystem();
     void PostInit() OVERRIDE;
     void LevelInitPreEntity() OVERRIDE;
     void LevelShutdownPreEntity() OVERRIDE;
@@ -130,4 +130,4 @@ private:
     bool m_bUsingSavelocMenu;
 };
 
-extern CMOMSaveLocSystem *g_pSavelocSystem;
+extern CSaveLocSystem *g_pSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -19,6 +19,8 @@ enum SavedLocationComponent_t
     SAVELOC_DISABLED_BTNS = 1 << 7,
     SAVELOC_EVENT_QUEUE = 1 << 8,
     SAVELOC_DUCKED = 1 << 9,
+    SAVELOC_TRACK = 1 << 10,
+    SAVELOC_ZONE = 1 << 11,
 
     SAVELOC_ALL = ~SAVELOC_NONE,
 };
@@ -35,6 +37,7 @@ struct SavedLocation_t
     float m_fGravityScale;
     float m_fMovementLagScale;
     int m_iDisabledButtons;
+    int m_iTrack, m_iZone;
     CEventQueueState entEventsState;
 
     int m_savedComponents;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -26,15 +26,15 @@ enum SavedLocationComponent_t
 // Saved Location used in the "Saveloc menu"
 struct SavedLocation_t
 {
-    bool crouched;
-    Vector pos;
-    Vector vel;
-    QAngle ang;
-    char targetName[512];
-    char targetClassName[512];
-    float gravityScale;
-    float movementLagScale;
-    int disabledButtons;
+    bool m_bCrouched;
+    Vector m_vecPos;
+    Vector m_vecVel;
+    QAngle m_qaAng;
+    char m_szTargetName[512];
+    char m_szTargetClassName[512];
+    float m_fGravityScale;
+    float m_fMovementLagScale;
+    int m_iDisabledButtons;
     CEventQueueState entEventsState;
 
     int m_savedComponents;

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -83,7 +83,7 @@ bool CMomentumTimer::Start(CMomentumPlayer *pPlayer)
     }
 
     // Perform all the checks to ensure player can start
-    if (g_pMOMSavelocSystem->IsUsingSaveLocMenu())
+    if (g_pSavelocSystem->IsUsingSaveLocMenu())
     {
         // MOM_TODO: Allow it based on gametype
         Warning("Cannot start timer while using save loc menu!\n");
@@ -164,7 +164,7 @@ void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */
 void CMomentumTimer::Reset(CMomentumPlayer *pPlayer)
 {
     // It'll get set to true if they teleport to a CP out of here
-    g_pMOMSavelocSystem->SetUsingSavelocMenu(false);
+    g_pSavelocSystem->SetUsingSavelocMenu(false);
     pPlayer->ResetRunStats();
     pPlayer->m_Data.m_bMapFinished = false;
     pPlayer->m_Data.m_bTimerRunning = false;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2053,7 +2053,7 @@ void CMomentumGameMovement::LimitStartZoneSpeed()
 {
 #ifndef CLIENT_DLL
     if (m_pPlayer->m_Data.m_bIsInZone && m_pPlayer->m_Data.m_iCurrentZone == 1 &&
-        !g_pMOMSavelocSystem->IsUsingSaveLocMenu()) // MOM_TODO: && g_Timer->IsForILs()
+        !g_pSavelocSystem->IsUsingSaveLocMenu()) // MOM_TODO: && g_Timer->IsForILs()
     {
         // set bhop flag to true so we can't prespeed with practice mode
         if (m_pPlayer->m_bHasPracticeMode)

--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -432,38 +432,6 @@ bool MomUtil::IsInBounds(const int x, const int y, const int rectX, const int re
     return IsInBounds(Vector2D(x, y), Vector2D(rectX, rectY), Vector2D(rectX + rectW, rectY + rectH));
 }
 
-#define SAVE_3D_TO_KV(kvInto, pName, toSave)                                                                           \
-    if (!kvInto || !pName)                                                                                             \
-        return;                                                                                                        \
-    char value[512];                                                                                                   \
-    Q_snprintf(value, 512, "%f %f %f", toSave.x, toSave.y, toSave.z);                                                  \
-    kvInto->SetString(pName, value);
-
-#define LOAD_3D_FROM_KV(kvFrom, pName, into)                                                                           \
-    if (!kvFrom || !pName)                                                                                             \
-        return;                                                                                                        \
-    sscanf(kvFrom->GetString(pName), "%f %f %f", &into.x, &into.y, &into.z);
-
-void MomUtil::KVSaveVector(KeyValues *kvInto, const char *pName, const Vector &toSave)
-{
-    SAVE_3D_TO_KV(kvInto, pName, toSave);
-}
-
-void MomUtil::KVLoadVector(KeyValues *kvFrom, const char *pName, Vector &vecInto)
-{
-    LOAD_3D_FROM_KV(kvFrom, pName, vecInto);
-}
-
-void MomUtil::KVSaveQAngles(KeyValues *kvInto, const char *pName, const QAngle &toSave)
-{
-    SAVE_3D_TO_KV(kvInto, pName, toSave);
-}
-
-void MomUtil::KVLoadQAngles(KeyValues *kvFrom, const char *pName, QAngle &angInto)
-{
-    LOAD_3D_FROM_KV(kvFrom, pName, angInto);
-}
-
 bool MomUtil::GetSHA1Hash(const CUtlBuffer& buf, char* pOut, size_t outLen)
 {
     CryptoPP::SHA1 hash;

--- a/mp/src/game/shared/momentum/util/mom_util.h
+++ b/mp/src/game/shared/momentum/util/mom_util.h
@@ -52,11 +52,24 @@ namespace MomUtil
     bool IsInBounds(const Vector2D &source, const Vector2D &bottomLeft, const Vector2D &topRight);
     bool IsInBounds(const int x, const int y, const int rectX, const int rectY, const int rectW, const int rectH);
 
-    void KVSaveVector(KeyValues *kvInto, const char *pName, const Vector &toSave);
-    void KVLoadVector(KeyValues *kvFrom, const char *pName, Vector &vecInto);
+    template< class T >
+    void Save3DToKeyValues( KeyValues *pKvInto, const char *pName, const T &toSave )
+    {
+        if ( !pKvInto || !pName )
+            return;
 
-    void KVSaveQAngles(KeyValues *kvInto, const char *pName, const QAngle &toSave);
-    void KVLoadQAngles(KeyValues *kvFrom, const char *pName, QAngle &angInto);
+        char value[128];
+        Q_snprintf( value, 128, "%f %f %f", toSave.x, toSave.y, toSave.z );
+        pKvInto->SetString( pName, value );
+    }
+
+    template< class T >
+    void Load3DFromKeyValues( KeyValues *pKvFrom, const char *pName, T &into )
+    {
+        if ( !pKvFrom || !pName )
+            return;
+        sscanf( pKvFrom->GetString( pName ), "%f %f %f", &into.x, &into.y, &into.z );
+    }
 
     bool GetSHA1Hash(const CUtlBuffer &buf, char *pOut, size_t outLen);
     bool GetFileHash(char *pOut, size_t outLen, const char *pFileName, const char *pPath = "GAME");


### PR DESCRIPTION
Closes #852 

This PR fixes the crouching reset camera bug by introducing the idea of components to savelocs. This allows other systems to use the saveloc systems and manually specify what parts of the saveloc system they want to save and apply to the player. For start marks (and eventually the trick system), this is only the position and angle.

Also renamed the system internally to better match our newer code.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
