### PR TITLE
Mount CSS and TF2 vpks before loose files

### DIFF
--- a/mp/src/game/shared/momentum/util/mom_util.cpp
+++ b/mp/src/game/shared/momentum/util/mom_util.cpp
@@ -79,23 +79,23 @@ void MomUtil::MountGameFiles()
         folderLen = SteamApps()->GetAppInstallDir(240, installPath, MAX_PATH);
         if (folderLen)
         {
-            filesystem->AddSearchPath(CFmtStr("%s/cstrike", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/cstrike/cstrike_pak.vpk", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/cstrike/download", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/cstrike/download", installPath), "download");
+            filesystem->AddSearchPath(CFmtStr("%s/cstrike", installPath), "GAME");
         }
 
         // TF2
         folderLen = SteamApps()->GetAppInstallDir(440, installPath, MAX_PATH);
         if (folderLen)
         {
-            filesystem->AddSearchPath(CFmtStr("%s/tf", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/tf2_misc.vpk", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/tf2_sound_misc.vpk", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/tf2_sound_vo_english.vpk", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/tf2_textures.vpk", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/download", installPath), "GAME");
             filesystem->AddSearchPath(CFmtStr("%s/tf/download", installPath), "download");
+            filesystem->AddSearchPath(CFmtStr("%s/tf", installPath), "GAME");
         }
 
         if (developer.GetInt())


### PR DESCRIPTION
This changes the mounting order of TF2 and CSS Search Paths. Previously, the game folders were mounted first, then the respective VPKs. Now, the order is reversed. This is following advice from the comments of gameinfo.txt: 

> We search VPK files before ordinary folders, because most files will be found in VPK and we can avoid making thousands of file system calls to attempt to open files in folders where they don't exist.  (Searching a VPK is much faster than making an operating system call.)

and also allows TF2 ambient sounds to load properly on Linux (previously, on sj_amazon, the game would generate hundreds of warning due to missing files that did exist, then crash, but doesn't anymore with this, at least for me).

I have tested multiple maps from TF2, CSS and Momentum game modes and everything was mounted properly.

### Checklist
- [X] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [X] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [X] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [X] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [X] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [X] My commits are relatively small and scoped to the best of my ability
- [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

