### PR TITLE
Speedometer autolayout setting

### DIFF
--- a/mp/game/momentum/cfg/speedometer_default.vdf
+++ b/mp/game/momentum/cfg/speedometer_default.vdf
@@ -3,7 +3,59 @@
     
     "#MOM_GameType_Unknown"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            "HudSpeedMeter"
+            {
+                "xpos" "c-60"
+                "ypos" "c+22"
+                "wide" "120"
+                "tall" "60"
+            }
+            "AbsSpeedometer"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "HorizSpeedometer"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "VertSpeedometer"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "ExplosiveJumpVelocity"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "LastJumpVelocity"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "RampBoardVelocity"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "RampLeaveVelocity"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+            "StageEnterExitVelocity"
+            {
+                "xpos" "0"
+                "ypos" "0"
+            }
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -60,7 +112,13 @@
     
     "#MOM_GameType_Surf"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -117,7 +175,13 @@
 
     "#MOM_GameType_Bhop"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -170,7 +234,13 @@
 
     "#MOM_GameType_RJ"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -244,7 +314,13 @@
 
     "#MOM_GameType_SJ"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -341,7 +417,13 @@
 
     "#MOM_GameType_Ahop"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"
@@ -394,7 +476,13 @@
 
     "#MOM_GameType_Parkour"
     {
-        "order"
+        "autolayout" "1"
+        "layout" // only used when autolayout is off
+        {
+            // Override control settings here
+            // see "#MOM_GameType_Unknown" for an example
+        }
+        "order" // only used when autolayout is on
         {
             "1" "AbsSpeedometer"
             "2" "HorizSpeedometer"

--- a/mp/game/momentum/resource/ui/Speedometer.res
+++ b/mp/game/momentum/resource/ui/Speedometer.res
@@ -19,12 +19,12 @@
         "fieldName"     "AbsSpeedometer"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersSmallBold"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "HorizSpeedometer"
     {
@@ -32,12 +32,12 @@
         "fieldName"     "HorizSpeedometer"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersSmallBold"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "VertSpeedometer"
     {
@@ -45,12 +45,12 @@
         "fieldName"     "VertSpeedometer"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersSmallBold"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "ExplosiveJumpVelocity"
     {
@@ -58,12 +58,12 @@
         "fieldName"	    "ExplosiveJumpVelocity"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersExtremelySmall"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "LastJumpVelocity"
     {
@@ -71,12 +71,12 @@
         "fieldName"	    "LastJumpVelocity"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersExtremelySmall"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "RampBoardVelocity"
     {
@@ -84,12 +84,12 @@
         "fieldName"	    "RampBoardVelocity"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersExtremelySmall"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "RampLeaveVelocity"
     {
@@ -97,12 +97,12 @@
         "fieldName"	    "RampLeaveVelocity"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersExtremelySmall"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
     "StageEnterExitVelocity"
     {
@@ -110,11 +110,11 @@
         "fieldName"     "StageEnterExitVelocity"
         "xpos"          "0"
         "ypos"          "0"
+        "wide"          "120"
         "textAlignment" "center"
         "font"          "HudNumbersExtremelySmall"
         "FgColor"       "MOM.Speedometer.Normal"
         "wrap"          "0"
         "auto_tall_tocontents" "1"
-        "auto_wide_tocontents" "1"
     }
 }

--- a/mp/src/game/client/client_momentum.vpc
+++ b/mp/src/game/client/client_momentum.vpc
@@ -158,6 +158,8 @@ $Project "Client (Momentum)"
                     $File "momentum\ui\controls\ImageGallery.cpp"
                     $File "momentum\ui\controls\VControlsListPanel.h"
                     $File "momentum\ui\controls\VControlsListPanel.cpp"
+                    $File "momentum\ui\controls\DoubleLabel.h"
+                    $File "momentum\ui\controls\DoubleLabel.cpp"
                 }
 
                 $Folder "Lobby"

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -31,7 +31,7 @@ CHudSpeedMeter *g_pSpeedometer = nullptr;
 
 CHudSpeedMeter::CHudSpeedMeter(const char *pElementName)
     : CHudElement(pElementName), EditablePanel(g_pClientMode->GetViewport(), "HudSpeedMeter"), 
-    m_cvarTimeScale("mom_replay_timescale"), m_pRunStats(nullptr), m_pRunEntData(nullptr), m_iLastZone(0)
+    m_cvarTimeScale("mom_replay_timescale"), m_pRunStats(nullptr), m_pRunEntData(nullptr), m_iLastZone(0), m_bAutoLayout(true)
 {
     ListenForGameEvent("zone_exit");
     ListenForGameEvent("zone_enter");
@@ -81,7 +81,7 @@ CHudSpeedMeter::CHudSpeedMeter(const char *pElementName)
 
     ResetLabelOrder();
 
-    LoadControlSettings("resource/ui/Speedometer.res");
+    LoadControlSettings(GetResFile());
 }
 
 void CHudSpeedMeter::Init()
@@ -183,13 +183,16 @@ void CHudSpeedMeter::ApplySchemeSettings(IScheme *pScheme)
 
 void CHudSpeedMeter::OnReloadControls()
 {
-    BaseClass::OnReloadControls();
+    // no need to call baseclass as controls are reloaded when loading speedo data
     g_pSpeedometerData->LoadGamemodeData(g_pSpeedometerData->GetCurrentlyLoadedGameMode());
 }
 
 void CHudSpeedMeter::PerformLayout()
 {
     EditablePanel::PerformLayout();
+
+    if (!m_bAutoLayout)
+        return;
 
     int iHeightAcc = 0;
     for (auto i = 0; i < m_LabelOrderList.Count(); i++)

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -200,7 +200,7 @@ void CHudSpeedMeter::PerformLayout()
         SpeedometerLabel *pLabel = m_LabelOrderList[i];
         if (pLabel->IsVisible())
         {
-            pLabel->SetPos(pLabel->GetXPos(), iHeightAcc);
+            pLabel->SetYPos(iHeightAcc);
             iHeightAcc += pLabel->GetTall();
         }
     }

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.h
@@ -33,8 +33,15 @@ class CHudSpeedMeter : public CHudElement, public vgui::EditablePanel
 
     void ResetLabelOrder();
 
+    void SetAutoLayout(bool bEnabled) { m_bAutoLayout = bEnabled; }
+    bool GetAutoLayout() const { return m_bAutoLayout; }
+
+    const char* GetResFile() const { return "resource/ui/Speedometer.res"; }
+
   private:
     int m_iLastZone;
+
+    bool m_bAutoLayout;
 
     SpeedometerLabel *m_pAbsSpeedoLabel, *m_pHorizSpeedoLabel, *m_pVertSpeedoLabel, *m_pExplosiveJumpVelLabel,
                      *m_pLastJumpVelLabel, *m_pRampBoardVelLabel, *m_pRampLeaveVelLabel, *m_pStageEnterExitVelLabel;

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
@@ -88,9 +88,7 @@ void SpeedometerLabel::Reset()
 
 void SpeedometerLabel::SetText(int value)
 {
-    char szValue[BUFSIZELOCL];
-    Q_snprintf(szValue, sizeof(szValue), "%i", value);
-    SetPrimaryText(szValue);
+    SetPrimaryText(CFmtStr("%i", value).Get());
 }
 
 void SpeedometerLabel::Update(float value)
@@ -229,10 +227,8 @@ void SpeedometerLabel::ColorizeComparisonSeparate()
     g_pMOMRunCompare->GetDiffColor(m_flDiff, &compareColor, true);
 
     char diffChar = m_flDiff > 0.0f ? '+' : '-';
-    char szText[BUFSIZELOCL];
-    Q_snprintf(szText, BUFSIZELOCL, " (%c %i)", diffChar, RoundFloatToInt(fabs(m_flDiff)));
 
-    SetSecondaryText(szText);
+    SetSecondaryText(CFmtStr(" (%c %i)", diffChar, RoundFloatToInt(fabs(m_flDiff))).Get());
     SetSecondaryFgColor(compareColor);
 }
 
@@ -242,13 +238,11 @@ void SpeedometerLabel::SaveToKV(KeyValues* pOut)
     pOut->SetBool("visible", IsVisible());
     pOut->SetInt("colorize", GetColorizeType());
     KeyValues *pRangesKV = pOut->FindKey("ranges", true);
-    char tmp[BUFSIZELOCL];
 
     FOR_EACH_VEC(m_vecRangeList, i)
     {
         Range_t range = m_vecRangeList[i];
-        Q_snprintf(tmp, BUFSIZELOCL, "%i", i + 1);
-        KeyValues *rangeKV = pRangesKV->FindKey(tmp, true);
+        KeyValues *rangeKV = pRangesKV->FindKey(CFmtStr("%i", i + 1).Get(), true);
         rangeKV->SetInt("min", range.min);
         rangeKV->SetInt("max", range.max);
         rangeKV->SetColor("color", range.color);

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
@@ -8,6 +8,7 @@
 #include "iclientmode.h"
 #include "momentum/util/mom_util.h"
 #include "mom_player_shared.h"
+#include "fmtstr.h"
 
 #include "tier0/memdbgon.h"
 
@@ -24,30 +25,16 @@ using namespace vgui;
 extern ConVar sv_gravity;
 
 SpeedometerLabel::SpeedometerLabel(Panel *parent, const char *panelName, SpeedometerColorize_t colorizeType)
-    : Label(parent, panelName, ""), m_eColorizeType(colorizeType), m_pflAlpha(nullptr),
-      m_bSupportsEnergyUnits(false), m_bDoneFading(false),
+    : DoubleLabel(parent, panelName, CFmtStr("%sComparison", panelName).Get()), m_eColorizeType(colorizeType),
+      m_pflAlpha(nullptr), m_bSupportsEnergyUnits(false), m_bDoneFading(false),
       m_eUnitType(SPEEDOMETER_UNITS_UPS), m_bDrawComparison(true), m_bSupportsSeparateComparison(true)
 {
-    // create a separate label for the comparison & pin it to this
-    char name[BUFSIZELOCL];
-    Q_snprintf(name, sizeof(name), "%sComparison", GetName());
-    m_pComparisonLabel = new Label(GetParent(), name, "");
-    m_pComparisonLabel->SetName(name);
-    m_pComparisonLabel->SetPos(0, 0);
-    m_pComparisonLabel->PinToSibling(GetName(), PIN_TOPLEFT, PIN_TOPRIGHT);
-    m_pComparisonLabel->SetFont(GetFont());
-    m_pComparisonLabel->SetAutoTall(true);
-    m_pComparisonLabel->SetAutoWide(true);
-    m_pComparisonLabel->SetContentAlignment(a_center);
-    m_pComparisonLabel->SetPinCorner(PIN_TOPLEFT, 0, 0);
-
     Reset();
 }
 
 void SpeedometerLabel::SetVisible(bool bVisible)
 {
-    m_pComparisonLabel->SetVisible(bVisible && m_bDrawComparison);
-    BaseClass::SetVisible(bVisible);
+    BaseClass::SetVisible(bVisible, bVisible && m_bDrawComparison);
     // parent's layout depends on the visibility of this, so invalidate it
     GetParent()->InvalidateLayout();
 }
@@ -64,30 +51,7 @@ void SpeedometerLabel::ApplySchemeSettings(IScheme *pScheme)
     m_NormalColor = GetSchemeColor("MOM.Speedometer.Normal", pScheme);
     m_IncreaseColor = GetSchemeColor("MOM.Speedometer.Increase", pScheme);
     m_DecreaseColor = GetSchemeColor("MOM.Speedometer.Decrease", pScheme);
-    m_pComparisonLabel->SetFont(GetFont());
     Reset();
-}
-
-void SpeedometerLabel::PerformLayout()
-{
-    BaseClass::PerformLayout();
-
-    // keep centered in parent
-    char szMain[BUFSIZELOCL];
-    GetText(szMain, BUFSIZELOCL);
-
-    HFont labelFont = GetFont();
-    int combinedLength = UTIL_ComputeStringWidth(labelFont, szMain);
-
-    if (m_eColorizeType == SPEEDOMETER_COLORIZE_COMPARISON_SEPARATE && m_bDrawComparison)
-    {
-        char szComparison[BUFSIZELOCL];
-        m_pComparisonLabel->GetText(szComparison, BUFSIZELOCL);
-        combinedLength += UTIL_ComputeStringWidth(labelFont, szComparison);
-    }
-
-    int xOffset = (GetParent()->GetWide() - combinedLength) / 2;
-    SetPos(xOffset, GetYPos());
 }
 
 void SpeedometerLabel::OnThink()
@@ -98,7 +62,6 @@ void SpeedometerLabel::OnThink()
         return;
 
     SetAlpha(*m_pflAlpha);
-    m_pComparisonLabel->SetAlpha(*m_pflAlpha);
 
     if (CloseEnough(*m_pflAlpha, 0.0f, FLT_EPSILON))
     {
@@ -118,8 +81,7 @@ void SpeedometerLabel::Reset()
     m_bDrawComparison = true;
     m_bDoneFading = true;
 
-    m_pComparisonLabel->SetText("");
-    BaseClass::SetText("");
+    BaseClass::SetText("", "");
 
     SetAlpha(HasFadeOutAnimation() ? 0 : 255);
 }
@@ -128,7 +90,7 @@ void SpeedometerLabel::SetText(int value)
 {
     char szValue[BUFSIZELOCL];
     Q_snprintf(szValue, sizeof(szValue), "%i", value);
-    BaseClass::SetText(szValue);
+    SetPrimaryText(szValue);
 }
 
 void SpeedometerLabel::Update(float value)
@@ -206,7 +168,7 @@ void SpeedometerLabel::Colorize()
         ColorizeComparisonSeparate();
         break;
     default:
-        SetFgColor(m_NormalColor);
+        SetPrimaryFgColor(m_NormalColor);
         break;
     }
 
@@ -241,18 +203,18 @@ void SpeedometerLabel::ColorizeRange()
             break;
         }
     }
-    SetFgColor(newColor);
+    SetPrimaryFgColor(newColor);
 }
 
 void SpeedometerLabel::ColorizeComparison()
 {
     m_flDiff = m_flCurrentValue - m_flPastValue;
-    SetFgColor(MomUtil::GetColorFromVariation(m_flDiff, COLORIZE_DEADZONE, m_NormalColor, m_IncreaseColor, m_DecreaseColor));
+    SetPrimaryFgColor(MomUtil::GetColorFromVariation(m_flDiff, COLORIZE_DEADZONE, m_NormalColor, m_IncreaseColor, m_DecreaseColor));
 }
 
 void SpeedometerLabel::ColorizeComparisonSeparate()
 {
-    SetFgColor(m_NormalColor);
+    SetPrimaryFgColor(m_NormalColor);
 
     if (!m_bDrawComparison)
         return;
@@ -270,8 +232,8 @@ void SpeedometerLabel::ColorizeComparisonSeparate()
     char szText[BUFSIZELOCL];
     Q_snprintf(szText, BUFSIZELOCL, " (%c %i)", diffChar, RoundFloatToInt(fabs(m_flDiff)));
 
-    m_pComparisonLabel->SetText(szText);
-    m_pComparisonLabel->SetFgColor(compareColor);
+    SetSecondaryText(szText);
+    SetSecondaryFgColor(compareColor);
 }
 
 void SpeedometerLabel::SaveToKV(KeyValues* pOut)

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vgui_controls/Label.h>
+#include "controls/DoubleLabel.h"
 #include "mom_shareddefs.h"
 
 // for ranged based coloring
@@ -13,16 +13,15 @@ struct Range_t
 };
 typedef CUtlVector<Range_t> RangeList;
 
-class SpeedometerLabel : public vgui::Label
+class SpeedometerLabel : public vgui::DoubleLabel
 {
-    DECLARE_CLASS_SIMPLE(SpeedometerLabel, vgui::Label);
+    DECLARE_CLASS_SIMPLE(SpeedometerLabel, vgui::DoubleLabel);
 
   public:
     SpeedometerLabel(Panel *parent, const char *panelName, SpeedometerColorize_t colorizeType);
 
     void ApplySchemeSettings(vgui::IScheme *pScheme) override;
     void OnThink() override; // for applying fadeout
-    void PerformLayout() override;
     
     void SetVisible(bool bVisible) override;
 
@@ -83,8 +82,6 @@ class SpeedometerLabel : public vgui::Label
     bool m_bDoneFading;
 
     Color m_NormalColor, m_IncreaseColor, m_DecreaseColor;
-
-    vgui::Label *m_pComparisonLabel;
 
     RangeList m_vecRangeList;
 

--- a/mp/src/game/client/momentum/ui/controls/DoubleLabel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/DoubleLabel.cpp
@@ -1,0 +1,150 @@
+#include "cbase.h"
+
+#include "DoubleLabel.h"
+#include "util/mom_util.h"
+#include "fmtstr.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+using namespace vgui;
+
+DoubleLabel::DoubleLabel(Panel *parent, const char *panelName) : BaseClass(parent, panelName, "")
+{
+    SetupSecondaryLabel(parent, CFmtStr("%sSecondary", panelName).Get(), "");
+}
+
+DoubleLabel::DoubleLabel(Panel *parent, const char *panelName, const char *secondPanelName) : BaseClass(parent, panelName, "")
+{
+    SetupSecondaryLabel(parent, secondPanelName, "");
+}
+
+DoubleLabel::DoubleLabel(Panel *parent, const char *panelName, const char *text1, const char *text2) : BaseClass(parent, panelName, text1)
+{
+    SetupSecondaryLabel(parent, CFmtStr("%sSecondary", panelName).Get(), text2);
+}
+
+DoubleLabel::DoubleLabel(Panel *parent, const char *panelName, const char *secondPanelName,
+                               const char *text1, const char *text2) : BaseClass(parent, panelName, text1)
+{
+    SetupSecondaryLabel(parent, secondPanelName, text2);
+}
+
+void DoubleLabel::SetupSecondaryLabel(Panel *parent, const char *panelName, const char *text)
+{
+    m_pSecondaryLabel = new Label(parent, panelName, text);
+    m_pSecondaryLabel->SetAutoTall(true);
+}
+
+void DoubleLabel::PerformLayout() 
+{
+    BaseClass::PerformLayout();
+
+    char szMain[256], szSecondary[256];
+    GetText(szMain, sizeof(szMain), szSecondary, sizeof(szSecondary));
+
+    HFont labelFont = GetFont();
+    int iPrimaryTextLength = UTIL_ComputeStringWidth(labelFont, szMain);
+    int iSecondaryTextLength = UTIL_ComputeStringWidth(labelFont, szSecondary);
+    int iCombinedTextLength = iPrimaryTextLength + iSecondaryTextLength;
+
+    // both labels have west content alignment by default
+    // this alignment is for this class specifically
+    switch (m_TextAlignment)
+    {
+    case a_northwest:
+    case a_west:
+    case a_southwest:
+        SetPrimaryTextInset(0, 0);
+        SetSecondaryTextInset(iPrimaryTextLength, 0);
+        break;
+    case a_center:
+        SetPrimaryTextInset((GetWide() - iCombinedTextLength) / 2, 0);  
+        SetSecondaryTextInset((GetWide() + iPrimaryTextLength - iSecondaryTextLength) / 2, 0);
+        break;
+    case a_northeast:
+    case a_east:
+    case a_southeast:
+        SetPrimaryTextInset(GetWide() - iCombinedTextLength, 0);
+        SetSecondaryTextInset(GetWide() - iSecondaryTextLength, 0);
+        break;
+    default:
+        break;
+    }
+}
+
+void vgui::DoubleLabel::ApplySchemeSettings(vgui::IScheme *pScheme) 
+{
+    BaseClass::ApplySchemeSettings(pScheme);
+    m_pSecondaryLabel->SetPos(GetXPos(), GetYPos());
+    m_pSecondaryLabel->SetWide(GetWide());
+}
+
+void vgui::DoubleLabel::SetYPos(int y) 
+{
+    SetPos(GetXPos(), y);
+    m_pSecondaryLabel->SetPos(GetXPos(), y);
+}
+
+void vgui::DoubleLabel::SetAlpha(int alpha)
+{
+    BaseClass::SetAlpha(alpha);
+    m_pSecondaryLabel->SetAlpha(alpha);
+}
+
+void vgui::DoubleLabel::SetWide(int wide) 
+{
+    BaseClass::SetWide(wide);
+    m_pSecondaryLabel->SetWide(wide);
+}
+
+void DoubleLabel::SetFont(HFont font)
+{
+    BaseClass::SetFont(font);
+    m_pSecondaryLabel->SetFont(font);
+}
+
+void DoubleLabel::SetText(const char *textPrimary, const char *textSecondary) 
+{
+    BaseClass::SetText(textPrimary);
+    m_pSecondaryLabel->SetText(textSecondary);
+}
+
+void DoubleLabel::SetText(const wchar_t *unicodeStringPrimary, const wchar_t *unicodeStringSecondary,
+                                bool bClearUnlocalizedSymbolPrimary, bool bClearUnlocalizedSymbolSecondary)
+{
+    BaseClass::SetText(unicodeStringPrimary, bClearUnlocalizedSymbolPrimary);
+    m_pSecondaryLabel->SetText(unicodeStringSecondary, bClearUnlocalizedSymbolSecondary);
+}
+
+void DoubleLabel::GetText(OUT_Z_BYTECAP(bufferLenPrimary) char *textOutPrimary, int bufferLenPrimary,
+                          OUT_Z_BYTECAP(bufferLenSecondary) char *textOutSecondary, int bufferLenSecondary)
+{
+    BaseClass::GetText(textOutPrimary, bufferLenPrimary);
+    m_pSecondaryLabel->GetText(textOutSecondary, bufferLenSecondary);
+}
+
+void DoubleLabel::SetFgColor(Color colorPrimary, Color colorSecondary) 
+{
+    BaseClass::SetFgColor(colorPrimary);
+    m_pSecondaryLabel->SetFgColor(colorSecondary);
+}
+
+void DoubleLabel::GetFgColor(Color &colorPrimary, Color &colorSecondary) 
+{
+    colorPrimary = BaseClass::GetFgColor();
+    colorSecondary = m_pSecondaryLabel->GetFgColor();
+}
+
+void DoubleLabel::SetTextInset(int xInsetPrimary, int yInsetPrimary, int xInsetSecondary, int yInsetSecondary) 
+{
+    BaseClass::SetTextInset(xInsetPrimary, yInsetPrimary);
+    m_pSecondaryLabel->SetTextInset(xInsetSecondary, yInsetSecondary);
+}
+
+void vgui::DoubleLabel::SetVisible(bool statePrimary, bool stateSecondary) 
+{
+    BaseClass::SetVisible(statePrimary);
+    m_pSecondaryLabel->SetVisible(stateSecondary);
+}
+

--- a/mp/src/game/client/momentum/ui/controls/DoubleLabel.h
+++ b/mp/src/game/client/momentum/ui/controls/DoubleLabel.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "vgui_controls/Label.h"
+
+namespace vgui
+{
+
+//-----------------------------------------------------------------------------
+// Class for displaying 2 labels together horizontally
+//-----------------------------------------------------------------------------
+class DoubleLabel : public Label
+{
+    DECLARE_CLASS_SIMPLE(DoubleLabel, Label);
+
+  public:
+    DoubleLabel(Panel *parent, const char *panelName);
+    DoubleLabel(Panel *parent, const char *panelName, const char *secondPanelName);
+    DoubleLabel(Panel *parent, const char *panelName, const char *text1, const char *text2);
+    DoubleLabel(Panel *parent, const char *panelName, const char *secondPanelName, const char *text1, const char *text2);
+
+    void PerformLayout() override;
+    void ApplySchemeSettings(vgui::IScheme *pScheme) override;
+
+    // Sets to both labels
+    void SetFont(HFont font) override;
+    void SetYPos(int y);
+    void SetAlpha(int alpha);
+    void SetWide(int wide);
+
+    void SetText(const char *textPrimary, const char *textSecondary);
+    void SetText(const wchar_t *unicodeStringPrimary, const wchar_t *unicodeStringSecondary,
+                 bool bClearUnlocalizedSymbolPrimary = false, bool bClearUnlocalizedSymbolSecondary = false);
+    void SetPrimaryText(const char *text) { BaseClass::SetText(text); };
+    void SetSecondaryText(const char *text) { m_pSecondaryLabel->SetText(text); }
+    void SetPrimaryText(const wchar_t *unicodeString, bool bClearUnlocalizedSymbol = false) { BaseClass::SetText(unicodeString, bClearUnlocalizedSymbol); }
+    void SetSecondaryText(const wchar_t *unicodeString, bool bClearUnlocalizedSymbol = false) { m_pSecondaryLabel->SetText(unicodeString, bClearUnlocalizedSymbol); }
+    void GetText(OUT_Z_BYTECAP(bufferLenPrimary) char *textOutPrimary, int bufferLenPrimary,
+                 OUT_Z_BYTECAP(bufferLenSecondary) char *textOutSecondary, int bufferLenSecondary);
+    void GetPrimaryText(OUT_Z_BYTECAP(bufferLen) char *textOut, int bufferLen) { BaseClass::GetText(textOut, bufferLen); }
+    void GetSecondaryText(OUT_Z_BYTECAP(bufferLen) char *textOut, int bufferLen) { m_pSecondaryLabel->GetText(textOut, bufferLen); }
+
+    void SetFgColor(Color colorPrimary, Color colorSecondary);
+    void GetFgColor(Color &colorPrimary, Color &colorSecondary);
+    void SetPrimaryFgColor(Color color) { BaseClass::SetFgColor(color); }
+    Color GetPrimaryFgColor() { return BaseClass::GetFgColor(); }
+    void SetSecondaryFgColor(Color color) { m_pSecondaryLabel->SetFgColor(color); }
+    Color GetSecondaryFgColor() { return m_pSecondaryLabel->GetFgColor(); }
+
+    void SetTextInset(int xInsetPrimary, int yInsetPrimary, int xInsetSecondary, int yInsetSecondary);
+    void SetPrimaryTextInset(int xInset, int yInset) { BaseClass::SetTextInset(xInset, yInset); }
+    void SetSecondaryTextInset(int xInset, int yInset) { m_pSecondaryLabel->SetTextInset(xInset, yInset); }
+    void GetPrimaryTextInset(int *xInset, int *yInset) { BaseClass::GetTextInset(xInset, yInset); }
+    void GetSecondaryTextInset(int *xInset, int *yInset) { m_pSecondaryLabel->GetTextInset(xInset, yInset); }
+
+    void SetVisible(bool statePrimary, bool stateSecondary);
+    void SetPrimaryVisible(bool state) { BaseClass::SetVisible(state); }
+    void SetSecondaryVisible(bool state) { m_pSecondaryLabel->SetVisible(state); }
+    bool IsPrimaryVisible(bool state) { return BaseClass::IsVisible(); }
+    bool IsSecondaryVisible(bool state) { return m_pSecondaryLabel->IsVisible(); }
+
+    // only use our alignment, not the baseclass'
+    void SetContentAlignment(Alignment alignment) override { m_TextAlignment = alignment; }
+    Alignment GetContentAlignment() const { return m_TextAlignment; }
+
+    Label *GetSecondaryLabel() { return m_pSecondaryLabel; }
+
+  private:
+    void SetupSecondaryLabel(Panel *parent, const char *panelName, const char *text);
+
+    Label *m_pSecondaryLabel;
+
+    Alignment m_TextAlignment;
+};
+
+}


### PR DESCRIPTION
Adds a cvar for toggling the autolayout of speedometer. 

I used a callback func here calling `OnReloadControls` so that the layout is reset according to the control resource. Unsure if there is a better way to do this though. 

Holding off on the docs issue as this could be done through the VDF file. My implementation of that is a bit ugly. Can't directly call `g_pSpeedometer->OnReloadControls` from `LoadGamemodeData` in `hud_speedometer_data` as that creates an infinite loop (data is reloaded in the speedometer's override of it). Can call the baseclass' one instead but then that's called twice in the `OnReloadControls` override.
Is there a better way of doing that?

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review