### PR TITLE
Subdivision markings for progress bars

### DIFF
--- a/mp/game/momentum/resource/ui/HudStickyCharge.res
+++ b/mp/game/momentum/resource/ui/HudStickyCharge.res
@@ -32,6 +32,10 @@
         "dulltext"		"0"
         "brighttext"	"0"
         "bgcolor_override" "0 0 0 100"
+        "subdivmarks_enabled" "0"
+        "subdivmarks_color" "MomentumRed"
+        "subdivmarks_count" "3"
+        "subdivmarks_width" "2"
     }
     "ChargeMeterLabel"
     {

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -133,14 +133,13 @@ void CHudSpeedMeter::FireGameEvent(IGameEvent *pEvent)
         return;
 
     // zone enter/exit
-    const auto ent = pEvent->GetInt("ent");
-    if (ent != pLocal->GetCurrentUIEntity()->GetEntIndex())
+    if (pEvent->GetInt("ent") != pLocal->GetCurrentUIEntity()->GetEntIndex())
         return;
 
-    int iCurrentZone = m_pRunEntData->m_iCurrentZone;
+    int iCurrentZone = pEvent->GetInt("num");
     const bool bExit = FStrEq(pEvent->GetName(), "zone_exit"), bEnter = FStrEq(pEvent->GetName(), "zone_enter");
 
-    if (m_pRunEntData->m_bIsInZone && iCurrentZone == 1 && bEnter)
+    if (bEnter && iCurrentZone == 1)
     {
         // disappear when entering start zone
         m_fExplosiveJumpVelAlpha = 0.0f;
@@ -168,8 +167,7 @@ void CHudSpeedMeter::FireGameEvent(IGameEvent *pEvent)
         if (bComparisonLoaded)
         {
             // set the label's custom diff
-            float diff = act - g_pMOMRunCompare->GetRunComparisons()->runStats.GetZoneEnterSpeed(
-                                    m_pRunEntData->m_iCurrentZone, velType);
+            float diff = act - g_pMOMRunCompare->GetRunComparisons()->runStats.GetZoneEnterSpeed(iCurrentZone, velType);
             m_pStageEnterExitVelLabel->SetCustomDiff(diff);
         }
         m_pStageEnterExitVelLabel->SetDrawComparison(bComparisonLoaded);

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -96,6 +96,7 @@ void CHudStickyCharge::OnThink()
     // Turn charge meter red while inside start zone to indicate that stickies can't be charged
     if (!m_pLauncher->IsChargeEnabled())
     {
+        m_pChargeMeter->SetSubdivMarksVisible(false);
         m_pChargeMeter->SetFgColor(m_cChargeDisabled);
         m_pChargeMeter->SetProgress(1.0f);
 
@@ -107,6 +108,7 @@ void CHudStickyCharge::OnThink()
         if (!m_pChargeLabel->IsVisible())
             m_pChargeLabel->SetVisible(true);
 
+        m_pChargeMeter->SetSubdivMarksVisible(true);
         m_pChargeMeter->SetFgColor(m_cChargeColor);
         float flChargeMaxTime = m_pLauncher->GetChargeMaxTime();
 

--- a/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_stickybombcharge.cpp
@@ -23,6 +23,13 @@ static MAKE_CONVAR(mom_hud_sj_chargemeter_units, "0", FCVAR_ARCHIVE,
                    " 2 = Speed in percent (0% = 900u/s, 100% = 2400u/s)",
                    0, 2);
 
+enum ChargeMeterUnits_t
+{
+    CHARGEMETER_UNITS_NONE = 0,
+    CHARGEMETER_UNITS_UPS,
+    CHARGEMETER_UNITS_PERCENT
+};
+
 class CHudStickyCharge : public CHudElement, public EditablePanel
 {
   public:
@@ -30,9 +37,10 @@ class CHudStickyCharge : public CHudElement, public EditablePanel
 
     CHudStickyCharge(const char *pElementName);
 
-    bool ShouldDraw() OVERRIDE;
-    void OnThink() OVERRIDE;
-    void Reset() OVERRIDE;
+    bool ShouldDraw() override;
+    void OnThink() override;
+    void Reset() override;
+    void FireGameEvent(IGameEvent *pEvent) override;
 
     CPanelAnimationVar(Color, m_cChargeColor, "ChargeColor", "MomGreydientStep8");
     CPanelAnimationVar(Color, m_cChargeDisabled, "ChargeDisabledColor", "MomentumRed");
@@ -48,6 +56,9 @@ DECLARE_HUDELEMENT(CHudStickyCharge);
 CHudStickyCharge::CHudStickyCharge(const char *pElementName)
     : CHudElement(pElementName), EditablePanel(g_pClientMode->GetViewport(), "HudStickyCharge")
 {
+    ListenForGameEvent("zone_exit");
+    ListenForGameEvent("zone_enter");
+
     SetHiddenBits(HIDEHUD_LEADERBOARDS);
 
     m_pLauncher = nullptr;
@@ -57,9 +68,38 @@ CHudStickyCharge::CHudStickyCharge(const char *pElementName)
     LoadControlSettings("resource/ui/HudStickyCharge.res");
 }
 
+void CHudStickyCharge::FireGameEvent(IGameEvent* pEvent)
+{
+    const auto pLocal = C_MomentumPlayer::GetLocalMomPlayer();
+    if (!pLocal)
+        return; 
+
+    if (pEvent->GetInt("num") != 1)
+        return;
+
+    if (FStrEq(pEvent->GetName(), "zone_enter"))
+    {
+        // Turn charge meter red while inside start zone to indicate that stickies can't be charged
+        m_pChargeLabel->SetVisible(false);
+        m_pChargeMeter->SetSubdivMarksVisible(false);
+        m_pChargeMeter->SetFgColor(m_cChargeDisabled);
+        m_pChargeMeter->SetProgress(1.0f);
+    }
+    else
+    {
+        m_pChargeLabel->SetVisible(true);
+        m_pChargeMeter->SetSubdivMarksVisible(true);
+        m_pChargeMeter->SetFgColor(m_cChargeColor);
+    }
+}
+
 void CHudStickyCharge::Reset()
 {
     m_pLauncher = nullptr;
+
+    m_pChargeLabel->SetVisible(true);
+    m_pChargeMeter->SetSubdivMarksVisible(true);
+    m_pChargeMeter->SetFgColor(m_cChargeColor);
 }
 
 bool CHudStickyCharge::ShouldDraw()
@@ -84,7 +124,7 @@ bool CHudStickyCharge::ShouldDraw()
 
 void CHudStickyCharge::OnThink()
 {
-    if (!m_pLauncher)
+    if (!m_pLauncher || !m_pLauncher->IsChargeEnabled())
         return;
 
     // Reset the charge label when player stops charging
@@ -93,55 +133,39 @@ void CHudStickyCharge::OnThink()
         m_pChargeLabel->SetText("CHARGE");
     }
 
-    // Turn charge meter red while inside start zone to indicate that stickies can't be charged
-    if (!m_pLauncher->IsChargeEnabled())
+    // Set progress of charge meter
+    float flChargeMaxTime = m_pLauncher->GetChargeMaxTime();
+
+    if (!CloseEnough(flChargeMaxTime, 0.0f, FLT_EPSILON))
     {
-        m_pChargeMeter->SetSubdivMarksVisible(false);
-        m_pChargeMeter->SetFgColor(m_cChargeDisabled);
-        m_pChargeMeter->SetProgress(1.0f);
+        float flChargeBeginTime = m_pLauncher->GetChargeBeginTime();
 
-        m_pChargeLabel->SetVisible(false);
-    }
-    else
-    {
-        // If charge label was disabled by start zone, enable it again
-        if (!m_pChargeLabel->IsVisible())
-            m_pChargeLabel->SetVisible(true);
-
-        m_pChargeMeter->SetSubdivMarksVisible(true);
-        m_pChargeMeter->SetFgColor(m_cChargeColor);
-        float flChargeMaxTime = m_pLauncher->GetChargeMaxTime();
-
-        if (!CloseEnough(flChargeMaxTime, 0.0f, FLT_EPSILON))
+        if (flChargeBeginTime > 0)
         {
-            float flChargeBeginTime = m_pLauncher->GetChargeBeginTime();
+            float flTimeCharged = max(0, gpGlobals->curtime - flChargeBeginTime);
+            float flPercentCharged = min(1.0, flTimeCharged / flChargeMaxTime);
 
-            if (flChargeBeginTime > 0)
+            m_pChargeMeter->SetProgress(flPercentCharged);
+
+            if (!mom_hud_sj_chargemeter_units.GetInt())
+                return;
+
+            char buf[64];
+            switch (mom_hud_sj_chargemeter_units.GetInt())
             {
-                float flTimeCharged = max(0, gpGlobals->curtime - flChargeBeginTime);
-                float flPercentCharged = min(1.0, flTimeCharged / flChargeMaxTime);
-
-                m_pChargeMeter->SetProgress(flPercentCharged);
-
-                if (mom_hud_sj_chargemeter_units.GetInt() == 1)
-                {
-                    char buf[64];
-                    Q_snprintf(buf, sizeof(buf), "%du/s", (int) m_pLauncher->CalculateProjectileSpeed(flTimeCharged));
-
-                    m_pChargeLabel->SetText(buf);
-                }
-                else if (mom_hud_sj_chargemeter_units.GetInt() == 2)
-                {
-                    char buf[64];
-                    Q_snprintf(buf, sizeof(buf), "%d%%", (int) (flPercentCharged * 100));
-
-                    m_pChargeLabel->SetText(buf);
-                }
+            case CHARGEMETER_UNITS_UPS:
+                Q_snprintf(buf, sizeof(buf), "%du/s", static_cast<int>(m_pLauncher->CalculateProjectileSpeed(flTimeCharged)));
+                break;
+            case CHARGEMETER_UNITS_PERCENT:
+            default:
+                Q_snprintf(buf, sizeof(buf), "%d%%", static_cast<int>(flPercentCharged * 100.0f));
+                break;
             }
-            else
-            {
-                m_pChargeMeter->SetProgress(0.0f);
-            }
+            m_pChargeLabel->SetText(buf);
+        }
+        else
+        {
+            m_pChargeMeter->SetProgress(0.0f);
         }
     }
 }

--- a/mp/src/public/vgui_controls/ProgressBar.h
+++ b/mp/src/public/vgui_controls/ProgressBar.h
@@ -20,73 +20,73 @@ namespace vgui
 
 //-----------------------------------------------------------------------------
 // Purpose: Status bar that visually displays discrete progress in the form
-//			of a segmented strip
+//          of a segmented strip
 //-----------------------------------------------------------------------------
 class ProgressBar : public Panel
 {
-	DECLARE_CLASS_SIMPLE( ProgressBar, Panel );
+    DECLARE_CLASS_SIMPLE(ProgressBar, Panel);
 
 public:
-	ProgressBar(Panel *parent, const char *panelName);
-	~ProgressBar();
+    ProgressBar(Panel *parent, const char *panelName);
+    ~ProgressBar();
 
-	// 'progress' is in the range [0.0f, 1.0f]
-	MESSAGE_FUNC_FLOAT( SetProgress, "SetProgress", progress );
-	float GetProgress();
-	virtual void SetSegmentInfo( int gap, int width );
+    // 'progress' is in the range [0.0f, 1.0f]
+    MESSAGE_FUNC_FLOAT(SetProgress, "SetProgress", progress);
+    float GetProgress();
+    virtual void SetSegmentInfo(int gap, int width);
     virtual void SetProgressText();
 
-	// utility function for calculating a time remaining string
-	static bool ConstructTimeRemainingString(OUT_Z_BYTECAP(outputBufferSizeInBytes) wchar_t *output, int outputBufferSizeInBytes, float startTime, float currentTime, float currentProgress, float lastProgressUpdateTime, bool addRemainingSuffix);
+    // utility function for calculating a time remaining string
+    static bool ConstructTimeRemainingString(OUT_Z_BYTECAP(outputBufferSizeInBytes) wchar_t *output, int outputBufferSizeInBytes, float startTime, float currentTime, float currentProgress, float lastProgressUpdateTime, bool addRemainingSuffix);
 
-	void SetBarInset( int pixels );
-	int GetBarInset( void );
-	void SetMargin( int pixels );
-	int GetMargin();
+    void SetBarInset(int pixels);
+    int GetBarInset();
+    void SetMargin(int pixels);
+    int GetMargin();
 
     void SetShouldDrawPercentString(bool bDraw);
-	
-	virtual void ApplySettings(KeyValues *inResourceData);
-	virtual void GetSettings(KeyValues *outResourceData);
-    void InitSettings() OVERRIDE;
 
-	// returns the number of segment blocks drawn
-	int GetDrawnSegmentCount();
+    virtual void ApplySettings(KeyValues *inResourceData);
+    virtual void GetSettings(KeyValues *outResourceData);
+    void InitSettings() override;
 
-	enum ProgressDir_e
-	{
-		PROGRESS_EAST,
-		PROGRESS_WEST,
-		PROGRESS_NORTH,
-		PROGRESS_SOUTH
-	};
+    // returns the number of segment blocks drawn
+    int GetDrawnSegmentCount();
 
-	int GetProgressDirection() const { return m_iProgressDirection; }
-	void SetProgressDirection( int val ) { m_iProgressDirection = val; }
+    enum ProgressDir_e
+    {
+        PROGRESS_EAST,
+        PROGRESS_WEST,
+        PROGRESS_NORTH,
+        PROGRESS_SOUTH
+    };
 
-protected:
-	virtual void Paint();
-    void PerformLayout() OVERRIDE;
-	void PaintSegment( int &x, int &y, int tall, int wide );
-	virtual void PaintBackground();
-	virtual void ApplySchemeSettings(IScheme *pScheme);
-	MESSAGE_FUNC_PARAMS( OnDialogVariablesChanged, "DialogVariables", dialogVariables );
-	/* CUSTOM MESSAGE HANDLING
-		"SetProgress"
-			input:	"progress"	- float value of the progress to set
-	*/
+    int GetProgressDirection() const { return m_iProgressDirection; }
+    void SetProgressDirection(int val) { m_iProgressDirection = val; }
 
 protected:
-	int m_iProgressDirection;
-	float _progress;
+    virtual void Paint();
+    void PerformLayout() override;
+    void PaintSegment(int &x, int &y, int tall, int wide);
+    virtual void PaintBackground();
+    virtual void ApplySchemeSettings(IScheme *pScheme);
+    MESSAGE_FUNC_PARAMS(OnDialogVariablesChanged, "DialogVariables", dialogVariables);
+    /* CUSTOM MESSAGE HANDLING
+        "SetProgress"
+            input:	"progress"	- float value of the progress to set
+    */
+
+protected:
+    int m_iProgressDirection;
+    float _progress;
 
 private:
-	int   _segmentCount;
-	int _segmentGap;
-	int _segmentWide;
-	int m_iBarInset;
-	int m_iBarMargin;
-	CUtlString m_pszDialogVar;
+    int _segmentCount;
+    int _segmentGap;
+    int _segmentWide;
+    int m_iBarInset;
+    int m_iBarMargin;
+    CUtlString m_pszDialogVar;
     Label *m_pProgressPercent;
 };
 
@@ -95,12 +95,12 @@ private:
 //-----------------------------------------------------------------------------
 class ContinuousProgressBar : public ProgressBar
 {
-	DECLARE_CLASS_SIMPLE( ContinuousProgressBar, ProgressBar );
+    DECLARE_CLASS_SIMPLE(ContinuousProgressBar, ProgressBar);
 
 public:
-	ContinuousProgressBar(Panel *parent, const char *panelName);
+    ContinuousProgressBar(Panel *parent, const char *panelName);
 
-	virtual void Paint();
+    virtual void Paint();
 };
 
 } // namespace vgui

--- a/mp/src/public/vgui_controls/ProgressBar.h
+++ b/mp/src/public/vgui_controls/ProgressBar.h
@@ -64,10 +64,23 @@ public:
     int GetProgressDirection() const { return m_iProgressDirection; }
     void SetProgressDirection(int val) { m_iProgressDirection = val; }
 
+    void SetSubdivMarksEnabled(bool bEnabled) { m_bSubdivMarksEnabled = bEnabled; }
+    void SetSubdivMarksVisible(bool bVisible) { m_bSubdivMarksVisible = bVisible; }
+    void SetSubdivMarksColor(Color color) { m_SubdivMarksColor = color; }
+    void SetSubdivMarksCount(int count) { m_iSubdivMarksCount = count; }
+    void SetSubdivMarksWidth(int width) { m_iSubdivMarksWidth = width; }
+
+    bool  GetSubdivMarksEnabled() const { return m_bSubdivMarksEnabled; }
+    bool  GetSubdivMarksVisible() const { return m_bSubdivMarksVisible; }
+    Color GetSubdivMarksColor() const { return m_SubdivMarksColor; }
+    int   GetSubdivMarksCount() const { return m_iSubdivMarksCount; }
+    int   GetSubdivMarksWidth() const { return m_iSubdivMarksWidth; }
+
 protected:
     virtual void Paint();
     void PerformLayout() override;
     void PaintSegment(int &x, int &y, int tall, int wide);
+    void PaintSubdivMarks(int x, int y, int tall, int wide);
     virtual void PaintBackground();
     virtual void ApplySchemeSettings(IScheme *pScheme);
     MESSAGE_FUNC_PARAMS(OnDialogVariablesChanged, "DialogVariables", dialogVariables);
@@ -88,6 +101,14 @@ private:
     int m_iBarMargin;
     CUtlString m_pszDialogVar;
     Label *m_pProgressPercent;
+
+    CPanelAnimationVar(Color, m_SubdivMarksColor, "subdivmarks_color", "MomentumRed");
+    CPanelAnimationVar(int, m_iSubdivMarksCount, "subdivmarks_count", "3");
+    CPanelAnimationVar(int, m_iSubdivMarksWidth, "subdivmarks_width", "2");
+    CPanelAnimationVar(bool, m_bSubdivMarksEnabled, "subdivmarks_enabled", "0");
+
+    // not user-facing; code can use this to toggle markings when they're enabled
+    bool m_bSubdivMarksVisible;
 };
 
 //-----------------------------------------------------------------------------

--- a/mp/src/vgui2/vgui_controls/ProgressBar.cpp
+++ b/mp/src/vgui2/vgui_controls/ProgressBar.cpp
@@ -41,6 +41,8 @@ ProgressBar::ProgressBar(Panel *parent, const char *panelName) : Panel(parent, p
     SetBarInset(4);
     SetMargin(0);
     m_iProgressDirection = PROGRESS_EAST;
+
+    m_bSubdivMarksVisible = false;
 }
 
 ProgressBar::~ProgressBar()
@@ -111,6 +113,29 @@ void ProgressBar::PaintSegment(int &x, int &y, int tall, int wide)
     }
 }
 
+void ProgressBar::PaintSubdivMarks(int x, int y, int tall, int wide)
+{
+    if (!m_bSubdivMarksVisible || !m_bSubdivMarksEnabled || !m_iSubdivMarksCount || m_iSubdivMarksWidth <= 0 || !m_SubdivMarksColor.a())
+        return;
+
+    bool bVertical = m_iProgressDirection == PROGRESS_SOUTH || m_iProgressDirection == PROGRESS_NORTH;
+    surface()->DrawSetColor(m_SubdivMarksColor);
+    int iSubdivCoord = 0 - (m_iSubdivMarksWidth / 2);
+    for (int i = 0; i < m_iSubdivMarksCount; i++)
+    {
+        if (bVertical)
+        {
+            iSubdivCoord += tall / (m_iSubdivMarksCount + 1);
+            surface()->DrawFilledRect(x, iSubdivCoord, wide - x, iSubdivCoord + m_iSubdivMarksWidth);
+        }
+        else
+        {
+            iSubdivCoord += wide / (m_iSubdivMarksCount + 1);
+            surface()->DrawFilledRect(iSubdivCoord, y, iSubdivCoord + m_iSubdivMarksWidth, tall - y);
+        }
+    }
+}
+
 void ProgressBar::Paint()
 {
     int wide, tall;
@@ -156,11 +181,14 @@ void ProgressBar::Paint()
         break;
     }
 
+    int xTmp = x, yTmp = y;
     surface()->DrawSetColor(GetFgColor());
     for (int i = 0; i < segmentsDrawn; i++)
     {
-        PaintSegment(x, y, tall, wide);
+        PaintSegment(xTmp, yTmp, tall, wide);
     }
+
+    PaintSubdivMarks(x, y, tall, wide);
 }
 
 void ProgressBar::PerformLayout()
@@ -426,4 +454,6 @@ void ContinuousProgressBar::Paint()
         surface()->DrawFilledRect(x, y, x + wide, y + static_cast<int>(tall * _progress));
         break;
     }
+
+    PaintSubdivMarks(x, y, tall, wide);
 }

--- a/mp/src/vgui2/vgui_controls/ProgressBar.cpp
+++ b/mp/src/vgui2/vgui_controls/ProgressBar.cpp
@@ -24,43 +24,34 @@
 
 using namespace vgui;
 
-DECLARE_BUILD_FACTORY( ProgressBar );
+DECLARE_BUILD_FACTORY(ProgressBar);
 
-//-----------------------------------------------------------------------------
-// Purpose: Constructor
-//-----------------------------------------------------------------------------
 ProgressBar::ProgressBar(Panel *parent, const char *panelName) : Panel(parent, panelName)
 {
     InitSettings();
-	_progress = 0.0f;
+    _progress = 0.0f;
     m_pProgressPercent = new Label(this, "ProgressPercent", "");
     m_pProgressPercent->SetContentAlignment(Label::a_center);
     m_pProgressPercent->SetMouseInputEnabled(false);
     m_pProgressPercent->SetKeyBoardInputEnabled(false);
     SetProgressText();
     m_pProgressPercent->SetVisible(false);
-	m_pszDialogVar = nullptr;
-	SetSegmentInfo( 4, 8 );
-	SetBarInset( 4 );
-	SetMargin( 0 );
-	m_iProgressDirection = PROGRESS_EAST;
+    m_pszDialogVar = nullptr;
+    SetSegmentInfo(4, 8);
+    SetBarInset(4);
+    SetMargin(0);
+    m_iProgressDirection = PROGRESS_EAST;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: Destructor
-//-----------------------------------------------------------------------------
 ProgressBar::~ProgressBar()
 {
-	m_pszDialogVar.Purge();
+    m_pszDialogVar.Purge();
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
-void ProgressBar::SetSegmentInfo( int gap, int width )
+void ProgressBar::SetSegmentInfo(int gap, int width)
 {
-	_segmentGap = gap;
-	_segmentWide = width;
+    _segmentGap = gap;
+    _segmentWide = width;
 }
 
 void ProgressBar::SetProgressText()
@@ -76,106 +67,100 @@ void ProgressBar::SetProgressText()
 //-----------------------------------------------------------------------------
 int ProgressBar::GetDrawnSegmentCount()
 {
-	int wide, tall;
-	GetSize(wide, tall);
-	int segmentTotal = wide / (_segmentGap + _segmentWide);
-	return (int)(segmentTotal * _progress);
+    int wide, tall;
+    GetSize(wide, tall);
+    int segmentTotal = wide / (_segmentGap + _segmentWide);
+    return static_cast<int>(segmentTotal * _progress);
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::PaintBackground()
 {
-	int wide, tall;
-	GetSize(wide, tall);
+    int wide, tall;
+    GetSize(wide, tall);
 
-	surface()->DrawSetColor(GetBgColor());
-	surface()->DrawFilledRect(0, 0, wide, tall);
+    surface()->DrawSetColor(GetBgColor());
+    surface()->DrawFilledRect(0, 0, wide, tall);
 }
 
-void ProgressBar::PaintSegment( int &x, int &y, int tall, int wide )
+void ProgressBar::PaintSegment(int &x, int &y, int tall, int wide)
 {
-	switch( m_iProgressDirection )
-	{
-	case PROGRESS_EAST:
+    switch(m_iProgressDirection)
+    {
+    case PROGRESS_EAST:
     default:
-		x += _segmentGap;
-		surface()->DrawFilledRect(x, y, x + _segmentWide, y + tall - (y * 2));
-		x += _segmentWide;
-		break;
+        x += _segmentGap;
+        surface()->DrawFilledRect(x, y, x + _segmentWide, y + tall - (y * 2));
+        x += _segmentWide;
+        break;
 
-	case PROGRESS_WEST:
-		x -= _segmentGap + _segmentWide;
-		surface()->DrawFilledRect(x, y, x + _segmentWide, y + tall - (y * 2));
-		break;
+    case PROGRESS_WEST:
+        x -= _segmentGap + _segmentWide;
+        surface()->DrawFilledRect(x, y, x + _segmentWide, y + tall - (y * 2));
+        break;
 
-	case PROGRESS_NORTH:
-		y -= _segmentGap + _segmentWide;
-		surface()->DrawFilledRect(x, y, x + wide - (x * 2), y + _segmentWide );
-		break;
+    case PROGRESS_NORTH:
+        y -= _segmentGap + _segmentWide;
+        surface()->DrawFilledRect(x, y, x + wide - (x * 2), y + _segmentWide);
+        break;
 
-	case PROGRESS_SOUTH:
-		y += _segmentGap;
-		surface()->DrawFilledRect(x, y, x + wide - (x * 2), y + _segmentWide );
-		y += _segmentWide;
-		break;
-	}
+    case PROGRESS_SOUTH:
+        y += _segmentGap;
+        surface()->DrawFilledRect(x, y, x + wide - (x * 2), y + _segmentWide);
+        y += _segmentWide;
+        break;
+    }
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::Paint()
 {
-	int wide, tall;
-	GetSize(wide, tall);
+    int wide, tall;
+    GetSize(wide, tall);
 
-	// gaps
-	int segmentTotal = 0, segmentsDrawn = 0;
-	int x = 0, y = 0;
+    // gaps
+    int segmentTotal = 0, segmentsDrawn = 0;
+    int x = 0, y = 0;
 
-	switch( m_iProgressDirection )
-	{
-	case PROGRESS_WEST:
-		wide -= 2 * m_iBarMargin;
-		x = wide - m_iBarMargin;
-		y = m_iBarInset;
-		segmentTotal = wide / (_segmentGap + _segmentWide);
-		segmentsDrawn = (int)(segmentTotal * _progress);
-		break;
+    switch(m_iProgressDirection)
+    {
+    case PROGRESS_WEST:
+        wide -= 2 * m_iBarMargin;
+        x = wide - m_iBarMargin;
+        y = m_iBarInset;
+        segmentTotal = wide / (_segmentGap + _segmentWide);
+        segmentsDrawn = static_cast<int>(segmentTotal * _progress);
+        break;
 
-	case PROGRESS_EAST:
+    case PROGRESS_EAST:
     default:
-		wide -= 2 * m_iBarMargin;
-		x = m_iBarMargin;
-		y = m_iBarInset;
-		segmentTotal = wide / (_segmentGap + _segmentWide);
-		segmentsDrawn = (int)(segmentTotal * _progress);
-		break;
+        wide -= 2 * m_iBarMargin;
+        x = m_iBarMargin;
+        y = m_iBarInset;
+        segmentTotal = wide / (_segmentGap + _segmentWide);
+        segmentsDrawn = static_cast<int>(segmentTotal * _progress);
+        break;
 
-	case PROGRESS_NORTH:
-		tall -= 2 * m_iBarMargin;
-		x = m_iBarInset;
-		y = tall - m_iBarMargin;
-		segmentTotal = tall / (_segmentGap + _segmentWide);
-		segmentsDrawn = (int)(segmentTotal * _progress);
-		break;
+    case PROGRESS_NORTH:
+        tall -= 2 * m_iBarMargin;
+        x = m_iBarInset;
+        y = tall - m_iBarMargin;
+        segmentTotal = tall / (_segmentGap + _segmentWide);
+        segmentsDrawn = static_cast<int>(segmentTotal * _progress);
+        break;
 
-	case PROGRESS_SOUTH:
-		tall -= 2 * m_iBarMargin;
-		x = m_iBarInset;
-		y = m_iBarMargin;
-		segmentTotal = tall / (_segmentGap + _segmentWide);
-		segmentsDrawn = (int)(segmentTotal * _progress);
-		break;
-	}
+    case PROGRESS_SOUTH:
+        tall -= 2 * m_iBarMargin;
+        x = m_iBarInset;
+        y = m_iBarMargin;
+        segmentTotal = tall / (_segmentGap + _segmentWide);
+        segmentsDrawn = static_cast<int>(segmentTotal * _progress);
+        break;
+    }
 
-	surface()->DrawSetColor(GetFgColor());
-	for (int i = 0; i < segmentsDrawn; i++)
-	{
-		PaintSegment( x, y, tall, wide );
-	}
+    surface()->DrawSetColor(GetFgColor());
+    for (int i = 0; i < segmentsDrawn; i++)
+    {
+        PaintSegment(x, y, tall, wide);
+    }
 }
 
 void ProgressBar::PerformLayout()
@@ -187,49 +172,40 @@ void ProgressBar::PerformLayout()
     m_pProgressPercent->SetSize(wide, tall);
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::SetProgress(float progress)
 {
-	if (progress != _progress)
-	{
-		// clamp the progress value within the range
-		if (progress < 0.0f)
-		{
-			progress = 0.0f;
-		}
-		else if (progress > 1.0f)
-		{
-			progress = 1.0f;
-		}
+    if (progress != _progress)
+    {
+        // clamp the progress value within the range
+        if (progress < 0.0f)
+        {
+            progress = 0.0f;
+        }
+        else if (progress > 1.0f)
+        {
+            progress = 1.0f;
+        }
 
-		_progress = progress;
+        _progress = progress;
 
         SetProgressText();
 
-		Repaint();
-	}
+        Repaint();
+    }
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
 float ProgressBar::GetProgress()
 {
-	return _progress;
+    return _progress;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::ApplySchemeSettings(IScheme *pScheme)
 {
-	Panel::ApplySchemeSettings(pScheme);
+    Panel::ApplySchemeSettings(pScheme);
 
-	SetFgColor(GetSchemeColor("ProgressBar.FgColor", pScheme));
-	SetBgColor(GetSchemeColor("ProgressBar.BgColor", pScheme));
-	SetBorder(pScheme->GetBorder("ButtonDepressedBorder"));
+    SetFgColor(GetSchemeColor("ProgressBar.FgColor", pScheme));
+    SetBgColor(GetSchemeColor("ProgressBar.BgColor", pScheme));
+    SetBorder(pScheme->GetBorder("ButtonDepressedBorder"));
     HFont hProgressFont = pScheme->GetFont(pScheme->GetResourceString("ProgressBar.ProgressTextFont"), IsProportional());
     if (hProgressFont == INVALID_FONT)
         hProgressFont = pScheme->GetFont("DefaultSmall", IsProportional());
@@ -244,127 +220,115 @@ void ProgressBar::ApplySchemeSettings(IScheme *pScheme)
 //-----------------------------------------------------------------------------
 bool ProgressBar::ConstructTimeRemainingString(wchar_t *output, int outputBufferSizeInBytes, float startTime, float currentTime, float currentProgress, float lastProgressUpdateTime, bool addRemainingSuffix)
 {
-	Assert(lastProgressUpdateTime <= currentTime);
-	output[0] = 0;
+    Assert(lastProgressUpdateTime <= currentTime);
+    output[0] = 0;
 
-	// calculate pre-extrapolation values
-	float timeElapsed = lastProgressUpdateTime - startTime;
-	float totalTime = timeElapsed / currentProgress;
+    // calculate pre-extrapolation values
+    float timeElapsed = lastProgressUpdateTime - startTime;
+    float totalTime = timeElapsed / currentProgress;
 
-	// calculate seconds
-	int secondsRemaining = (int)(totalTime - timeElapsed);
-	if (lastProgressUpdateTime < currentTime)
-	{
-		// old update, extrapolate
-		float progressRate = currentProgress / timeElapsed;
-		float extrapolatedProgress = progressRate * (currentTime - startTime);
-		float extrapolatedTotalTime = (currentTime - startTime) / extrapolatedProgress;
-		secondsRemaining = (int)(extrapolatedTotalTime - timeElapsed);
-	}
-	// if there's some time, make sure it's at least one second left
-	if ( secondsRemaining == 0 && ( ( totalTime - timeElapsed ) > 0 ) )
-	{
-		secondsRemaining = 1;
-	}
+    // calculate seconds
+    int secondsRemaining = static_cast<int>(totalTime - timeElapsed);
+    if (lastProgressUpdateTime < currentTime)
+    {
+        // old update, extrapolate
+        float progressRate = currentProgress / timeElapsed;
+        float extrapolatedProgress = progressRate * (currentTime - startTime);
+        float extrapolatedTotalTime = (currentTime - startTime) / extrapolatedProgress;
+        secondsRemaining = static_cast<int>(extrapolatedTotalTime - timeElapsed);
+    }
+    // if there's some time, make sure it's at least one second left
+    if (secondsRemaining == 0 && ((totalTime - timeElapsed) > 0))
+    {
+        secondsRemaining = 1;
+    }
 
-	// calculate minutes
-	int minutesRemaining = 0;
-	while (secondsRemaining >= 60)
-	{
-		minutesRemaining++;
-		secondsRemaining -= 60;
-	}
+    // calculate minutes
+    int minutesRemaining = 0;
+    while (secondsRemaining >= 60)
+    {
+        minutesRemaining++;
+        secondsRemaining -= 60;
+    }
 
     char minutesBuf[16];
-    Q_snprintf(minutesBuf, sizeof( minutesBuf ), "%d", minutesRemaining);
+    Q_snprintf(minutesBuf, sizeof(minutesBuf), "%d", minutesRemaining);
     char secondsBuf[16];
-    Q_snprintf(secondsBuf, sizeof( secondsBuf ), "%d", secondsRemaining);
+    Q_snprintf(secondsBuf, sizeof(secondsBuf), "%d", secondsRemaining);
 
-	if (minutesRemaining > 0)
-	{
-		wchar_t unicodeMinutes[16];
-		g_pVGuiLocalize->ConvertANSIToUnicode(minutesBuf, unicodeMinutes, sizeof( unicodeMinutes ));
-		wchar_t unicodeSeconds[16];
-		g_pVGuiLocalize->ConvertANSIToUnicode(secondsBuf, unicodeSeconds, sizeof( unicodeSeconds ));
+    if (minutesRemaining > 0)
+    {
+        wchar_t unicodeMinutes[16];
+        g_pVGuiLocalize->ConvertANSIToUnicode(minutesBuf, unicodeMinutes, sizeof(unicodeMinutes));
+        wchar_t unicodeSeconds[16];
+        g_pVGuiLocalize->ConvertANSIToUnicode(secondsBuf, unicodeSeconds, sizeof(unicodeSeconds));
 
-		const char *unlocalizedString = "#vgui_TimeLeftMinutesSeconds";
-		if (minutesRemaining == 1 && secondsRemaining == 1)
-		{
-			unlocalizedString = "#vgui_TimeLeftMinuteSecond";
-		}
-		else if (minutesRemaining == 1)
-		{
-			unlocalizedString = "#vgui_TimeLeftMinuteSeconds";
-		}
-		else if (secondsRemaining == 1)
-		{
-			unlocalizedString = "#vgui_TimeLeftMinutesSecond";
-		}
+        const char *unlocalizedString = "#vgui_TimeLeftMinutesSeconds";
+        if (minutesRemaining == 1 && secondsRemaining == 1)
+        {
+            unlocalizedString = "#vgui_TimeLeftMinuteSecond";
+        }
+        else if (minutesRemaining == 1)
+        {
+            unlocalizedString = "#vgui_TimeLeftMinuteSeconds";
+        }
+        else if (secondsRemaining == 1)
+        {
+            unlocalizedString = "#vgui_TimeLeftMinutesSecond";
+        }
 
-		char unlocString[64];
-		Q_strncpy(unlocString, unlocalizedString,sizeof( unlocString ));
-		if (addRemainingSuffix)
-		{
-			Q_strncat(unlocString, "Remaining", sizeof(unlocString ), COPY_ALL_CHARACTERS);
-		}
-		g_pVGuiLocalize->ConstructString(output, outputBufferSizeInBytes, g_pVGuiLocalize->Find(unlocString), 2, unicodeMinutes, unicodeSeconds);
+        char unlocString[64];
+        Q_strncpy(unlocString, unlocalizedString,sizeof(unlocString));
+        if (addRemainingSuffix)
+        {
+            Q_strncat(unlocString, "Remaining", sizeof(unlocString), COPY_ALL_CHARACTERS);
+        }
+        g_pVGuiLocalize->ConstructString(output, outputBufferSizeInBytes, g_pVGuiLocalize->Find(unlocString), 2, unicodeMinutes, unicodeSeconds);
 
-	}
-	else if (secondsRemaining > 0)
-	{
-		wchar_t unicodeSeconds[16];
-		g_pVGuiLocalize->ConvertANSIToUnicode(secondsBuf, unicodeSeconds, sizeof( unicodeSeconds ));
+    }
+    else if (secondsRemaining > 0)
+    {
+        wchar_t unicodeSeconds[16];
+        g_pVGuiLocalize->ConvertANSIToUnicode(secondsBuf, unicodeSeconds, sizeof(unicodeSeconds));
 
-		const char *unlocalizedString = "#vgui_TimeLeftSeconds";
-		if (secondsRemaining == 1)
-		{
-			unlocalizedString = "#vgui_TimeLeftSecond";
-		}
-		char unlocString[64];
-		Q_strncpy(unlocString, unlocalizedString,sizeof(unlocString));
-		if (addRemainingSuffix)
-		{
-			Q_strncat(unlocString, "Remaining",sizeof(unlocString), COPY_ALL_CHARACTERS);
-		}
-		g_pVGuiLocalize->ConstructString(output, outputBufferSizeInBytes, g_pVGuiLocalize->Find(unlocString), 1, unicodeSeconds);
-	}
-	else
-	{
-		return false;
-	}
-	return true;
+        const char *unlocalizedString = "#vgui_TimeLeftSeconds";
+        if (secondsRemaining == 1)
+        {
+            unlocalizedString = "#vgui_TimeLeftSecond";
+        }
+        char unlocString[64];
+        Q_strncpy(unlocString, unlocalizedString,sizeof(unlocString));
+        if (addRemainingSuffix)
+        {
+            Q_strncat(unlocString, "Remaining",sizeof(unlocString), COPY_ALL_CHARACTERS);
+        }
+        g_pVGuiLocalize->ConstructString(output, outputBufferSizeInBytes, g_pVGuiLocalize->Find(unlocString), 1, unicodeSeconds);
+    }
+    else
+    {
+        return false;
+    }
+    return true;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
-void ProgressBar::SetBarInset( int pixels )
+void ProgressBar::SetBarInset(int pixels)
 { 
-	m_iBarInset = pixels;
+    m_iBarInset = pixels;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
-int ProgressBar::GetBarInset( void )
+int ProgressBar::GetBarInset()
 {
-	return m_iBarInset;
+    return m_iBarInset;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
-void ProgressBar::SetMargin( int pixels )
+void ProgressBar::SetMargin(int pixels)
 { 
-	m_iBarMargin = pixels;
+    m_iBarMargin = pixels;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: data accessor
-//-----------------------------------------------------------------------------
 int ProgressBar::GetMargin()
 {
-	return m_iBarMargin;
+    return m_iBarMargin;
 }
 
 void ProgressBar::SetShouldDrawPercentString(bool bDraw)
@@ -372,39 +336,33 @@ void ProgressBar::SetShouldDrawPercentString(bool bDraw)
     m_pProgressPercent->SetVisible(bDraw);
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::ApplySettings(KeyValues *inResourceData)
 {
-	_progress = inResourceData->GetFloat("progress", 0.0f);
+    _progress = inResourceData->GetFloat("progress", 0.0f);
 
     _segmentGap = inResourceData->GetInt("segment_gap", 4);
     _segmentWide = inResourceData->GetInt("segment_width", 8);
 
-	const char *dialogVar = inResourceData->GetString("variable", "");
-	if (dialogVar && *dialogVar)
-	{
+    const char *dialogVar = inResourceData->GetString("variable", "");
+    if (dialogVar && *dialogVar)
+    {
         m_pszDialogVar.Purge();
-		m_pszDialogVar = dialogVar;
-	}
+        m_pszDialogVar = dialogVar;
+    }
 
     if (inResourceData->FindKey("draw_percent"))
         SetShouldDrawPercentString(inResourceData->GetBool("draw_percent"));
 
-	BaseClass::ApplySettings(inResourceData);
+    BaseClass::ApplySettings(inResourceData);
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ProgressBar::GetSettings(KeyValues *outResourceData)
 {
-	BaseClass::GetSettings(outResourceData);
-	outResourceData->SetFloat("progress", _progress );
+    BaseClass::GetSettings(outResourceData);
+    outResourceData->SetFloat("progress", _progress);
     outResourceData->SetInt("segment_gap", _segmentGap);
     outResourceData->SetInt("segment_width", _segmentWide);
-	outResourceData->SetString("variable", m_pszDialogVar);
+    outResourceData->SetString("variable", m_pszDialogVar);
     outResourceData->SetBool("draw_percent", m_pProgressPercent->IsVisible());
 }
 
@@ -424,54 +382,48 @@ void ProgressBar::InitSettings()
 //-----------------------------------------------------------------------------
 void ProgressBar::OnDialogVariablesChanged(KeyValues *dialogVariables)
 {
-	if (!m_pszDialogVar.IsEmpty())
-	{
-		int val = dialogVariables->GetInt(m_pszDialogVar, -1);
-		if (val >= 0.0f)
-		{
-			SetProgress(val / 100.0f);
-		}
-	}
+    if (!m_pszDialogVar.IsEmpty())
+    {
+        int val = dialogVariables->GetInt(m_pszDialogVar, -1);
+        if (val >= 0.0f)
+        {
+            SetProgress(val / 100.0f);
+        }
+    }
 }
 
 
-DECLARE_BUILD_FACTORY( ContinuousProgressBar );
+DECLARE_BUILD_FACTORY(ContinuousProgressBar);
 
-//-----------------------------------------------------------------------------
-// Purpose: Constructor
-//-----------------------------------------------------------------------------
 ContinuousProgressBar::ContinuousProgressBar(Panel *parent, const char *panelName) : ProgressBar(parent, panelName)
 {
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 void ContinuousProgressBar::Paint()
 {
-	int x = 0, y = 0;
-	int wide, tall;
-	GetSize(wide, tall);
+    int x = 0, y = 0;
+    int wide, tall;
+    GetSize(wide, tall);
 
-	surface()->DrawSetColor(GetFgColor());
+    surface()->DrawSetColor(GetFgColor());
 
-	switch( m_iProgressDirection )
-	{
-	case PROGRESS_EAST:
+    switch(m_iProgressDirection)
+    {
+    case PROGRESS_EAST:
     default:
-		surface()->DrawFilledRect( x, y, x + (int)( wide * _progress ), y + tall );
-		break;
+        surface()->DrawFilledRect(x, y, x + static_cast<int>(wide * _progress), y + tall);
+        break;
 
-	case PROGRESS_WEST:
-		surface()->DrawFilledRect( x + (int)( wide * ( 1.0f - _progress ) ), y, x + wide, y + tall );
-		break;
+    case PROGRESS_WEST:
+        surface()->DrawFilledRect(x + static_cast<int>(wide * (1.0f - _progress)), y, x + wide, y + tall);
+        break;
 
-	case PROGRESS_NORTH:
-		surface()->DrawFilledRect( x, y + (int)( tall * ( 1.0f - _progress ) ), x + wide, y + tall );
-		break;
+    case PROGRESS_NORTH:
+        surface()->DrawFilledRect(x, y + static_cast<int>(tall * (1.0f - _progress)), x + wide, y + tall);
+        break;
 
-	case PROGRESS_SOUTH:
-		surface()->DrawFilledRect( x, y, x + wide, y + (int)( tall * _progress ) );
-		break;
-	}
+    case PROGRESS_SOUTH:
+        surface()->DrawFilledRect(x, y, x + wide, y + static_cast<int>(tall * _progress));
+        break;
+    }
 }


### PR DESCRIPTION
Closes #786 

Adds functionality for progress bars to have subdivision markings. Can be set in code or in res file. Works for horizontal filling progress bars (`PROGRESS_EAST` & `PROGRESS_WEST`) and also vertical filling ones (`PROGRESS_SOUTH` & `PROGRESS_NORTH`). Includes the number of subdivisions, their width, their color, and their visibility.

Added the appropriate fields for this in the charge meter's control resource, though it is off by default.

Had to add an extra "hidden" field to allow code to toggle the drawing without losing the user-defined visibility of it in the res file. Done as it should be hidden when charge meter is disabled.

Also changed to lower case `override`, converted to spaces instead of tabs, `(int)` casts to `static_cast<int>`, and removed duh comments and empty "purpose" blocks.

Horizontal:
![image](https://user-images.githubusercontent.com/9014762/89261209-8772e300-d5e2-11ea-9c25-9bcaa7a173cf.png)
Vertical:
![image](https://user-images.githubusercontent.com/9014762/89261307-b0937380-d5e2-11ea-9f43-33d7e1a4f4a6.png)

Currently have this drawn in `Paint()`, mainly because I believe the markings should display overtop the progress. Is there a way to just draw this on applying settings but have the Z be over the progress bar?
Also thinking about moving the chargemeter stuff to listen for zone enter/exit so some logic can be taken out of its `OnThink()`, but for a separate PR.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review