### PR TITLE
Add Toggle BaseClass to remove error

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -5,6 +5,13 @@
 // TF2 COMPATIBILITY
 //
 // -----------------------------------------------------------------------
+
+@BaseClass = Toggle
+[
+	// Inputs
+	input Toggle(void) : "Toggle the enabled/disabled status of this entity."
+]
+
 @SolidClass base(Targetname, EnableDisable, Toggle) = func_nogrenades : "Rockets and grenades will not detonate inside this area." 
 [
     airborne_only(choices) : "Prevent airborne explosions only" : 0 = 


### PR DESCRIPTION
Closes N/A

Simply adds the Toggle BaseClass to the Momentum FGD to remove an error.
This should also allow the func_nogrenades brush entity to be selected.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review