### PR TITLE
Added "Fizzling Immediately" properties for func_nogrenades

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -14,10 +14,12 @@
 
 @SolidClass base(Targetname, EnableDisable, Toggle) = func_nogrenades : "Rockets and grenades will not detonate inside this area." 
 [
-    airborne_only(choices) : "Prevent airborne explosions only" : 0 = 
+    explosion_prevention_type(choices) : "Explosive prevention method" : 0 =
     [
-        0 : "False"
-        1 : "True"
+        0 : "[Default] Prevent explosive from detonating inside this trigger."
+        1 : "Prevent explosive detonation only if explosive is airborne."
+        2 : "Destroy stickybombs upon them landing (instead of on attempted det)."
+        3 : "Destroy explosive upon it entering the trigger."
     ]
 ]
 

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -687,9 +687,16 @@ public:
     void InputEnable(inputdata_t &inputdata) override { m_bDisabled = false; }
     void InputToggle(inputdata_t &inputdata) override { m_bDisabled = !m_bDisabled; }
 
-    static bool IsInsideNoGrenadesZone(CBaseEntity *pOther);
+    static CNoGrenadesZone* IsInsideNoGrenadesZone(CBaseEntity *pOther);
 
-    bool m_bAirborneOnly;
+    int m_iExplosivePreventionType;
+    enum ExplosivePreventionType_t
+    {
+        FIZZLE_ON_DET,
+        FIZZLE_ON_DET_AIRBORNE_ONLY,
+        FIZZLE_ON_LAND,
+        FIZZLE_ON_ENTRANCE
+    };
 };
 
 class CTriggerMomentumCatapult : public CBaseMomentumTrigger


### PR DESCRIPTION
Closes #957 

This pull request adds the aforementioned "fizzling immediately" properties for func_nogrenades in regards to the stickybomb launcher; allowing you to choose between fizzling when the player dets (the original functionality), having the sticky be fizzled once it lands (if airborne only is `false`, otherwise acts as it originally did), or having the sticky be fizzled immediately upon entering the func brush

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review