### PR TITLE
Fix Main Menu Softlock

### DIFF
--- a/mp/src/public/vgui_controls/Frame.h
+++ b/mp/src/public/vgui_controls/Frame.h
@@ -199,6 +199,7 @@ private:
 	void SetupResizeCursors();
 	void FinishClose();
 	void OnFrameFocusChanged(bool bHasFocus);
+	void ReleaseModal();
 
 	Color		_titleBarBgColor;
 	Color		_titleBarDisabledBgColor;

--- a/mp/src/vgui2/vgui_controls/Frame.cpp
+++ b/mp/src/vgui2/vgui_controls/Frame.cpp
@@ -980,6 +980,21 @@ void Frame::DoModal( )
 	vgui::input()->SetAppModalSurface( GetVPanel() );
 }
 
+void Frame::ReleaseModal()
+{
+	const auto hVPanel = GetVPanel();
+	if (input()->GetAppModalSurface() != hVPanel)
+		return;
+
+	input()->ReleaseAppModalSurface();
+
+	if (m_hPreviousModal != 0 && m_hPreviousModal != hVPanel)
+	{
+		input()->SetAppModalSurface(m_hPreviousModal);
+	}
+
+    m_hPreviousModal = 0;
+}
 
 //-----------------------------------------------------------------------------
 // Closes a modal dialog

--- a/mp/src/vgui2/vgui_controls/Frame.cpp
+++ b/mp/src/vgui2/vgui_controls/Frame.cpp
@@ -878,15 +878,7 @@ Frame::Frame(Panel *parent, const char *panelName, bool showTaskbarIcon /*=true*
 //-----------------------------------------------------------------------------
 Frame::~Frame()
 {
-	if ( input()->GetAppModalSurface() == GetVPanel() )
-	{
-		vgui::input()->ReleaseAppModalSurface();
-		if ( m_hPreviousModal != 0 )
-		{
-			vgui::input()->SetAppModalSurface( m_hPreviousModal );
-			m_hPreviousModal = 0;
-		}
-	}
+	ReleaseModal();
 
 	delete _title;
 }
@@ -1001,15 +993,8 @@ void Frame::ReleaseModal()
 //-----------------------------------------------------------------------------
 void Frame::CloseModal()
 {
-	vgui::input()->ReleaseAppModalSurface();
-	if ( m_hPreviousModal != 0 )
-	{
-		vgui::input()->SetAppModalSurface( m_hPreviousModal );
-		m_hPreviousModal = 0;
-	}
-	PostMessage( this, new KeyValues("Close") );
+	OnClose();
 }
-
 
 //-----------------------------------------------------------------------------
 // Purpose: activates the dialog 
@@ -1759,15 +1744,7 @@ void Frame::InitSettings()
 void Frame::OnClose()
 {
 	// if we're modal, release that before we hide the window else the wrong window will get focus
-	if (input()->GetAppModalSurface() == GetVPanel())
-	{
-		input()->ReleaseAppModalSurface();
-		if ( m_hPreviousModal != 0 )
-		{
-			vgui::input()->SetAppModalSurface( m_hPreviousModal );
-			m_hPreviousModal = 0;
-		}
-	}
+	ReleaseModal();
 	
 	BaseClass::OnClose();
 

--- a/mp/src/vgui2/vgui_controls/Frame.cpp
+++ b/mp/src/vgui2/vgui_controls/Frame.cpp
@@ -964,12 +964,15 @@ void Frame::Activate()
 //-----------------------------------------------------------------------------
 void Frame::DoModal( )
 {
+	if (input()->GetAppModalSurface() == GetVPanel())
+		return;
+
 	// move to the middle of the screen
 	MoveToCenterOfScreen();
 	InvalidateLayout();
 	Activate();
-	m_hPreviousModal = vgui::input()->GetAppModalSurface();
-	vgui::input()->SetAppModalSurface( GetVPanel() );
+	m_hPreviousModal = input()->GetAppModalSurface();
+	input()->SetAppModalSurface( GetVPanel() );
 }
 
 void Frame::ReleaseModal()


### PR DESCRIPTION
Closes #982

This PR fixes a softlock found by hex by preventing modal panels from becoming modal multiple times, which in turn made them set themselves to modal before deleting themselves... not pretty. Cleaned up the modal logic to prevent this from happening ever again in the first place.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
