### PR TITLE
Fix autocomplete for long replay names

### DIFF
--- a/mp/src/public/tier1/convar.h
+++ b/mp/src/public/tier1/convar.h
@@ -63,7 +63,7 @@ typedef void ( *FnCommandCallbackVoid_t )( void );
 typedef void ( *FnCommandCallback_t )( const CCommand &command );
 
 #define COMMAND_COMPLETION_MAXITEMS		64
-#define COMMAND_COMPLETION_ITEM_LENGTH	64
+#define COMMAND_COMPLETION_ITEM_LENGTH	128 // 64 -> 128 for long replay names
 
 //-----------------------------------------------------------------------------
 // Returns 0 to COMMAND_COMPLETION_MAXITEMS worth of completion strings


### PR DESCRIPTION
As discussed on discord
This is only really needed for long replay name autocomplete but changing it outside of tier1 would result in a lot of code duplication or going even deeper, since the definition of ConCommand also relies on it through FnCommandCompletionCallback. I have tested the relevant functions that use autocompletion and none of them break.

### Checklist
- [X] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [X] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [X] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [X] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [X] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [X] My commits are relatively small and scoped to the best of my ability
- [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

