### PR TITLE
Fix for leaderboard's mouse input being enabled on game startup

### DIFF
--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -58,6 +58,9 @@ CClientTimesDisplay::CClientTimesDisplay(IViewPort *pViewPort) : EditablePanel(n
     // update scoreboard instantly if one of these events occur
     ListenForGameEvent("replay_save");
     ListenForGameEvent("run_upload");
+
+    // can be toggled on at start of game launch if starts visible
+    SetVisible(false);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #887 

Happening because the leaderboard's mouse input could be enabled via code in [`clientmode_mom_normal.cpp`](https://github.com/momentum-mod/game/blob/d6d1262cc5157b71b508755de3f60dc7cbc9f3dd/mp/src/game/client/momentum/clientmode_mom_normal.cpp#L169), because it started as visible.

This sets the panel not visible at construction to avoid capturing mouse2 input at game startup.

Tested that it still toggles in game as well.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review