### PR TITLE
Show start zone exit speed on linear maps

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -156,8 +156,9 @@ void CHudSpeedMeter::FireGameEvent(IGameEvent *pEvent)
     if (!m_pRunEntData->m_bTimerRunning || (iCurrentZone <= m_iLastZone && bLinear))
         return;
 
-    // Logical XOR; equivalent to (bLinear && !bExit) || (!bLinear && bExit)
-    if (bLinear != bExit)
+    const auto bLinearStartExit = bLinear && bExit && iCurrentZone == 1;
+    // Logical XOR; shown on enter for linear maps, exits for staged maps
+    if (bLinear != bExit || bLinearStartExit) 
     {
         m_iLastZone = iCurrentZone;
 


### PR DESCRIPTION
First part of #918 

Removed the `bLinear != bExit` with something more explicit, allowing exit vel to be updated when exiting start zone on linear maps.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review