### PR TITLE
Change precedence of det success/fail sounds via cvar

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_stickybomblauncher.h
@@ -62,7 +62,7 @@ class CMomentumStickybombLauncher : public CWeaponBaseGun
 
     CNetworkVar(int, m_iStickybombCount);
     CNetworkVar(float, m_flChargeBeginTime);
-    float m_flLastDenySoundTime;
+    float m_flLastDetSoundTime;
 
     // This var mainly serves to disable the charge animation, sound and turn the charge meter red if set to false
     // Networked so hud code can check the state


### PR DESCRIPTION
Closes #941 

When player tries to det and detonation is both a success (sticky explodes) and a fail (trying to det too early), the det fail sound takes precedence. This is a little unintuitive as a sticky is actually det.

This change allows the det success sound to have precedence over the det fail one. 

It is a subtle difference, though this does differs from TF2's implementation so players may not like it. Maybe have a toggle cvar for it?

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
