### PR TITLE
Cvar for automatically untoggling inputs on teleporting via a Momentum teleport

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -73,6 +73,12 @@
         0 : "False"
         1 : "True"
     ]
+    
+    fail(choices) : "Indicates whether this teleport is for failing a level" : 0 =
+    [
+        0 : "False"
+        1 : "True"
+    ]
 ]
 
 @SolidClass base(TeleTrigger) = trigger_momentum_teleport : "A trigger volume that teleports entities that touch it. Entities are teleported to the Remote Destination. "+

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -19,7 +19,7 @@ MAKE_TOGGLE_CONVAR(mom_saveloc_save_between_sessions, "1", FCVAR_ARCHIVE, "Defin
 
 SavedLocation_t::SavedLocation_t() : m_bCrouched(false), m_vecPos(vec3_origin), m_vecVel(vec3_origin), m_qaAng(vec3_angle),
                                      m_fGravityScale(1.0f), m_fMovementLagScale(1.0f), m_iDisabledButtons(0), m_savedComponents(SAVELOC_NONE),
-                                     m_iZone(-1), m_iTrack(-1)
+                                     m_iZone(-1), m_iTrack(-1), m_iToggledButtons(0)
 {
     m_szTargetName[0] = '\0';
     m_szTargetClassName[0] = '\0';
@@ -62,6 +62,9 @@ SavedLocation_t::SavedLocation_t(CMomentumPlayer* pPlayer, int components /*= SA
     if ( components & SAVELOC_ZONE )
         m_iZone = pPlayer->m_Data.m_iCurrentZone;
 
+    if ( components & SAVELOC_TOGGLED_BTNS )
+        m_iToggledButtons = pPlayer->m_nButtonsToggled;
+
     if ( components & SAVELOC_EVENT_QUEUE )
         g_EventQueue.SaveForTarget(pPlayer, entEventsState);
 }
@@ -103,6 +106,9 @@ void SavedLocation_t::Save(KeyValues* kvCP) const
     if ( m_savedComponents & SAVELOC_ZONE )
         kvCP->SetInt( "zone", m_iZone );
 
+    if ( m_savedComponents & SAVELOC_TOGGLED_BTNS )
+        kvCP->SetInt("toggledButtons", m_iToggledButtons);
+
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         entEventsState.SaveToKeyValues(kvCP);
 }
@@ -121,6 +127,7 @@ void SavedLocation_t::Load(KeyValues* pKv)
     m_iDisabledButtons = pKv->GetInt("disabledButtons");
     m_iTrack = pKv->GetInt( "track", -1 );
     m_iZone = pKv->GetInt( "zone", -1 );
+    m_iToggledButtons = pKv->GetInt("toggledButtons");
     entEventsState.LoadFromKeyValues(pKv);
 }
 
@@ -162,6 +169,9 @@ void SavedLocation_t::Teleport(CMomentumPlayer* pPlayer)
 
     if ( m_savedComponents & SAVELOC_ZONE && m_iZone > -1 )
         pPlayer->m_Data.m_iCurrentZone = m_iZone;
+
+    if ( m_savedComponents & SAVELOC_TOGGLED_BTNS )
+        pPlayer->m_nButtonsToggled = m_iToggledButtons;
 
     if ( m_savedComponents & SAVELOC_EVENT_QUEUE )
         g_EventQueue.RestoreForTarget(pPlayer, entEventsState);

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -21,6 +21,7 @@ enum SavedLocationComponent_t
     SAVELOC_DUCKED = 1 << 9,
     SAVELOC_TRACK = 1 << 10,
     SAVELOC_ZONE = 1 << 11,
+    SAVELOC_TOGGLED_BTNS = 1 << 12,
 
     SAVELOC_ALL = ~SAVELOC_NONE,
 };
@@ -37,6 +38,7 @@ struct SavedLocation_t
     float m_fGravityScale;
     float m_fMovementLagScale;
     int m_iDisabledButtons;
+    int m_iToggledButtons;
     int m_iTrack, m_iZone;
     CEventQueueState entEventsState;
 

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -563,6 +563,15 @@ bool CTriggerMomentumTeleport::DoTeleport(CBaseEntity *pTeleportTo, CBaseEntity 
     return true;
 }
 
+void CTriggerMomentumTeleport::OnFailTeleport(CBaseEntity *pEntTeleported)
+{
+    const auto pPlayer = ToCMOMPlayer(pEntTeleported);
+    if (!pPlayer)
+        return;
+
+    pPlayer->m_nButtonsToggled = 0;
+}
+
 //---------- CTriggerProgress ----------------------------------------------------------------
 LINK_ENTITY_TO_CLASS(trigger_momentum_progress, CTriggerProgress);
 

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -505,6 +505,7 @@ LINK_ENTITY_TO_CLASS(trigger_momentum_teleport, CTriggerMomentumTeleport);
 BEGIN_DATADESC(CTriggerMomentumTeleport)
     DEFINE_KEYFIELD(m_bResetVelocity, FIELD_BOOLEAN, "stop"),
     DEFINE_KEYFIELD(m_bResetAngles, FIELD_BOOLEAN, "resetang"),
+    DEFINE_KEYFIELD(m_bFail, FIELD_BOOLEAN, "fail"),
 END_DATADESC()
 
 void CTriggerMomentumTeleport::OnStartTouch(CBaseEntity *pOther)
@@ -530,21 +531,24 @@ void CTriggerMomentumTeleport::OnEndTouch(CBaseEntity *pOther)
 
 void CTriggerMomentumTeleport::HandleTeleport(CBaseEntity *pOther)
 {
-    if (pOther)
-    {
-        if (!m_hDestinationEnt.Get())
-        {
-            if (m_target != NULL_STRING)
-                m_hDestinationEnt = gEntList.FindEntityByName(nullptr, m_target, nullptr, pOther, pOther);
-            else
-            {
-                DevWarning("CTriggerTeleport cannot teleport, pDestinationEnt and m_target are null!\n");
-                return;
-            }
-        }
+    if (!pOther)
+        return;
 
-        DoTeleport(m_hDestinationEnt.Get(), pOther);
+    if (!m_hDestinationEnt.Get())
+    {
+        if (m_target != NULL_STRING)
+            m_hDestinationEnt = gEntList.FindEntityByName(nullptr, m_target, nullptr, pOther, pOther);
+        else
+        {
+            DevWarning("CTriggerTeleport cannot teleport, pDestinationEnt and m_target are null!\n");
+            return;
+        }
     }
+
+    DoTeleport(m_hDestinationEnt.Get(), pOther);
+
+    if (m_bFail)
+        OnFailTeleport(pOther);
 }
 
 bool CTriggerMomentumTeleport::DoTeleport(CBaseEntity *pTeleportTo, CBaseEntity *pEntToTeleport)

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -303,11 +303,14 @@ public:
     // True if the entity was teleported, else false
     virtual bool DoTeleport(CBaseEntity *pTeleportTo, CBaseEntity *pEntToTeleport);
     // After teleporting, do this code. Base class does nothing.
-    virtual void AfterTeleport(CBaseEntity *pEntTeleported) {};
+    virtual void AfterTeleport(CBaseEntity *pEntTeleported) {}
+    // Called when teleported by a fail teleport
+    void OnFailTeleport(CBaseEntity *pEntTeleported) {}
 
 private:
     bool m_bResetVelocity;
     bool m_bResetAngles;
+    bool m_bFail;
     EHANDLE m_hDestinationEnt;
 };
 

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -305,7 +305,7 @@ public:
     // After teleporting, do this code. Base class does nothing.
     virtual void AfterTeleport(CBaseEntity *pEntTeleported) {}
     // Called when teleported by a fail teleport
-    void OnFailTeleport(CBaseEntity *pEntTeleported) {}
+    void OnFailTeleport(CBaseEntity *pEntTeleported);
 
 private:
     bool m_bResetVelocity;


### PR DESCRIPTION
Closes #922

Only untoggles if the teleport is a `CTriggerMomentumTeleport` as not all teleporting of the player should reset inputs.

Uses defined but unused `AfterTeleport` function.

Probably should've been a good first issue but I had already assigned to myself.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
