### PR TITLE
IsObserver check in LoadAppearance

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -409,6 +409,9 @@ void CMomentumPlayer::FlashlightToggle(bool bOn, bool bEmitSound)
 
 void CMomentumPlayer::LoadAppearance(bool bForceUpdate)
 {
+    if (IsObserver())
+        return;
+
     AppearanceData_t newData;
     uint32 newHexColor = MomUtil::GetHexFromColor(mom_trail_color.GetString());
     newData.m_iTrailRGBAColorAsHex = newHexColor;


### PR DESCRIPTION
If observing, return out of LoadAppearance, it'll get called by Spawn after finish speccing

Closes #844 

Tested with ghost replays and online in lobbies with Brae

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
