### PR TITLE
Load defaults from speedometer data when missing

### DIFF
--- a/mp/game/momentum/cfg/speedometer_default.vdf
+++ b/mp/game/momentum/cfg/speedometer_default.vdf
@@ -75,14 +75,20 @@
         "HorizSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "LastJumpVelocity"
         {
@@ -138,14 +144,20 @@
         "HorizSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "LastJumpVelocity"
         {
@@ -201,14 +213,20 @@
         "HorizSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "LastJumpVelocity"
         {
@@ -219,10 +237,14 @@
         "RampBoardVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampLeaveVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "StageEnterExitVelocity"
         {
@@ -253,7 +275,9 @@
         }
         "AbsSpeedometer"
         {
-            "visible" "0"
+            "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "HorizSpeedometer"
         {
@@ -285,6 +309,8 @@
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
@@ -295,14 +321,20 @@
         "LastJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "RampBoardVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampLeaveVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "StageEnterExitVelocity"
         {
@@ -333,7 +365,9 @@
         }
         "AbsSpeedometer"
         {
-            "visible" "0"
+            "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "HorizSpeedometer"
         {
@@ -398,14 +432,20 @@
         "LastJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampBoardVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampLeaveVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "StageEnterExitVelocity"
         {
@@ -443,14 +483,20 @@
         "HorizSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "LastJumpVelocity"
         {
@@ -461,10 +507,14 @@
         "RampBoardVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampLeaveVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "StageEnterExitVelocity"
         {
@@ -502,14 +552,20 @@
         "HorizSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "VertSpeedometer"
         {
             "visible"  "0"
+            "colorize" "2"
+            "units"    "0"
         }
         "ExplosiveJumpVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "LastJumpVelocity"
         {
@@ -520,10 +576,14 @@
         "RampBoardVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "RampLeaveVelocity"
         {
             "visible"  "0"
+            "colorize" "0"
+            "units"    "0"
         }
         "StageEnterExitVelocity"
         {

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.cpp
@@ -178,7 +178,7 @@ void SpeedometerData::Apply()
             bShouldSave = true;
         }
 
-        pSpeedoLabel->LoadFromKV(pSpeedoKV);
+        pSpeedoLabel->ApplyKV(pSpeedoKV);
     }
 
     if (bShouldSave)

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.cpp
@@ -15,6 +15,9 @@
 #define SPEEDOMETER_KEY_VISIBLE "visible"
 #define SPEEDOMETER_KEY_COLORIZE "colorize"
 #define SPEEDOMETER_KEY_UNITS "units"
+#define SPEEDOMETER_KEY_LAYOUT "layout"
+#define SPEEDOMETER_KEY_AUTOLAYOUT "autolayout"
+#define SPEEDOMETER_KEY_ORDER "order"
 
 CON_COMMAND_F(mom_hud_speedometer_loadcfg, "Loads the speedometer setup for the current gamemode from file.\n",
               FLAG_HUD_CVAR | FCVAR_CLIENTCMD_CAN_EXECUTE)
@@ -85,15 +88,15 @@ void SpeedometerData::Apply()
     }
 
     // get autolayout. if no custom layout specified, set autolayout on
-    KeyValues *pLayoutKV = pGamemodeKV->FindKey("layout");
-    bool bAutoLayout = pGamemodeKV->GetBool("autolayout", true) || !pLayoutKV;
+    auto pLayoutKV = pGamemodeKV->FindKey(SPEEDOMETER_KEY_LAYOUT);
+    bool bAutoLayout = pGamemodeKV->GetBool(SPEEDOMETER_KEY_AUTOLAYOUT, true) || !pLayoutKV;
     g_pSpeedometer->SetAutoLayout(bAutoLayout);
 
     if (bAutoLayout)
     {
         g_pSpeedometer->LoadControlSettings(g_pSpeedometer->GetResFile());
         // get ordering
-        KeyValues *pOrderKV = pGamemodeKV->FindKey("order");
+        auto pOrderKV = pGamemodeKV->FindKey(SPEEDOMETER_KEY_ORDER);
         if (pOrderKV)
         {
             auto pOrderList = g_pSpeedometer->GetLabelOrderListPtr();

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_data.h
@@ -25,7 +25,7 @@ class SpeedometerData
     SpeedometerUnits_t GetUnits(GameMode_t gametype, SpeedometerLabel_t speedometerLabelType) const;
 
   private:
-    SpeedometerLabel *GetLabelFromName(const char *name) const;
+    bool LoadDefaultSubKeyData(KeyValues *pGamemodeKV, KeyValues *pDefaultGamemodeKV, const char *pszKeyName);
 
     KeyValues *GetSpeedoKVs(GameMode_t gametype, SpeedometerLabel_t speedometerLabelType) const;
 

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
@@ -232,25 +232,7 @@ void SpeedometerLabel::ColorizeComparisonSeparate()
     SetSecondaryFgColor(compareColor);
 }
 
-void SpeedometerLabel::SaveToKV(KeyValues* pOut)
-{
-    pOut->Clear();
-    pOut->SetBool("visible", IsVisible());
-    pOut->SetInt("colorize", GetColorizeType());
-    KeyValues *pRangesKV = pOut->FindKey("ranges", true);
-
-    FOR_EACH_VEC(m_vecRangeList, i)
-    {
-        Range_t range = m_vecRangeList[i];
-        KeyValues *rangeKV = pRangesKV->FindKey(CFmtStr("%i", i + 1).Get(), true);
-        rangeKV->SetInt("min", range.min);
-        rangeKV->SetInt("max", range.max);
-        rangeKV->SetColor("color", range.color);
-    }
-    pOut->SetInt("units", GetUnitType());
-}
-
-void SpeedometerLabel::LoadFromKV(KeyValues* pIn)
+void SpeedometerLabel::ApplyKV(KeyValues *pIn)
 {
     if (!pIn)
         return;

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.cpp
@@ -252,6 +252,9 @@ void SpeedometerLabel::SaveToKV(KeyValues* pOut)
 
 void SpeedometerLabel::LoadFromKV(KeyValues* pIn)
 {
+    if (!pIn)
+        return;
+
     SetVisible(pIn->GetBool("visible", false));
     if (!IsVisible())
         return;

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.h
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer_label.h
@@ -53,9 +53,8 @@ class SpeedometerLabel : public vgui::DoubleLabel
 
     bool GetSupportsSeparateComparison() { return m_bSupportsSeparateComparison; }
     void SetSupportsSeparateComparison(bool bSupportsSeparateComparison) { m_bSupportsSeparateComparison = bSupportsSeparateComparison; }
-
-    void SaveToKV(KeyValues *pOut);
-    void LoadFromKV(KeyValues *pIn);
+    
+    void ApplyKV(KeyValues *pIn);
 
   private:
     void ConvertUnits();


### PR DESCRIPTION
When the speedometer setup or it's ordering are incorrect/missing, load from the default speedometer data set.

Also:
- Removed a `SaveToKV` method in `SpeedometerLabel` that is no longer needed. 
- Changed the name of the `LoadFromKV` method to `ApplyKV` to better fit the naming scheme in the speedometer data.
- Added missing "colorize"/"units" fields in the default speedo data set. I feel that the default file should contain all defaults.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
