### PR TITLE
Enhance/fix catapult

### DIFF
--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1906,32 +1906,19 @@ int CTriggerMomentumCatapult::DrawDebugTextOverlays()
     text_offset++;
 
     Vector vecLaunchVelocity = vec3_origin;
+    Vector vecLaunchVelocityExact = vec3_origin;
     if (m_target != NULL_STRING)
     {
-        // Create dummy velocity
-        Vector vecPlayerOrigin = GetAbsOrigin();
+        vecLaunchVelocity = CalculateLaunchVelocity(this);
+        vecLaunchVelocityExact = CalculateLaunchVelocityExact(this);
 
-        vecPlayerOrigin.z += m_flHeightOffset;
+        Q_snprintf(tempstr, sizeof(tempstr), "Adjusted player velocity: %f",
+                   m_iUseExactVelocity ? (float)vecLaunchVelocity.Length() : (float)vecLaunchVelocityExact.Length());
 
-        Vector vecAbsDifference = m_hLaunchTarget->GetAbsOrigin() - vecPlayerOrigin;
-
-        float flSpeed2 = m_flPlayerSpeed * m_flPlayerSpeed;
-        float flGravity = GetCurrentGravity();
-
-        float flDiscriminant = 4.0f * flSpeed2 * vecAbsDifference.Length() * vecAbsDifference.Length();
-
-        flDiscriminant = sqrtf(flDiscriminant);
-        float fTime = 0.5f * (flDiscriminant / flSpeed2);
-
-        vecLaunchVelocity = (vecAbsDifference / fTime);
-
-        Vector vecGravityComp = 0.5 * (flGravity * Vector(0, 0, -1)) * fTime;
-        vecLaunchVelocity -= vecGravityComp;
+        EntityText(text_offset, tempstr, 0);
+        text_offset++;
     }
 
-    Q_snprintf(tempstr, sizeof(tempstr), "Adjusted player velocity: %f", m_iUseExactVelocity ? (float)vecLaunchVelocity.Length() : m_flPlayerSpeed);
-    EntityText(text_offset, tempstr, 0);
-    text_offset++;
 
     return text_offset;
 }

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1669,7 +1669,7 @@ Vector CTriggerMomentumCatapult::CalculateLaunchVelocity(CBaseEntity *pOther)
 
     Vector vecLaunchVelocity = (vecAbsDifference / fTime);
 
-    Vector vecGravityComp(0, 0, 0.5f * flGravity * fTime);
+    Vector vecGravityComp(0, 0, 0.5f * -flGravity * fTime);
     vecLaunchVelocity -= vecGravityComp;
 
     return vecLaunchVelocity;

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -1850,6 +1850,9 @@ void CTriggerMomentumCatapult::Touch(CBaseEntity *pOther)
 
     if (m_bEveryTick)
     {
+        if (!PassesTriggerFilters(pOther))
+            return;
+
         if (pOther && pOther->IsPlayer())
         {
             Launch(pOther);


### PR DESCRIPTION
Fixes a regression in the trigger_momentum_catapult velocity calculation, adds trigger filter check to touch override, and cleans up the debug overlay output/calculation.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
