### PR TITLE
Fix constant menu blur while in tools mode

### DIFF
--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
@@ -9,8 +9,6 @@
 #include "vgui/ISurface.h"
 #include "tier0/icommandline.h"
 #include "ienginevgui.h"
-#include "viewpostprocess.h"
-
 #include "vgui_controls/AnimationController.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -62,10 +60,6 @@ CBaseMenuPanel::CBaseMenuPanel() : BaseClass(nullptr, "BaseGameUIPanel")
     m_bEverActivated = false;
     m_bHaveDarkenedBackground = false;
     m_BackdropColor = Color(0, 0, 0, 128);
-
-    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_START] = 0.0f;
-    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_END] = 0.0f;
-    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_BLUR_STRENGTH] = 1.0f;
 
     SetZPos(-100);
     m_pMainMenu = new MainMenu(this);
@@ -139,8 +133,6 @@ void CBaseMenuPanel::OnGameUIActivated()
 
 void CBaseMenuPanel::OnGameUIHidden()
 {
-    SetPostProcessParams(&m_PostProcessParameters, false);
-
     m_pMainMenu->SetVisible(false);
 }
 
@@ -158,7 +150,6 @@ void CBaseMenuPanel::UpdateBackgroundState()
 {
     if (GameUIUtil::IsInLevel())
     {
-        SetPostProcessParams(&m_PostProcessParameters, true);
         SetBackgroundRenderState(BACKGROUND_LEVEL);
     }
     else if (GameUIUtil::IsInBackgroundLevel() && !m_bLevelLoading)

--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
@@ -75,8 +75,6 @@ private:
     float m_flTransitionStartTime;
     float m_flTransitionEndTime;
 
-    PostProcessParameters_t m_PostProcessParameters;
-
     // background fill transition
     bool m_bHaveDarkenedBackground;
     float m_flFrameFadeInTime;

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
@@ -22,6 +22,8 @@
 #include "controls/UserComponent.h"
 #include "drawer/MenuDrawer.h"
 
+#include "viewpostprocess.h"
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -98,6 +100,10 @@ MainMenu::MainMenu(CBaseMenuPanel *pParent) : BaseClass(pParent, "MainMenu")
     m_pVersionLabel->SetAutoWide(true);
     m_pVersionLabel->SetAutoTall(true);
     // MOM_TODO: LoadControlSettings("resource/ui/MainMenuLayout.res");
+
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_START] = 0.0f;
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_END] = 0.0f;
+    m_PostProcessParameters.m_flParameters[PPPN_VIGNETTE_BLUR_STRENGTH] = 1.0f;
 
     CheckVersion();
 
@@ -309,6 +315,8 @@ void MainMenu::DrawMainMenu()
         }
     }
 
+    SetPostProcessParams(&m_PostProcessParameters, true);
+
     if (GameUIUtil::IsInLevel())
     {
         m_nSortFlags &= ~FL_SORT_MENU;
@@ -442,6 +450,14 @@ void MainMenu::PerformLayout()
                                 screenTall - m_pUserComponent->GetTall() - m_iButtonsOffsetY,
                                 GetScaledVal(200),
                                 GetScaledVal(50));
+}
+
+void MainMenu::SetVisible(bool state)
+{
+    if (!state)
+        SetPostProcessParams(&m_PostProcessParameters, false);
+
+    BaseClass::SetVisible(state);
 }
 
 void MainMenu::Activate()

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
@@ -315,10 +315,10 @@ void MainMenu::DrawMainMenu()
         }
     }
 
-    SetPostProcessParams(&m_PostProcessParameters, true);
-
     if (GameUIUtil::IsInLevel())
     {
+        SetPostProcessParams(&m_PostProcessParameters, true);
+
         m_nSortFlags &= ~FL_SORT_MENU;
 
         m_bNeedSort = (!m_bNeedSort && !(m_nSortFlags & FL_SORT_INGAME));

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.h
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.h
@@ -35,6 +35,7 @@ class MainMenu : public vgui::EditablePanel, public CGameEventListener
     void CheckVersion();
     void Paint() OVERRIDE;
     void PerformLayout() override;
+    void SetVisible(bool state) override;
 
     void Activate();
 
@@ -76,4 +77,6 @@ private:
     vgui::Label *m_pVersionLabel;
 
     CBaseMenuPanel *m_pBasePanel;
+
+    PostProcessParameters_t m_PostProcessParameters;
 };

--- a/mp/src/game/client/viewpostprocess.cpp
+++ b/mp/src/game/client/viewpostprocess.cpp
@@ -1103,7 +1103,7 @@ void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters
 void SetPostProcessParams( const PostProcessParameters_t* pPostProcessParameters, bool bOverride )
 {
     s_bOverridePostProcessParams = bOverride;
-    s_LocalPostProcessParameters = *pPostProcessParameters;
+    SetPostProcessParams(pPostProcessParameters);
 }
 
 void SetViewFadeParams( byte r, byte g, byte b, byte a, bool bModulate )


### PR DESCRIPTION
Closes #959

Opening the menu and/or console is still broken in tools mode and I imagine that will require engine to fix.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
