### PR TITLE
Minor Settings Panel Fixes

### DIFF
--- a/mp/game/momentum/scripts/kb_act.lst
+++ b/mp/game/momentum/scripts/kb_act.lst
@@ -10,6 +10,7 @@
 "+walk"         "#Valve_Walk"
 "+jump"			"#Valve_Jump"
 "+duck"			"#Valve_Duck"
+"+speed"        "#Valve_Sprint"
 "blank"			"=========================="
 "blank"			"#MOM_Controls_Title"
 "blank"			"=========================="

--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -371,14 +371,12 @@ bool ClientModeMOMNormal::CreateMove(float flInputSampleTime, CUserCmd *cmd)
     static int dominant_buttons = 0;
     static int prev_flags = 0;
 
-    int mdir;
-
     if (!local_player)
     {
         return false;
     }
 
-    mdir = MovementDirection(cmd->viewangles, local_player->GetAbsVelocity());
+    int mdir = MovementDirection(cmd->viewangles, local_player->GetAbsVelocity());
 
     if (mom_release_forward_on_jump.GetBool() && prev_flags & FL_ONGROUND && FL_ONGROUND & local_player->GetFlags() &&
         local_player->GetGroundEntity() &&
@@ -417,7 +415,7 @@ bool ClientModeMOMNormal::CreateMove(float flInputSampleTime, CUserCmd *cmd)
         }
     }
 
-    if (!mom_enable_overlapping_keys.GetBool())
+    if (mom_enable_overlapping_keys.GetBool())
     {
         cmd->buttons &= ~local_player->m_afButtonDisabled;
 

--- a/mp/src/vgui2/vgui_controls/Frame.cpp
+++ b/mp/src/vgui2/vgui_controls/Frame.cpp
@@ -899,13 +899,21 @@ void Frame::SetupResizeCursors()
 	if (IsSizeable())
 	{
 		_topGrip->SetCursor(dc_sizens);
+		_topGrip->SetVisible(true);
 		_bottomGrip->SetCursor(dc_sizens);
+		_bottomGrip->SetVisible(true);
 		_leftGrip->SetCursor(dc_sizewe);
+		_leftGrip->SetVisible(true);
 		_rightGrip->SetCursor(dc_sizewe);
+		_rightGrip->SetVisible(true);
 		_topLeftGrip->SetCursor(dc_sizenwse);
+		_topLeftGrip->SetVisible(true);
 		_topRightGrip->SetCursor(dc_sizenesw);
+		_topRightGrip->SetVisible(true);
 		_bottomLeftGrip->SetCursor(dc_sizenesw);
+		_bottomLeftGrip->SetVisible(true);
 		_bottomRightGrip->SetCursor(dc_sizenwse);
+		_bottomRightGrip->SetVisible(true);
 
 		_bottomRightGrip->SetPaintEnabled(true);
 		_bottomRightGrip->SetPaintBackgroundEnabled(true);
@@ -914,13 +922,21 @@ void Frame::SetupResizeCursors()
 	{
 		// not resizable, so just use the default cursor
 		_topGrip->SetCursor(dc_arrow);
+		_topGrip->SetVisible(false);
 		_bottomGrip->SetCursor(dc_arrow);
+		_bottomGrip->SetVisible(false);
 		_leftGrip->SetCursor(dc_arrow);
+		_leftGrip->SetVisible(false);
 		_rightGrip->SetCursor(dc_arrow);
+		_rightGrip->SetVisible(false);
 		_topLeftGrip->SetCursor(dc_arrow);
+		_topLeftGrip->SetVisible(false);
 		_topRightGrip->SetCursor(dc_arrow);
+		_topRightGrip->SetVisible(false);
 		_bottomLeftGrip->SetCursor(dc_arrow);
+		_bottomLeftGrip->SetVisible(false);
 		_bottomRightGrip->SetCursor(dc_arrow);
+		_bottomRightGrip->SetVisible(false);
 
 		_bottomRightGrip->SetPaintEnabled(false);
 		_bottomRightGrip->SetPaintBackgroundEnabled(false);


### PR DESCRIPTION
Closes #849
Closes #833

This branch fixes some minor things noticed in the settings panel.

 - Added sprint binding to keybinds
 - Inverted the logic surrounding `mom_enable_overlapping_keys` (checked should mean "on" now)
 - Hid frame grips for unsizable frames

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
