### PR TITLE
Enhance/surface interactions

### DIFF
--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -92,7 +92,7 @@ public:
     // Last collision
     void SetLastCollision(const trace_t &tr);
     int GetLastCollisionTick() const { return m_iLastCollisionTick; }
-    trace_t& GetLastCollisionTrace() { return m_trLastCollisionTrace; }
+    const trace_t& GetLastCollisionTrace() const { return m_trLastCollisionTrace; }
 
     // Mobility sound functions
     void PlayStepSound(const Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force) override;

--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -6,6 +6,42 @@
 class C_MomentumOnlineGhostEntity;
 class C_MomentumReplayGhostEntity;
 
+struct SurfaceInteraction
+{
+    enum Type
+    {
+        TYPE_LEAVE = 0,
+        TYPE_FLOOR,
+        TYPE_WALL,
+        TYPE_CEILING,
+        TYPE_LAND,
+        TYPE_GROUNDED,
+        TYPE_COUNT
+    };
+
+    enum Action
+    {
+        ACTION_LEAVE = 0,
+        ACTION_KNOCKBACK,
+        ACTION_WALK,
+        ACTION_DUCKWALK,
+        ACTION_JUMP,
+        ACTION_DUCKJUMP,
+        ACTION_CTAP,
+        ACTION_COLLISION,
+        ACTION_SLIDE,
+        ACTION_EDGEBUG,
+        ACTION_LAND,
+        ACTION_GROUNDED,
+    };
+
+    int tick;
+    trace_t trace;
+    Vector velocity;
+    Action action;
+};
+typedef SurfaceInteraction SurfInt;
+
 class C_MomentumPlayer : public C_BasePlayer, public CMomRunEntity
 {
 public:
@@ -89,10 +125,11 @@ public:
     float GetGrabbableLadderTime() const { return m_flGrabbableLadderTime; }
     void SetGrabbableLadderTime(float new_time) { m_flGrabbableLadderTime = new_time; }
 
-    // Last collision
-    void SetLastCollision(const trace_t &tr);
-    int GetLastCollisionTick() const { return m_iLastCollisionTick; }
-    const trace_t& GetLastCollisionTrace() const { return m_trLastCollisionTrace; }
+    // Surface interactions
+    int GetInteractionIndex(SurfInt::Type type) const;
+    const SurfInt& GetInteraction(int index) const;
+    bool SetLastInteraction(const trace_t &tr, const Vector &velocity, SurfInt::Type type);
+    void UpdateLastAction(SurfInt::Action action);
 
     // Mobility sound functions
     void PlayStepSound(const Vector &vecOrigin, surfacedata_t *psurface, float fvol, bool force) override;
@@ -138,9 +175,9 @@ private:
     // Ladder stuff
     float m_flGrabbableLadderTime;
 
-    // Last collision
-    int m_iLastCollisionTick; // Tick at which the player last collided with a non-vertical surface
-    trace_t m_trLastCollisionTrace; // (startpos and endpos raised up to player head for ceilings)
+    // List of airborne surface interations and start and end ground interactions
+    SurfInt m_surfIntList[SurfInt::TYPE_COUNT]; // Stores interactions by type
+    SurfInt::Type m_surfIntHistory[SurfInt::TYPE_COUNT]; // Keeps track of the history of interactions
 
     float m_flStamina;
 

--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -6,42 +6,6 @@
 class C_MomentumOnlineGhostEntity;
 class C_MomentumReplayGhostEntity;
 
-struct SurfaceInteraction
-{
-    enum Type
-    {
-        TYPE_LEAVE = 0,
-        TYPE_FLOOR,
-        TYPE_WALL,
-        TYPE_CEILING,
-        TYPE_LAND,
-        TYPE_GROUNDED,
-        TYPE_COUNT
-    };
-
-    enum Action
-    {
-        ACTION_LEAVE = 0,
-        ACTION_KNOCKBACK,
-        ACTION_WALK,
-        ACTION_DUCKWALK,
-        ACTION_JUMP,
-        ACTION_DUCKJUMP,
-        ACTION_CTAP,
-        ACTION_COLLISION,
-        ACTION_SLIDE,
-        ACTION_EDGEBUG,
-        ACTION_LAND,
-        ACTION_GROUNDED,
-    };
-
-    int tick;
-    trace_t trace;
-    Vector velocity;
-    Action action;
-};
-typedef SurfaceInteraction SurfInt;
-
 class C_MomentumPlayer : public C_BasePlayer, public CMomRunEntity
 {
 public:

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -2070,6 +2070,11 @@ void CMomentumPlayer::ApplyPushFromDamage(const CTakeDamageInfo &info, Vector &v
     Vector vecForce = -vecDir * force;
     ApplyAbsVelocityImpulse(vecForce);
 
+    if (GetFlags() & FL_ONGROUND)
+    {
+        UpdateLastAction(SurfInt::ACTION_KNOCKBACK);
+    }
+
     IGameEvent *pEvent = gameeventmanager->CreateEvent("player_explosive_hit");
     if (pEvent)
     {

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -12,42 +12,6 @@ class CTriggerProgress;
 class CTriggerSlide;
 class CMomentumGhostBaseEntity;
 
-struct SurfaceInteraction
-{
-    enum Type
-    {
-        TYPE_LEAVE = 0,
-        TYPE_FLOOR,
-        TYPE_WALL,
-        TYPE_CEILING,
-        TYPE_LAND,
-        TYPE_GROUNDED,
-        TYPE_COUNT
-    };
-
-    enum Action
-    {
-        ACTION_LEAVE = 0,
-        ACTION_KNOCKBACK,
-        ACTION_WALK,
-        ACTION_DUCKWALK,
-        ACTION_JUMP,
-        ACTION_DUCKJUMP,
-        ACTION_CTAP,
-        ACTION_COLLISION,
-        ACTION_SLIDE,
-        ACTION_EDGEBUG,
-        ACTION_LAND,
-        ACTION_GROUNDED,
-    };
-
-    int tick;
-    trace_t trace;
-    Vector velocity;
-    Action action;
-};
-typedef SurfaceInteraction SurfInt;
-
 struct SavedState_t
 {
     char m_pszTargetName[128];// Saved player targetname

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -244,7 +244,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     // Last collision
     void SetLastCollision(const trace_t &tr);
     int GetLastCollisionTick() const { return m_iLastCollisionTick; }
-    trace_t& GetLastCollisionTrace() { return m_trLastCollisionTrace; }
+    const trace_t& GetLastCollisionTrace() const { return m_trLastCollisionTrace; }
 
     void SetLastEyeAngles(const QAngle &ang) { m_qangLastAngle = ang; }
     const QAngle &LastEyeAngles() const { return m_qangLastAngle; }

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -12,6 +12,42 @@ class CTriggerProgress;
 class CTriggerSlide;
 class CMomentumGhostBaseEntity;
 
+struct SurfaceInteraction
+{
+    enum Type
+    {
+        TYPE_LEAVE = 0,
+        TYPE_FLOOR,
+        TYPE_WALL,
+        TYPE_CEILING,
+        TYPE_LAND,
+        TYPE_GROUNDED,
+        TYPE_COUNT
+    };
+
+    enum Action
+    {
+        ACTION_LEAVE = 0,
+        ACTION_KNOCKBACK,
+        ACTION_WALK,
+        ACTION_DUCKWALK,
+        ACTION_JUMP,
+        ACTION_DUCKJUMP,
+        ACTION_CTAP,
+        ACTION_COLLISION,
+        ACTION_SLIDE,
+        ACTION_EDGEBUG,
+        ACTION_LAND,
+        ACTION_GROUNDED,
+    };
+
+    int tick;
+    trace_t trace;
+    Vector velocity;
+    Action action;
+};
+typedef SurfaceInteraction SurfInt;
+
 struct SavedState_t
 {
     char m_pszTargetName[128];// Saved player targetname
@@ -241,10 +277,11 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     float GetGrabbableLadderTime() const { return m_flGrabbableLadderTime; }
     void SetGrabbableLadderTime(float new_time) { m_flGrabbableLadderTime = new_time; }
 
-    // Last collision
-    void SetLastCollision(const trace_t &tr);
-    int GetLastCollisionTick() const { return m_iLastCollisionTick; }
-    const trace_t& GetLastCollisionTrace() const { return m_trLastCollisionTrace; }
+    // Surface interactions
+    int GetInteractionIndex(SurfInt::Type type) const;
+    const SurfInt& GetInteraction(int index) const;
+    bool SetLastInteraction(const trace_t &tr, const Vector &velocity, SurfInt::Type type);
+    void UpdateLastAction(SurfInt::Action action);
 
     void SetLastEyeAngles(const QAngle &ang) { m_qangLastAngle = ang; }
     const QAngle &LastEyeAngles() const { return m_qangLastAngle; }
@@ -361,9 +398,9 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     // Ladder stuff
     float m_flGrabbableLadderTime;
 
-    // Last collision
-    int m_iLastCollisionTick; // Tick at which the player last collided with a non-vertical surface
-    trace_t m_trLastCollisionTrace; // (startpos and endpos raised up to player head for ceilings)
+    // List of airborne surface interations and start and end ground interactions
+    SurfInt m_surfIntList[SurfInt::TYPE_COUNT]; // Stores interactions by type
+    SurfInt::Type m_surfIntHistory[SurfInt::TYPE_COUNT]; // Keeps track of the history of interactions
 
     // Trigger stuff
     CUtlVector<CTriggerOnehop*> m_vecOnehops;

--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -899,7 +899,7 @@ void CBasePlayer::UpdateWetness()
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CGameMovement::CategorizeGroundSurface( trace_t &pm )
+void CGameMovement::CategorizeGroundSurface( const trace_t &pm )
 {
 	IPhysicsSurfaceProps *pPhysprops = MoveHelper()->GetSurfaceProps();
 	player->m_surfaceProps = pm.surface.surfaceProps;
@@ -3567,7 +3567,7 @@ bool CGameMovement::CheckWater( void )
 	return (player->GetWaterLevel() > WL_Feet);
 }
 
-void CGameMovement::SetGroundEntity( trace_t *pm )
+void CGameMovement::SetGroundEntity( const trace_t *pm )
 {
 	CBaseEntity *newGround = pm ? pm->m_pEnt : nullptr;
 

--- a/mp/src/game/shared/gamemovement.h
+++ b/mp/src/game/shared/gamemovement.h
@@ -233,7 +233,7 @@ protected:
 
 	float			SplineFraction( float value, float scale );
 
-	void			CategorizeGroundSurface( trace_t &pm );
+	void			CategorizeGroundSurface( const trace_t &pm );
 
 	bool			InWater( void );
 
@@ -251,7 +251,7 @@ protected:
 	// Figures out how the constraint should slow us down
 	float			ComputeConstraintSpeedFactor( void );
 
-	virtual void	SetGroundEntity( trace_t *pm );
+	virtual void	SetGroundEntity( const trace_t *pm );
 
 	virtual void	StepMove( Vector &vecDestination, trace_t &trace );
 

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1985,7 +1985,7 @@ void CMomentumGameMovement::FullWalkMove()
         }
 
         // Let player bhop after an edgebug
-        trace_t &tr = m_pPlayer->GetLastCollisionTrace();
+        const trace_t &tr = m_pPlayer->GetLastCollisionTrace();
         if (sv_edge_fix.GetBool() && !bIsSliding &&
             bInAirBefore && bInAirAfter && m_pPlayer->GetLastCollisionTick() == gpGlobals->tickcount && // Player edgebugged
             (m_pPlayer->HasAutoBhop() && (mv->m_nButtons & IN_JUMP)) && // Player wants to bhop
@@ -2792,7 +2792,7 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
     return blocked;
 }
 
-void CMomentumGameMovement::SetGroundEntity(trace_t *pm)
+void CMomentumGameMovement::SetGroundEntity(const trace_t *pm)
 {
     // We check jump button because the player might want jumping while sliding
     // And it's more fun like this

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2557,9 +2557,13 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
         {
             SurfInt::Type type = SurfInt::TYPE_WALL;
             if (pm.plane.normal.z > 0.0f)
+            {
                 type = SurfInt::TYPE_FLOOR;
+            }
             else if (pm.plane.normal.z < 0.0f)
+            {
                 type = SurfInt::TYPE_CEILING;
+            }
             
             m_pPlayer->SetLastInteraction(pm, mv->m_vecVelocity, type);
         }

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -17,7 +17,7 @@ class CMomentumGameMovement : public CGameMovement
 public:
     CMomentumGameMovement();
 
-    void SetGroundEntity(trace_t *pm) override;
+    void SetGroundEntity(const trace_t *pm) override;
 
     bool CanAccelerate() override;
     bool CheckJumpButton() override;

--- a/mp/src/game/shared/momentum/run/mom_run_entity.h
+++ b/mp/src/game/shared/momentum/run/mom_run_entity.h
@@ -12,6 +12,42 @@ class CTriggerZone;
 class CMomExplosive;
 #endif
 
+struct SurfaceInteraction
+{
+    enum Type
+    {
+        TYPE_LEAVE = 0,
+        TYPE_FLOOR,
+        TYPE_WALL,
+        TYPE_CEILING,
+        TYPE_LAND,
+        TYPE_GROUNDED,
+        TYPE_COUNT
+    };
+
+    enum Action
+    {
+        ACTION_LEAVE = 0,
+        ACTION_KNOCKBACK,
+        ACTION_WALK,
+        ACTION_DUCKWALK,
+        ACTION_JUMP,
+        ACTION_DUCKJUMP,
+        ACTION_CTAP,
+        ACTION_COLLISION,
+        ACTION_SLIDE,
+        ACTION_EDGEBUG,
+        ACTION_LAND,
+        ACTION_GROUNDED,
+    };
+
+    int tick;
+    trace_t trace;
+    Vector velocity;
+    Action action;
+};
+typedef SurfaceInteraction SurfInt;
+
 enum RUN_ENT_TYPE
 {
     RUN_ENT_PLAYER = 0, // Local player


### PR DESCRIPTION
Introduces a system that keeps a history of how the player interacted with surfaces from leaving the ground to getting grounded again. The history always gets reset when the player leaves the ground, but will be kept until then. The system only keeps track of 6 types of interactions, so some will potentially be overridden if the same interaction type happens again. The types of interactions are leaving the ground, collisions with floors (positive z normal), walls (zero z normal), ceilings (negative z normal), landing, and grounded interactions after landing. Each entry in the history keeps the tick, the collision trace, and the player velocity prior to the collision. Entries additionally also have "actions" that can specify if the player did anything special while in contact with the surface, for example jumping when leaving the ground.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
