### PR TITLE
Add back menu background blur

### DIFF
--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
@@ -9,6 +9,7 @@
 #include "vgui/ISurface.h"
 #include "tier0/icommandline.h"
 #include "ienginevgui.h"
+#include "viewpostprocess.h"
 
 #include "vgui_controls/AnimationController.h"
 
@@ -61,6 +62,10 @@ CBaseMenuPanel::CBaseMenuPanel() : BaseClass(nullptr, "BaseGameUIPanel")
     m_bEverActivated = false;
     m_bHaveDarkenedBackground = false;
     m_BackdropColor = Color(0, 0, 0, 128);
+
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_START] = 0.0f;
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_END] = 0.0f;
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_BLUR_STRENGTH] = 1.0f;
 
     SetZPos(-100);
     m_pMainMenu = new MainMenu(this);
@@ -134,6 +139,8 @@ void CBaseMenuPanel::OnGameUIActivated()
 
 void CBaseMenuPanel::OnGameUIHidden()
 {
+    SetPostProcessParams(&m_PostProcessParameters, false);
+
     m_pMainMenu->SetVisible(false);
 }
 
@@ -151,6 +158,7 @@ void CBaseMenuPanel::UpdateBackgroundState()
 {
     if (GameUIUtil::IsInLevel())
     {
+        SetPostProcessParams(&m_PostProcessParameters, true);
         SetBackgroundRenderState(BACKGROUND_LEVEL);
     }
     else if (GameUIUtil::IsInBackgroundLevel() && !m_bLevelLoading)

--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
@@ -75,6 +75,8 @@ private:
     float m_flTransitionStartTime;
     float m_flTransitionEndTime;
 
+    PostProcessParameters_t m_PostProcessParameters;
+
     // background fill transition
     bool m_bHaveDarkenedBackground;
     float m_flFrameFadeInTime;

--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -1092,9 +1092,18 @@ PostProcessParameters_t s_LocalPostProcessParameters;
 static Vector4D s_viewFadeColor;
 static bool  s_bViewFadeModulate;
 
+static bool s_bOverridePostProcessParams = false;
+
 void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters )
 {
-	s_LocalPostProcessParameters = *pPostProcessParameters;
+    if (!s_bOverridePostProcessParams)
+	    s_LocalPostProcessParameters = *pPostProcessParameters;
+}
+
+void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters, bool bOverride )
+{
+    s_bOverridePostProcessParams = bOverride;
+    s_LocalPostProcessParameters = *pPostProcessParameters;
 }
 
 void SetViewFadeParams( byte r, byte g, byte b, byte a, bool bModulate )

--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -2341,7 +2341,7 @@ void DoEnginePostProcessing( int x, int y, int w, int h, bool bFlashlightIsOn, b
 
 			// bloom, software-AA and colour-correction (applied in 1 pass, after generation of the bloom texture)
 			bool  bPerformSoftwareAA	= false; // this was: IsX360() && ( engine->GetDXSupportLevel() >= 90 ) && ( flAAStrength != 0.0f );
-			bool  bPerformBloom			= !bPostVGui && ( flBloomScale > 0.0f ) && ( engine->GetDXSupportLevel() >= 90 );
+			bool  bPerformBloom			= true; // !bPostVGui && ( flBloomScale > 0.0f ) && ( engine->GetDXSupportLevel() >= 90 );
 			bool  bPerformColCorrect	= !bPostVGui && 
 										  ( g_pMaterialSystemHardwareConfig->GetDXSupportLevel() >= 90) &&
 										  ( g_pMaterialSystemHardwareConfig->GetHDRType() != HDR_TYPE_FLOAT ) &&

--- a/mp/src/game/client/viewpostprocess.h
+++ b/mp/src/game/client/viewpostprocess.h
@@ -18,6 +18,7 @@ void DoImageSpaceMotionBlur( const CViewSetup &viewSetup );
 void DumpTGAofRenderTarget( const int width, const int height, const char *pFilename );
 
 void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters );
+void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters, bool override );
 
 void SetViewFadeParams( byte r, byte g, byte b, byte a, bool bModulate );
 

--- a/mp/src/game/client/viewrender.cpp
+++ b/mp/src/game/client/viewrender.cpp
@@ -1973,7 +1973,7 @@ void CViewRender::RenderView( const CViewSetup &viewSetup, int nClearFlags, int 
 		RenderPlayerSprites();
 
 		// Image-space motion blur
-		if ( !building_cubemaps.GetBool() && viewSetup.m_bDoBloomAndToneMapping ) // We probably should use a different view. variable here
+		if ( !building_cubemaps.GetBool() ) // We probably should use a different view. variable here
 		{
 			if ( ( mat_motion_blur_enabled.GetInt() ) && ( g_pMaterialSystemHardwareConfig->GetDXSupportLevel() >= 90 ) )
 			{
@@ -2011,7 +2011,7 @@ void CViewRender::RenderView( const CViewSetup &viewSetup, int nClearFlags, int 
 		// Prevent sound stutter if going slow
 		engine->Sound_ExtraUpdate();	
 	
-		if ( !building_cubemaps.GetBool() && viewSetup.m_bDoBloomAndToneMapping )
+		if ( !building_cubemaps.GetBool() )
 		{
 			pRenderContext.GetFrom( materials );
 			{


### PR DESCRIPTION
We used to have a blur shader for the menu background that was removed because it had a heavy performance impact. This PR adds back menu background blur using the vignette blur effect found in the recently overridden `Engine_Post` shader from Alien Swarm. Contrary to the old blur shader, this has little to no performance impact and it looks better.

![image](https://user-images.githubusercontent.com/24222257/91485015-67190a00-e8aa-11ea-9896-fc390dd6fa04.png)

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
