### PR TITLE
Redirect the retry command to reload

### DIFF
--- a/mp/src/game/client/momentum/client_events.cpp
+++ b/mp/src/game/client/momentum/client_events.cpp
@@ -14,6 +14,13 @@
 
 extern IFileSystem *filesystem;
 
+inline void UnloadConVarOrCommand(const char *pName)
+{
+    const auto pCmd = g_pCVar->FindCommandBase(pName);
+    if (pCmd)
+        g_pCVar->UnregisterConCommand(pCmd);
+}
+
 bool CMOMClientEvents::Init()
 {
     // Mount CSS content even if it's on a different drive than this game
@@ -33,6 +40,13 @@ bool CMOMClientEvents::Init()
             pCvar = pNext;
         }
     }
+
+    UnloadConVarOrCommand("retry");
+
+    static ConCommand retry("retry", []()
+    {
+        engine->ExecuteClientCmd("reload");
+    });
 
     return true;
 }


### PR DESCRIPTION
The `retry` command is often used by players to reconnect to servers on other games, and often they can try to do the same here which can cause issues. Not to mention the command is useless in Momentum because it doesn't actually reload the map or even reset entities. So `retry` was simply turned into an alias of `reload`.

Closes #940 

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
