### PR TITLE
Prevent crashes when there are more than 4096 static props

### DIFF
--- a/mp/src/game/shared/momentum/util/engine_patch.cpp
+++ b/mp/src/game/shared/momentum/util/engine_patch.cpp
@@ -42,6 +42,16 @@ CEnginePatch g_EnginePatches[] =
         PATCH_REFERENCE,
         -1.0f
     },
+    // Replace == (jz = 74) with >= (jge = 7D) to prevent static props above 4095 from bypassing this check and causing crashes
+    // https://github.com/VSES/SourceEngine2007/blob/master/se2007/engine/staticpropmgr.cpp#L1748
+    {
+        "IsStaticPropPatch",
+        "\x55\x8B\xEC\x8B\x4D\x08\x85\xC9\x74\x19\x8B\x01",
+        "xxxxxxxxxxxx",
+        27,
+        PATCH_IMMEDIATE,
+        "\x7D\x06\x32\xC0"
+    },
     // Example patch: Trigger "Map has too many brushes" error at 16384 brushes instead of 8192
     //{
     //    "BrushLimit",
@@ -70,6 +80,16 @@ CEnginePatch g_EnginePatches[] =
         20,
         PATCH_REFERENCE,
         -1.0f
+    },
+    // Replace == (setz = 0F 94) with >= (setae = 0F 93) to prevent static props above 4095 from bypassing this check and causing crashes
+    // https://github.com/VSES/SourceEngine2007/blob/master/se2007/engine/staticpropmgr.cpp#L1748
+    {
+        "IsStaticPropPatch",
+        "\x55\xB8\x00\x00\x00\x00\x89\xE5\x83\xEC\x18\x8B\x55\x0C\x85\xD2\x74\x15",
+        "xx????xxxxxxxxxxxx",
+        36,
+        PATCH_IMMEDIATE,
+        "\x0F\x94\xC0\xC9"
     },
     // Example patch: Trigger "Map has too many brushes" error at 16384 brushes instead of 8192
     //{

--- a/mp/src/game/shared/momentum/util/engine_patch.cpp
+++ b/mp/src/game/shared/momentum/util/engine_patch.cpp
@@ -28,6 +28,7 @@
 // m_iOffset:       Patch offset
 // m_bImmediate:    Immediate or referenced variable
 // m_pPatch:        Patch bytes (int/float/char*)
+// m_iLength:       Patch length (only with char* patches)
 //==============================
 CEnginePatch g_EnginePatches[] =
 {
@@ -50,7 +51,8 @@ CEnginePatch g_EnginePatches[] =
         "xxxxxxxxxxxx",
         27,
         PATCH_IMMEDIATE,
-        "\x7D\x06\x32\xC0"
+        "\x7D",
+        1
     },
     // Example patch: Trigger "Map has too many brushes" error at 16384 brushes instead of 8192
     //{
@@ -68,7 +70,8 @@ CEnginePatch g_EnginePatches[] =
     //    "xxxxx????",
     //    5,
     //    PATCH_IMMEDIATE,
-    //    "\x00\x40\x00\x00"
+    //    "\x00\x40\x00\x00",
+    //    4
     //}
 #elif __linux__
     // Prevent the culling of skyboxes at high FOVs
@@ -89,7 +92,8 @@ CEnginePatch g_EnginePatches[] =
         "xx????xxxxxxxxxxxx",
         36,
         PATCH_IMMEDIATE,
-        "\x0F\x94\xC0\xC9"
+        "\x0F\x93",
+        2
     },
     // Example patch: Trigger "Map has too many brushes" error at 16384 brushes instead of 8192
     //{
@@ -107,7 +111,8 @@ CEnginePatch g_EnginePatches[] =
     //    "x????xxxxxxxxx",
     //    14,
     //    PATCH_IMMEDIATE,
-    //    "\x00\x40\x00\x00"
+    //    "\x00\x40\x00\x00",
+    //    4
     //}
 #endif //_WIN32
 };
@@ -269,9 +274,9 @@ CEnginePatch::CEnginePatch(const char* name, char* signature, char* mask, size_t
     Q_memcpy(m_pPatch, &value, m_iLength);
 }
 
-CEnginePatch::CEnginePatch(const char* name, char* signature, char* mask, size_t offset, bool immediate, char* bytes)
+CEnginePatch::CEnginePatch(const char* name, char* signature, char* mask, size_t offset, bool immediate, char* bytes, size_t length)
     : CEnginePatch(name, signature, mask, offset, immediate)
 {
-    m_iLength = sizeof(bytes);
+    m_iLength = length;
     m_pPatch = bytes;
 }

--- a/mp/src/game/shared/momentum/util/engine_patch.h
+++ b/mp/src/game/shared/momentum/util/engine_patch.h
@@ -38,7 +38,7 @@ public:
     CEnginePatch(const char*, char*, char*, size_t, bool);
     CEnginePatch(const char*, char*, char*, size_t, bool, int);
     CEnginePatch(const char*, char*, char*, size_t, bool, float);
-    CEnginePatch(const char*, char*, char*, size_t, bool, char*);
+    CEnginePatch(const char*, char*, char*, size_t, bool, char*, size_t);
 
     void ApplyPatch();
 


### PR DESCRIPTION
When a static prop is initialized, it's given a special EHandle serial number, `STATICPROP_EHANDLE_MASK >> NUM_ENT_ENTRY_BITS` or `0x40000`. The problem is when a static prop with an index of 4096 or above gets initalized, its index overlaps with the serial number when both are ORed in `CBaseHandle::Init`, so the serial number becomes `0x40001`. The [check](https://github.com/VSES/SourceEngine2007/blob/master/se2007/engine/staticpropmgr.cpp#L1748) for whether an entity handle is a static prop only passes when the serial number is `0x40000`, so any static prop above 4096 would bypass the check. This causes a crash whenever such a prop interacts with trigger bounds, since it would bypass the check and the engine attempts to retrieve its edict which doesn't exist.

This PR adds a patch for a single byte in the engine so the check uses `>=` instead of `==`.

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
