### PR TITLE
Add catapult 

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -345,12 +345,12 @@
     author(string) : "Map Author" : "" : "The map's original author(s)."
 ]
 
-@SolidClass base(Trigger) = trigger_catapult : "Catapult the player in a given diretion at a given velocity."
+@SolidClass base(Trigger) = trigger_momentum_catapult : "Catapult the player in a given diretion at a given velocity."
 [
 	playerSpeed(float) : "Player Speed" : 450 : "Speed at which to launch the players (u/sec)"
 	//physicsSpeed(float) : "Physics Object Speed" : 450 : "Speed at which to launch physics objects (u/sec)"
-	//useThresholdCheck(integer) : "Use Threshold Check" : 0
-	//entryAngleTolerance(float) : "Entry Angle Tolerance" : "0.0" : "Flung object's velocity must be pointing this much at the target. Specify a value between [-1...1] 1 means exactly, 0 means within 180 degrees -1 means any angle is accepted. This is only used if Use Threshold Check is set to yes."
+	useThresholdCheck(integer) : "Use Threshold Check" : 0
+	entryAngleTolerance(float) : "Entry Angle Tolerance" : "0.0" : "Flung object's velocity must be pointing this much at the target. Specify a value between [-1...1] 1 means exactly, 0 means within 180 degrees -1 means any angle is accepted. This is only used if Use Threshold Check is set to yes."
 	useExactVelocity(integer) : "Use Exact Velocity" : 0 : "Try to fling exactly at the speed specified - this prevents the added upward velocity from a launch target."
 	exactVelocityChoiceType(choices) : "Exact Solution Method" : 0 :
 	"Using exact velocity generates two correct solutions. Use this to force which one you choose." =
@@ -359,11 +359,11 @@
 		1 : "Solution One"
 		2 : "Solution Two"
 	]
-	//lowerThreshold(float) : "Lower Threshold" : "0.15" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .15) This is only used if Use Threshold Check is set to yes."
-	//upperThreshold(float) : "Upper Threshold" : "0.30" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .30) This is only used if Use Threshold Check is set to yes."
-	//launchDirection(angle) : "Launch direction" : "0 0 0" : "Direction to launch the player in."
+	lowerThreshold(float) : "Lower Threshold" : "0.15" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .15) This is only used if Use Threshold Check is set to yes."
+	upperThreshold(float) : "Upper Threshold" : "0.30" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .30) This is only used if Use Threshold Check is set to yes."
+	launchDirection(angle) : "Launch direction" : "0 0 0" : "Direction to launch the player in."
 	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
-	//onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
+	onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
 	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
 	//AirCtrlSupressionTime(float) : "Air Control SupressionTime" : "-1.0" : "[Launch by target only!]If greater than zero, supress player aircontrol for this number (in seconds). If less than zero use the default (quarter second)."
 

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -365,7 +365,7 @@
 	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
 	onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
 	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
-    OnThink(integer) : "Update every intervals" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
+    OnThink(integer) : "Update every interval" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
     Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
     EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
 	output OnCatapulted(void) : "The object has been launched."

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -347,7 +347,6 @@
 @SolidClass base(Trigger) = trigger_momentum_catapult : "Catapult the player in a given diretion at a given velocity."
 [
 	playerSpeed(float) : "Player Speed" : 450 : "Speed at which to launch the players (u/sec)"
-	//physicsSpeed(float) : "Physics Object Speed" : 450 : "Speed at which to launch physics objects (u/sec)"
 	useThresholdCheck(integer) : "Use Threshold Check" : 0
 	entryAngleTolerance(float) : "Entry Angle Tolerance" : "0.0" : "Flung object's velocity must be pointing this much at the target. Specify a value between [-1...1] 1 means exactly, 0 means within 180 degrees -1 means any angle is accepted. This is only used if Use Threshold Check is set to yes."
 	useExactVelocity(integer) : "Use Exact Velocity" : 0 : "Try to fling exactly at the speed specified - this prevents the added upward velocity from a launch target."
@@ -358,12 +357,11 @@
 		1 : "Solution One"
 		2 : "Solution Two"
 	]
-	lowerThreshold(float) : "Lower Threshold" : "0.15" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .15) This is only used if Use Threshold Check is set to yes."
-	upperThreshold(float) : "Upper Threshold" : "0.30" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .30) This is only used if Use Threshold Check is set to yes."
+	lowerThreshold(float) : "Lower Threshold" : "0.15" : "Flung player must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .15) This is only used if Use Threshold Check is set to yes."
+	upperThreshold(float) : "Upper Threshold" : "0.30" : "Flung player must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .30) This is only used if Use Threshold Check is set to yes."
 	launchDirection(angle) : "Launch direction" : "0 0 0" : "Direction to launch the player in."
 	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
 	onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
-	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
     OnThink(integer) : "Update every interval" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
     Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
     heightOffset(float) :"Height Offset" : "32.0" : "Offset the origin of the player in the target calculation."

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -365,9 +365,10 @@
 	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
 	onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
 	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
-	//AirCtrlSupressionTime(float) : "Air Control SupressionTime" : "-1.0" : "[Launch by target only!]If greater than zero, supress player aircontrol for this number (in seconds). If less than zero use the default (quarter second)."
-
-	//output OnCatapulted(void) : "The object has been launched."
+    OnThink(integer) : "Update every intervals" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
+    Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
+    EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
+	output OnCatapulted(void) : "The object has been launched."
 ]
 
 //-------------------------------------------------------------------------

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -251,7 +251,6 @@
     Direction(angle) : "Direction (Pitch Yaw Roll)" : "0 0 0" : "Direction of the speed applied. Keep in mind that only Y angle is taken into account because vertical speed can be set already."
     OnThink(integer) : "Update every intervals" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
     Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
-    EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
 ]
 @PointClass base(Targetname) iconsprite("editor/momentum_serversettings.vmt") = point_momentum_serversettings : "An entity that sets the default specialized settings to the map."
 [
@@ -367,7 +366,7 @@
 	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
     OnThink(integer) : "Update every interval" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
     Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
-    EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
+    heightOffset(float) :"Height Offset" : "32.0" : "Offset the origin of the player in the target calculation."
 	output OnCatapulted(void) : "The object has been launched."
 ]
 

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -344,7 +344,7 @@
     author(string) : "Map Author" : "" : "The map's original author(s)."
 ]
 
-@SolidClass base(Trigger) = trigger_momentum_catapult : "Catapult the player in a given diretion at a given velocity."
+@SolidClass base(MomentumTrigger) = trigger_momentum_catapult : "Catapult the player at a target or in a given diretion at a given velocity."
 [
 	playerSpeed(float) : "Player Speed" : 450 : "Speed at which to launch the players (u/sec)"
 	useThresholdCheck(integer) : "Use Threshold Check" : 0
@@ -363,7 +363,8 @@
 	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
 	onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
     OnThink(integer) : "Update every interval" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
-    Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
+    Interval(float) : "Interval" : "1.0" : "Time in seconds between each update"
+    EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
     heightOffset(float) :"Height Offset" : "32.0" : "Offset the origin of the player in the target calculation."
 	output OnCatapulted(void) : "The object has been launched."
 ]

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -345,6 +345,31 @@
     author(string) : "Map Author" : "" : "The map's original author(s)."
 ]
 
+@SolidClass base(Trigger) = trigger_catapult : "Catapult the player in a given diretion at a given velocity."
+[
+	playerSpeed(float) : "Player Speed" : 450 : "Speed at which to launch the players (u/sec)"
+	//physicsSpeed(float) : "Physics Object Speed" : 450 : "Speed at which to launch physics objects (u/sec)"
+	//useThresholdCheck(integer) : "Use Threshold Check" : 0
+	//entryAngleTolerance(float) : "Entry Angle Tolerance" : "0.0" : "Flung object's velocity must be pointing this much at the target. Specify a value between [-1...1] 1 means exactly, 0 means within 180 degrees -1 means any angle is accepted. This is only used if Use Threshold Check is set to yes."
+	useExactVelocity(integer) : "Use Exact Velocity" : 0 : "Try to fling exactly at the speed specified - this prevents the added upward velocity from a launch target."
+	exactVelocityChoiceType(choices) : "Exact Solution Method" : 0 :
+	"Using exact velocity generates two correct solutions. Use this to force which one you choose." =
+	[
+		0 : "Best"
+		1 : "Solution One"
+		2 : "Solution Two"
+	]
+	//lowerThreshold(float) : "Lower Threshold" : "0.15" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .15) This is only used if Use Threshold Check is set to yes."
+	//upperThreshold(float) : "Upper Threshold" : "0.30" : "Flung object must be within this percentage value in order to activate fling. Specify a value between [0...1] (default is .30) This is only used if Use Threshold Check is set to yes."
+	//launchDirection(angle) : "Launch direction" : "0 0 0" : "Direction to launch the player in."
+	launchTarget(target_destination) : "Launch target" : "" : "Entity to try to 'hit' when we're launched."
+	//onlyVelocityCheck(integer) : "Only check velocity" : 0 : "Only check velocity of the touching object - don't actually catapult it.  Use in conjunction with OnCatapulted to create velocity checking triggers.  Only works when Use Threshhold Check is enabled."
+	//applyAngularImpulse(integer) : "Apply angular impulse" : 1 : "If a random angular impulse should be applied to physics objects being catapulted."
+	//AirCtrlSupressionTime(float) : "Air Control SupressionTime" : "-1.0" : "[Launch by target only!]If greater than zero, supress player aircontrol for this number (in seconds). If less than zero use the default (quarter second)."
+
+	//output OnCatapulted(void) : "The object has been launched."
+]
+
 //-------------------------------------------------------------------------
 //
 // Weapons

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1752,12 +1752,15 @@ void CTriggerMomentumCatapult::OnStartTouch(CBaseEntity* pOther)
     // Ignore vphys only allow players
     if (pOther && pOther->IsPlayer())
     {
+        bool bLaunch = true;
+
         // Check threshold
         if (m_bUseThresholdCheck)
         {
             Vector vecPlayerVelocity = pOther->GetAbsVelocity();
             float flPlayerSpeed = vecPlayerVelocity.Length();
-            
+            bLaunch = false;
+
             // From VDC
             if (flPlayerSpeed > m_flPlayerSpeed - (m_flPlayerSpeed * m_flLowerThreshold) &&
                 flPlayerSpeed < m_flPlayerSpeed + (m_flPlayerSpeed * m_flUpperThreshold))
@@ -1776,6 +1779,7 @@ void CTriggerMomentumCatapult::OnStartTouch(CBaseEntity* pOther)
                             m_OnCatapulted.FireOutput(pOther, this);
                             return;
                         }
+                        bLaunch = true;
                     }
                 }
                 else
@@ -1792,18 +1796,22 @@ void CTriggerMomentumCatapult::OnStartTouch(CBaseEntity* pOther)
                             m_OnCatapulted.FireOutput(pOther, this);
                             return;
                         }
+                        bLaunch = true;
                     }
                 }
             }
         }
 
-        if (m_bUseLaunchTarget)
+        if (bLaunch)
         {
-            LaunchAtTarget(pOther);
-        }
-        else
-        {
-            LaunchAtDirection(pOther);
+            if (m_bUseLaunchTarget)
+            {
+                LaunchAtTarget(pOther);
+            }
+            else
+            {
+                LaunchAtDirection(pOther);
+            }
         }
 
     }

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1602,6 +1602,7 @@ BEGIN_DATADESC(CTriggerMomentumCatapult)
     DEFINE_OUTPUT(m_OnCatapulted, "OnCatapulted"),
     DEFINE_KEYFIELD(m_flInterval, FIELD_FLOAT, "Interval"),
     DEFINE_KEYFIELD(m_bOnThink, FIELD_BOOLEAN, "OnThink"),
+    DEFINE_KEYFIELD(m_bEveryTick, FIELD_BOOLEAN, "EveryTick"),
     DEFINE_KEYFIELD(m_flHeightOffset, FIELD_FLOAT, "heightOffset"),
 END_DATADESC()
 
@@ -1620,6 +1621,7 @@ CTriggerMomentumCatapult::CTriggerMomentumCatapult()
     m_bOnlyCheckVelocity = false;
     m_flInterval = 1.0;
     m_bOnThink = false;
+    m_bEveryTick = false;
     m_flHeightOffset = 32.0f;
 }
 
@@ -1842,9 +1844,22 @@ void CTriggerMomentumCatapult::OnStartTouch(CBaseEntity* pOther)
     }
 }
 
+void CTriggerMomentumCatapult::Touch(CBaseEntity *pOther)
+{
+    BaseClass::Touch(pOther);
+
+    if (m_bEveryTick)
+    {
+        if (pOther && pOther->IsPlayer())
+        {
+            Launch(pOther);
+        }
+    }
+}
+
 void CTriggerMomentumCatapult::Think()
 {
-    if (m_bOnThink)
+    if (!m_bOnThink)
     {
         SetNextThink(TICK_NEVER_THINK);
         return;

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -702,10 +702,13 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
   public:
     void OnStartTouch(CBaseEntity *) OVERRIDE;
     void Spawn() OVERRIDE;
+    void Think() OVERRIDE;
+
 
   private:
     Vector CalculateLaunchVelocity(CBaseEntity *);
     Vector CalculateLaunchVelocityExact(CBaseEntity *);
+    void Launch(CBaseEntity *);
     void LaunchAtDirection(CBaseEntity *);
     void LaunchAtTarget(CBaseEntity *);
 
@@ -730,4 +733,7 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     bool m_bOnlyCheckVelocity;
     float m_flEntryAngleTolerance;
     COutputEvent m_OnCatapulted;
+    float m_flInterval;
+    bool m_bOnThink;
+    bool m_bEveryTick;
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -688,3 +688,24 @@ public:
 
     bool m_bAirborneOnly;
 };
+
+
+// CTriggerMomentumCatapult
+class CTriggerMomentumCatapult : public CBaseMomentumTrigger
+{
+  public:
+    DECLARE_CLASS(CTriggerMomentumCatapult, CBaseMomentumTrigger);
+    DECLARE_DATADESC();
+
+    // CTriggerMomentumCatapult();
+
+  public:
+    void OnStartTouch(CBaseEntity *) OVERRIDE;
+
+  private:
+    float m_fPlayerSpeed;
+    int m_iUseExactVelocity;
+    int m_iExactVelocityChoiceType;
+    Vector m_vLaunchDirection;
+    EHANDLE m_hLaunchTarget;
+};

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -689,8 +689,6 @@ public:
     bool m_bAirborneOnly;
 };
 
-
-// CTriggerMomentumCatapult
 class CTriggerMomentumCatapult : public CBaseMomentumTrigger
 {
   public:
@@ -700,11 +698,11 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     CTriggerMomentumCatapult();
 
   public:
-    void OnStartTouch(CBaseEntity *) OVERRIDE;
-    void Spawn() OVERRIDE;
-    void Think() OVERRIDE;
+    void OnStartTouch(CBaseEntity *) override;
+    void Spawn() override;
+    void Think() override;
 
-    int DrawDebugTextOverlays() OVERRIDE;
+    int DrawDebugTextOverlays() override;
 
   private:
     Vector CalculateLaunchVelocity(CBaseEntity *);
@@ -715,9 +713,9 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
 
   private:
 
-    enum
+    enum ExactVelocityChoice_t
     {
-        BEST=0,
+        BEST = 0,
         SOLUTION_ONE,
         SOLUTION_TWO,
     };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -697,15 +697,29 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     DECLARE_CLASS(CTriggerMomentumCatapult, CBaseMomentumTrigger);
     DECLARE_DATADESC();
 
-    // CTriggerMomentumCatapult();
+    CTriggerMomentumCatapult();
 
   public:
     void OnStartTouch(CBaseEntity *) OVERRIDE;
+    void Spawn() OVERRIDE;
 
   private:
-    float m_fPlayerSpeed;
+    Vector CalculateLaunchVelocity(CBaseEntity *);
+    Vector CalculateLaunchVelocityExact(CBaseEntity *);
+    void LaunchAtDirection(CBaseEntity *);
+    void LaunchAtTarget(CBaseEntity *);
+
+  private:
+    float m_flPlayerSpeed;
     int m_iUseExactVelocity;
     int m_iExactVelocityChoiceType;
-    Vector m_vLaunchDirection;
+    QAngle m_vLaunchDirection;
     EHANDLE m_hLaunchTarget;
+    bool m_bUseLaunchTarget;
+    bool m_bUseThresholdCheck;
+    float m_flLowerThreshold;
+    float m_flUpperThreshold;
+    bool m_bOnlyCheckVelocity;
+    float m_flEntryAngleTolerance;
+    COutputEvent m_OnCatapulted;
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -704,6 +704,7 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     void Spawn() OVERRIDE;
     void Think() OVERRIDE;
 
+    int DrawDebugTextOverlays() OVERRIDE;
 
   private:
     Vector CalculateLaunchVelocity(CBaseEntity *);
@@ -735,5 +736,5 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     COutputEvent m_OnCatapulted;
     float m_flInterval;
     bool m_bOnThink;
-    bool m_bEveryTick;
+    float m_flHeightOffset;
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -699,6 +699,7 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
 
   public:
     void OnStartTouch(CBaseEntity *) override;
+    void Touch(CBaseEntity *) override;
     void Spawn() override;
     void Think() override;
 
@@ -734,5 +735,6 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     COutputEvent m_OnCatapulted;
     float m_flInterval;
     bool m_bOnThink;
+    bool m_bEveryTick;
     float m_flHeightOffset;
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -710,6 +710,14 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     void LaunchAtTarget(CBaseEntity *);
 
   private:
+
+    enum
+    {
+        BEST=0,
+        SOLUTION_ONE,
+        SOLUTION_TWO,
+    };
+
     float m_flPlayerSpeed;
     int m_iUseExactVelocity;
     int m_iExactVelocityChoiceType;


### PR DESCRIPTION
Closes  #865

Adds the trigger_momentum_catapult to mimic the trigger_catapult present in tf2.

This is not 1:1 as per the tf2 fgd: vphys and the random angular impulse are not currently supported, exposed options for the think interval 

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
