### PR TITLE
Properly reset sticky launcher charge animation

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.cpp
@@ -297,6 +297,7 @@ bool CMomentumStickybombLauncher::SetChargeEnabled(bool state)
         StopWeaponSound(GetWeaponSound("charge"));
         if (m_flChargeBeginTime > 0) // was charging when disabled
         {
+            SendWeaponAnim(ACT_VM_IDLE);
             WeaponSound(GetWeaponSound("chargestop"));
         }
     }


### PR DESCRIPTION
Found a little bug relating to the sticky launcher charging animation while testing @VortexParadox 's new weapon viewmodels branch ( #933 )

When the sticky launcher charge is disabled (eg. entering a start zone) while it is currently charging, the charging animation (`ACT_VM_PULLBACK`) is not reset to `ACT_VM_IDLE`.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
