### PR TITLE
Re-add the EveryTick fgd value to trigger_momentum_setspeed

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -251,6 +251,7 @@
     Direction(angle) : "Direction (Pitch Yaw Roll)" : "0 0 0" : "Direction of the speed applied. Keep in mind that only Y angle is taken into account because vertical speed can be set already."
     OnThink(integer) : "Update every intervals" : 0 : "If you want to make the trigger updating for each defined interval, set it to 1."
     Interval(float) : "Interval" : "1.0" : "Set here in seconds how many time the trigger should update."
+    EveryTick(integer) : "Every tick" : 0 : "If you want the trigger to update and fire every tick, set this to 1."
 ]
 @PointClass base(Targetname) iconsprite("editor/momentum_serversettings.vmt") = point_momentum_serversettings : "An entity that sets the default specialized settings to the map."
 [


### PR DESCRIPTION
Re-add the EveryTick fgd value to trigger_momentum_setspeed that was accidentally removed in 9204dcf24492b3b131cd92b7d185b8954d60ec3e

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
