### PR TITLE
Add Cubemap to Main Menu Model

### DIFF
--- a/mp/src/game/client/c_baseentity.cpp
+++ b/mp/src/game/client/c_baseentity.cpp
@@ -4202,13 +4202,14 @@ vec_t C_BaseEntity::GetLocalAnglesDim( int iDim ) const
 // Prevent these for now until hierarchy is properly networked
 void C_BaseEntity::SetLocalAngles( const QAngle& angles )
 {
-	// NOTE: The angle normalize is a little expensive, but we can save
-	// a bunch of time in interpolation if we don't have to invalidate everything
-	// and sometimes it's off by a normalization amount
-
-	// FIXME: The normalize caused problems in server code like momentary_rot_button that isn't
-	//        handling things like +/-180 degrees properly. This should be revisited.
-	//QAngle angleNormalize( AngleNormalize( angles.x ), AngleNormalize( angles.y ), AngleNormalize( angles.z ) );
+	// Safety check against NaN's or really huge numbers
+	// And actually normalize the angles rather than freeze the entity and spam warnings
+	if (!IsEntityQAngleReasonable(angles))
+	{
+		QAngle angleNormalize(AngleNormalize(angles.x), AngleNormalize(angles.y), AngleNormalize(angles.z));
+		SetLocalAngles(angleNormalize);
+		return;
+	}
 
 	if (m_angRotation != angles)
 	{

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -441,11 +441,11 @@ void CRenderPanel::DrawModel()
 
 void CRenderPanel::SetRenderColors(C_BaseEntity* pEnt)
 {
-    color32 col = pEnt->GetRenderColor();
-    float color[4] = { col.r / 255.0f, col.g / 255.0f, col.b / 255.0f, col.a / 255.0f };
-    float alphaBias = (GetParent() ? GetParent()->GetAlpha() : GetAlpha()) / 255.0f;
+    const auto col = pEnt->GetRenderColor();
+    const auto fAlpha = col.a / 255.0f;
+    float color[4] = { col.r / 255.0f, col.g / 255.0f, col.b / 255.0f, fAlpha };
     render->SetColorModulation(color);
-    render->SetBlend(alphaBias * color[3]);
+    render->SetBlend(fAlpha);
 }
 
 void CRenderPanel::FireGameEvent(IGameEvent* event)

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -45,6 +45,8 @@ CRenderPanel::CRenderPanel(Panel *parent, const char *pElementName) : BaseClass(
     __ViewProj.Identity();
     __ViewProjNDC.Identity();
 
+    m_hDefaultCubemap.Init(materials->FindTexture("cubemaps/cubemap_menu_model_bg.hdr", TEXTURE_GROUP_CUBE_MAP));
+
     ListenForGameEvent("invalid_mdl_cache");
     SetPaintBorderEnabled(true);
 }
@@ -112,7 +114,6 @@ void CRenderPanel::OnThink()
         {
             if (m_nAllowedRotateModes & ROTATE_PITCH)
             {
-
                 m_flPitch -= mdelta_y * 0.5f;
                 m_flPitch = clamp(m_flPitch, -89, 89);
             }
@@ -133,8 +134,7 @@ void CRenderPanel::OnThink()
 #define RENDER_DRAGPOS_MOVESCALE 0.2f
             Vector viewRight, viewUp;
             AngleVectors(render_ang, NULL, &viewRight, &viewUp);
-            render_offset +=
-                mdelta_x * -viewRight * RENDER_DRAGPOS_MOVESCALE + mdelta_y * viewUp * RENDER_DRAGPOS_MOVESCALE;
+            render_offset += mdelta_x * -viewRight * RENDER_DRAGPOS_MOVESCALE + mdelta_y * viewUp * RENDER_DRAGPOS_MOVESCALE;
         }
         break;
         default:
@@ -421,6 +421,8 @@ void CRenderPanel::Paint()
     MaterialFogMode_t oldFog = pRenderContext->GetFogMode();
     pRenderContext->FogMode(MATERIAL_FOG_NONE);
 
+    pRenderContext->BindLocalCubemap(m_hDefaultCubemap);
+
     DrawModel();
 
     pRenderContext->FogMode(oldFog);
@@ -428,6 +430,8 @@ void CRenderPanel::Paint()
     render->PopView(frustum);
 
     modelrender->SuppressEngineLighting(false);
+
+    pRenderContext->Flush();
 }
 
 void CRenderPanel::DrawModel()

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -383,6 +383,9 @@ void CRenderPanel::Paint()
 {
     BaseClass::Paint();
 
+    if (!IsModelReady())
+        return;
+
     MDLCACHE_CRITICAL_SECTION();
 
     modelrender->SuppressEngineLighting(true);

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.h
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.h
@@ -6,8 +6,8 @@ enum DragRotateMode_t
 {
     RDRAG_NONE = 0,
     RDRAG_ROTATE = 1 << 0,
-    RDRAG_LIGHT = 1 << 1,
-    RDRAG_POS = 1 << 2,
+    RDRAG_POS = 1 << 1,
+    RDRAG_LIGHT = 1 << 2,
 
     RDRAG_ALL = ~RDRAG_NONE,
 };

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.h
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.h
@@ -120,6 +120,7 @@ private:
     VMatrix __ViewProj;
     VMatrix __ViewProjNDC;
 
+    CTextureReference m_hDefaultCubemap;
     C_ModelPanelModel *m_pModelInstance;
     char m_szModelPath[MAX_PATH];
 

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/MainMenu.cpp
@@ -125,6 +125,7 @@ MainMenu::MainMenu(CBaseMenuPanel *pParent) : BaseClass(pParent, "MainMenu")
     m_pModelPanel->SetAllowedDragModes(RDRAG_ROTATE);
     m_pModelPanel->SetAllowedRotateModes(ROTATE_YAW);
     m_pModelPanel->SetCameraDefaults(40, 0.0f, 180.0f, 200);
+    m_pModelPanel->SetDefaultLightAngle(QAngle(90.0f, 0, 0));
     m_pModelPanel->SetAutoModelRotationSpeed(QAngle(0, mom_menu_model_rotation_speed.GetInt(), 0));
     m_pModelPanel->LoadModel(mom_menu_model_path.GetString());
 


### PR DESCRIPTION
Closes #981

![image](https://user-images.githubusercontent.com/5162166/94983391-59414f00-0510-11eb-83a6-a4bc4135cfa5.png)

This PR adds a default cubemap to use for the model panel. Since the model panel is only used in the menu and settings panel, it is hardcoded to use the default cubemap, but can be expanded in the future to update cubemaps based on the background textures (unlocked progress?), or be customized completely via res file or something.

Fixed a regression from my earlier changes and did some minor optimizations to the ModelPanel class.

Tested it by going in game, both LDR and HDR, and changing model / resolution settings. Solid as far as I know.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
