### PR TITLE
Ability to draw a zone's side faces, not just outline

### DIFF
--- a/mp/game/momentum/materials/momentum/zone_material.vmt
+++ b/mp/game/momentum/materials/momentum/zone_material.vmt
@@ -6,5 +6,5 @@
     "$selfillum" "1"
     "$nofog" "1"
     "$nocull" "1"
-    "$alphatest" "1"
+    "$alphatest" "0"
 }

--- a/mp/game/momentum/materials/momentum/zone_material_overlay.vmt
+++ b/mp/game/momentum/materials/momentum/zone_material_overlay.vmt
@@ -1,0 +1,10 @@
+"UnlitGeneric"
+{
+    "$vertexcolor" "1"
+    "$vertexalpha" "1"
+    "$ignorez" "1" // Change this to 1 to see it through walls
+    "$selfillum" "1"
+    "$nofog" "1"
+    "$nocull" "1"
+    "$alphatest" "0"
+}

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -9,6 +9,7 @@
 #include "mom_shareddefs.h"
 #include "dt_utlvector_recv.h"
 #include "debugoverlay_shared.h"
+#include "mom_player_shared.h"
 
 #include "tier0/memdbgon.h"
 
@@ -121,6 +122,18 @@ bool C_BaseMomZoneTrigger::ShouldDraw()
 
 int C_BaseMomZoneTrigger::DrawModel(int flags)
 {
+    const auto pPlayer = C_MomentumPlayer::GetLocalMomPlayer();
+    if (!pPlayer)
+        return 0;
+
+    const auto pRunEntData = pPlayer->GetCurrentUIEntData();
+    if (!pRunEntData)
+        return 0;
+
+    const auto pStartZone = dynamic_cast<C_TriggerTimerStart*>(this);
+    if (!pStartZone && m_iTrackNumber != pRunEntData->m_iCurrentTrack)
+        return 0;
+
     if (ShouldDrawOutline())
     {
         if ((flags & STUDIO_RENDER) && (flags & (STUDIO_SHADOWDEPTHTEXTURE | STUDIO_SHADOWDEPTHTEXTURE)) == 0)

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -22,6 +22,17 @@ static ConVar mom_zone_start_outline_color("mom_zone_start_outline_color", "00FF
 static ConVar mom_zone_end_outline_color("mom_zone_end_outline_color", "FF0000FF", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Color of the end zone.");
 static ConVar mom_zone_stage_outline_color("mom_zone_stage_outline_color", "0000FFFF", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Color of the stage zone(s).");
 static ConVar mom_zone_checkpoint_outline_color("mom_zone_checkpoint_outline_color", "FFFF00FF", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Color of the checkpoint zone(s).");
+enum ZoneDrawMode_t
+{
+    MOM_ZONE_DRAW_MODE_NONE = 0,
+    MOM_ZONE_DRAW_MODE_OUTLINE,
+    MOM_ZONE_DRAW_MODE_FACES_BRUSH,
+    MOM_ZONE_DRAW_MODE_FACES_OVERLAY,
+
+    MOM_ZONE_DRAW_MODE_FIRST = MOM_ZONE_DRAW_MODE_NONE,
+    MOM_ZONE_DRAW_MODE_LAST = MOM_ZONE_DRAW_MODE_FACES_OVERLAY
+};
+
 
 CTriggerOutlineRenderer::CTriggerOutlineRenderer()
 {
@@ -52,8 +63,8 @@ bool CTriggerOutlineRenderer::RenderBrushModelSurface(IClientEntity* pBaseEntity
 
     CMeshBuilder builder;
     builder.Begin(pRenderContext->GetDynamicMesh(true, nullptr, nullptr, 
-                                                 materials->FindMaterial("momentum/zone_outline", TEXTURE_GROUP_OTHER)),
-                    MATERIAL_LINE_LOOP, vertices);
+        materials->FindMaterial("momentum/zone_outline", TEXTURE_GROUP_OTHER)),
+        m_iRenderMode == MOM_ZONE_DRAW_MODE_FACES_BRUSH || m_iRenderMode == MOM_ZONE_DRAW_MODE_FACES_OVERLAY ? MATERIAL_POLYGON : MATERIAL_LINE_LOOP, vertices);
 
     for (int i = 0; i < vertices; i++)
     {

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -235,8 +235,7 @@ int C_BaseMomZoneTrigger::DrawModel(int flags)
     if (!pRunEntData)
         return 0;
 
-    const auto pStartZone = dynamic_cast<C_TriggerTimerStart*>(this);
-    if (!pStartZone && m_iTrackNumber != pRunEntData->m_iCurrentTrack)
+    if (GetZoneType() != ZONE_TYPE_START && m_iTrackNumber != pRunEntData->m_iCurrentTrack)
         return 0;
 
     int iRenderMode = GetDrawMode();
@@ -273,6 +272,11 @@ int C_BaseMomZoneTrigger::DrawModel(int flags)
     return BaseClass::DrawModel(flags);
 }
 
+int C_BaseMomZoneTrigger::GetZoneType()
+{
+    return ZONE_TYPE_INVALID;
+}
+
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_start, C_TriggerTimerStart);
 
 IMPLEMENT_CLIENTCLASS_DT(C_TriggerTimerStart, DT_TriggerTimerStart, CTriggerTimerStart)
@@ -286,6 +290,11 @@ bool C_TriggerTimerStart::GetDrawColor()
 int C_TriggerTimerStart::GetDrawMode()
 {
     return mom_zone_start_draw_mode.GetInt();
+}
+
+int C_TriggerTimerStart::GetZoneType()
+{
+    return ZONE_TYPE_START;
 }
 
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_stop, C_TriggerTimerStop);
@@ -303,6 +312,11 @@ int C_TriggerTimerStop::GetDrawMode()
     return mom_zone_end_draw_mode.GetInt();
 }
 
+int C_TriggerTimerStop::GetZoneType()
+{
+    return ZONE_TYPE_STOP;
+}
+
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_stage, C_TriggerStage);
 
 IMPLEMENT_CLIENTCLASS_DT(C_TriggerStage, DT_TriggerStage, CTriggerStage)
@@ -318,6 +332,11 @@ int C_TriggerStage::GetDrawMode()
     return mom_zone_stage_draw_mode.GetInt();
 }
 
+int C_TriggerStage::GetZoneType()
+{
+    return ZONE_TYPE_STAGE;
+}
+
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_checkpoint, C_TriggerCheckpoint);
 
 IMPLEMENT_CLIENTCLASS_DT(C_TriggerCheckpoint, DT_TriggerCheckpoint, CTriggerCheckpoint)
@@ -331,6 +350,11 @@ bool C_TriggerCheckpoint::GetDrawColor()
 int C_TriggerCheckpoint::GetDrawMode()
 {
     return mom_zone_checkpoint_draw_mode.GetInt();
+}
+
+int C_TriggerCheckpoint::GetZoneType()
+{
+    return ZONE_TYPE_CHECKPOINT;
 }
 
 // ====================================
@@ -353,6 +377,11 @@ C_TriggerTrickZone::C_TriggerTrickZone()
 int C_TriggerTrickZone::GetDrawMode()
 {
     return m_iDrawState > TRICK_DRAW_NONE;
+}
+
+int C_TriggerTrickZone::GetZoneType()
+{
+    return ZONE_TYPE_TRICK;
 }
 
 bool C_TriggerTrickZone::GetDrawColor()

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -136,6 +136,33 @@ bool C_BaseMomZoneTrigger::ShouldDraw()
     return true;
 }
 
+void C_BaseMomZoneTrigger::DrawSideFacesModelAsOverlay()
+{
+    const int iNum = m_vecZonePoints.Count();
+    if (iNum <= 2)
+        return;
+
+    Color faceColor = m_OutlineRenderer.outlineColor;
+
+    Vector min = Vector(0, 0, 0);
+    for (int i = 0; i < iNum; i++)
+    {
+        const auto& vecCurr = m_vecZonePoints[i];
+        const auto& vecNext = m_vecZonePoints[(i + 1) % iNum];
+
+        QAngle angle(0.0f, 0.0f, 0.0f);
+        float iWidth = sqrtf(Sqr(vecNext.x - vecCurr.x) + Sqr(vecNext.y - vecCurr.y));
+
+        VectorAngles(vecNext - vecCurr, angle);
+
+        // `AddBoxOverlay` always draws outlines based on the color given so `AddBoxOverlay2` is used
+        // 0.001 duration used as 0, FLT_EPSILON, 0.01, etc. flickers for some reason
+        // too high of duration causes too much to be rendered at once and can crash / lag the game
+        debugoverlay->AddBoxOverlay(vecCurr, min, Vector(iWidth, 0, m_flZoneHeight), angle, faceColor.r(), faceColor.g(),
+                                    faceColor.b(), faceColor.a(), mom_zone_draw_overlay_duration.GetFloat());
+    }
+}
+
 int C_BaseMomZoneTrigger::DrawModel(int flags)
 {
     const auto pPlayer = C_MomentumPlayer::GetLocalMomPlayer();

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -81,38 +81,54 @@ C_BaseMomZoneTrigger::C_BaseMomZoneTrigger()
     m_iTrackNumber = -1; // TRACK_ALL
 }
 
-void C_BaseMomZoneTrigger::DrawOutlineModel(const Color& outlineColor)
+void C_BaseMomZoneTrigger::DrawOutlineModel()
 {
     const int iNum = m_vecZonePoints.Count();
-
     if (iNum <= 2)
         return;
 
+    Color outlineColor = m_OutlineRenderer.outlineColor;
+
+    CMatRenderContextPtr pRenderContext(materials);
+    IMesh *pMesh = pRenderContext->GetDynamicMesh(true, nullptr, nullptr, materials->FindMaterial("momentum/zone_outline", TEXTURE_GROUP_OTHER));
+    CMeshBuilder builder;
+
     // Bottom
+    builder.Begin(pMesh, MATERIAL_LINE_LOOP, iNum);
     for (int i = 0; i < iNum; i++)
     {
-        const auto cur = m_vecZonePoints[i];
-        const auto next = i == (iNum - 1) ? m_vecZonePoints[0] : m_vecZonePoints[i+1];
-        debugoverlay->AddLineOverlayAlpha(cur, next, outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a(), false, 0.0f);
+        builder.Position3fv(m_vecZonePoints[i].Base());
+        builder.Color4ub(outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a());
+        builder.AdvanceVertex();
     }
+    builder.End(false, true);
 
     // Connecting lines
     for (int i = 0; i < iNum; i++)
     {
-        const Vector &cur = m_vecZonePoints[i];
-        const Vector next(cur.x, cur.y, cur.z + m_flZoneHeight);
-        debugoverlay->AddLineOverlayAlpha(cur, next, outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a(), false, 0.0f);
+        // Connecting lines
+        builder.Begin(pMesh, MATERIAL_LINES, 2);
+
+        builder.Position3fv(m_vecZonePoints[i].Base());
+        builder.Color4ub(outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a());
+        builder.AdvanceVertex();
+
+        builder.Position3f(m_vecZonePoints[i].x, m_vecZonePoints[i].y, m_vecZonePoints[i].z + m_flZoneHeight);
+        builder.Color4ub(outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a());
+        builder.AdvanceVertex();
+
+        builder.End(false, true);
     }
 
     // Top
+    builder.Begin(pMesh, MATERIAL_LINE_LOOP, iNum);
     for (int i = 0; i < iNum; i++)
     {
-        auto cur = m_vecZonePoints[i];
-        auto next = i == (iNum - 1) ? m_vecZonePoints[0] : m_vecZonePoints[i + 1];
-        Vector curUp(cur.x, cur.y, cur.z + m_flZoneHeight);
-        Vector nextUp(next.x, next.y, next.z + m_flZoneHeight);
-        debugoverlay->AddLineOverlayAlpha(curUp, nextUp, outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a(), false, 0.0f);
+        builder.Position3f(m_vecZonePoints[i].x, m_vecZonePoints[i].y, m_vecZonePoints[i].z + m_flZoneHeight);
+        builder.Color4ub(outlineColor.r(), outlineColor.g(), outlineColor.b(), outlineColor.a());
+        builder.AdvanceVertex();
     }
+    builder.End(false, true);
 }
 
 bool C_BaseMomZoneTrigger::ShouldDraw()

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -131,9 +131,43 @@ void C_BaseMomZoneTrigger::DrawOutlineModel()
     builder.End(false, true);
 }
 
-bool C_BaseMomZoneTrigger::ShouldDraw()
+void C_BaseMomZoneTrigger::DrawSideFacesModelAsBrush()
 {
-    return true;
+    const int iNum = m_vecZonePoints.Count();
+    if (iNum <= 2)
+        return;
+
+    Color faceColor = m_OutlineRenderer.outlineColor;
+
+    CMatRenderContextPtr pRenderContext(materials);
+    IMesh *pMesh = pRenderContext->GetDynamicMesh(true, nullptr, nullptr, materials->FindMaterial("momentum/zone_outline", TEXTURE_GROUP_OTHER));
+    CMeshBuilder builder;
+
+    for (int i = 0; i < iNum; i++)
+    {
+        const auto& vecCurr = m_vecZonePoints[i];
+        const auto& vecNext = m_vecZonePoints[(i + 1) % iNum];
+
+        builder.Begin(pMesh, MATERIAL_QUADS, 4);
+
+        builder.Position3fv(vecCurr.Base());
+        builder.Color4ub(faceColor.r(), faceColor.g(), faceColor.b(), faceColor.a());
+        builder.AdvanceVertex();
+
+        builder.Position3f(vecCurr.x, vecCurr.y, vecCurr.z + m_flZoneHeight);
+        builder.Color4ub(faceColor.r(), faceColor.g(), faceColor.b(), faceColor.a());
+        builder.AdvanceVertex();
+
+        builder.Position3f(vecNext.x, vecNext.y, vecNext.z + m_flZoneHeight);
+        builder.Color4ub(faceColor.r(), faceColor.g(), faceColor.b(), faceColor.a());
+        builder.AdvanceVertex();
+
+        builder.Position3fv(vecNext.Base());
+        builder.Color4ub(faceColor.r(), faceColor.g(), faceColor.b(), faceColor.a());
+        builder.AdvanceVertex();
+        
+        builder.End(false, true);
+    }
 }
 
 void C_BaseMomZoneTrigger::DrawSideFacesModelAsOverlay()

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -248,6 +248,19 @@ int C_BaseMomZoneTrigger::DrawModel(int flags)
     return BaseClass::DrawModel(flags);
 }
 
+void C_BaseMomZoneTrigger::Spawn()
+{
+    BaseClass::Spawn();
+    Precache();
+}
+
+void C_BaseMomZoneTrigger::Precache()
+{
+    BaseClass::Precache();
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL);
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL_OVERLAY);
+}
+
 int C_BaseMomZoneTrigger::GetZoneType()
 {
     return ZONE_TYPE_INVALID;

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -33,6 +33,8 @@ public:
     int DrawModel(int flags) override;
     bool IsTwoPass() override { return true; }
     bool IsTransparent() override { return true; }
+    void Spawn() override;
+    void Precache() override;
 
     virtual int GetZoneType();
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -5,8 +5,8 @@ class CTriggerOutlineRenderer : public IBrushRenderer
 public:
     CTriggerOutlineRenderer();
     virtual ~CTriggerOutlineRenderer();
-    Color outlineColor;
     bool RenderBrushModelSurface(IClientEntity* pBaseEntity, IBrushSurface* pBrushSurface) override;
+    Color m_Color;
     int m_iRenderMode;
 private:
     BrushVertex_t *m_pVertices;
@@ -21,8 +21,9 @@ class C_BaseMomZoneTrigger : public C_BaseEntity
 public:
     C_BaseMomZoneTrigger();
 
-    virtual bool ShouldDrawOutline() { return false; }
-    virtual bool GetOutlineColor() { return false; }
+    virtual bool ShouldDrawModel() { return false; }
+    virtual bool GetDrawColor() { return false; }
+    virtual int GetDrawMode() { return 0; }
 
     void DrawOutlineModel();
 
@@ -40,7 +41,7 @@ public:
     float m_flZoneHeight;
 
 protected:
-    CTriggerOutlineRenderer m_OutlineRenderer;
+    CTriggerOutlineRenderer m_ZoneModelRenderer;
 };
 
 class C_TriggerTimerStart : public C_BaseMomZoneTrigger
@@ -48,8 +49,9 @@ class C_TriggerTimerStart : public C_BaseMomZoneTrigger
   public:
     DECLARE_CLASS(C_TriggerTimerStart, C_BaseMomZoneTrigger);
     DECLARE_CLIENTCLASS();
-    bool ShouldDrawOutline() OVERRIDE;
-    bool GetOutlineColor() OVERRIDE;
+
+    bool GetDrawColor() override;
+    int GetDrawMode() override;
 };
 
 class C_TriggerTimerStop : public C_BaseMomZoneTrigger
@@ -58,8 +60,8 @@ class C_TriggerTimerStop : public C_BaseMomZoneTrigger
     DECLARE_CLASS(C_TriggerTimerStop, C_BaseMomZoneTrigger);
     DECLARE_CLIENTCLASS();
 
-    bool ShouldDrawOutline() OVERRIDE;
-    bool GetOutlineColor() OVERRIDE;
+    bool GetDrawColor() override;
+    int GetDrawMode() override;
 };
 
 class C_TriggerStage : public C_BaseMomZoneTrigger
@@ -68,8 +70,8 @@ public:
     DECLARE_CLASS(C_TriggerStage, C_BaseMomZoneTrigger);
     DECLARE_CLIENTCLASS();
 
-    bool ShouldDrawOutline() OVERRIDE;
-    bool GetOutlineColor() OVERRIDE;
+    bool GetDrawColor() override;
+    int GetDrawMode() override;
 };
 
 class C_TriggerCheckpoint : public C_BaseMomZoneTrigger
@@ -78,8 +80,8 @@ public:
     DECLARE_CLASS(C_TriggerCheckpoint, C_BaseMomZoneTrigger);
     DECLARE_CLIENTCLASS();
 
-    bool ShouldDrawOutline() OVERRIDE;
-    bool GetOutlineColor() OVERRIDE;
+    bool GetDrawColor() override;
+    int GetDrawMode() override;
 };
 
 class C_TriggerTrickZone : public C_BaseMomZoneTrigger
@@ -90,8 +92,8 @@ public:
 
     C_TriggerTrickZone();
 
-    bool ShouldDrawOutline() override;
-    bool GetOutlineColor() override;
+    bool GetDrawColor() override;
+    int GetDrawMode() override;
 
     void OnDataChanged(DataUpdateType_t type) override;
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -35,6 +35,8 @@ public:
     bool IsTwoPass() override { return true; }
     bool IsTransparent() override { return true; }
 
+    virtual int GetZoneType();
+
     int m_iTrackNumber;
 
     CUtlVector<Vector> m_vecZonePoints;
@@ -52,6 +54,7 @@ class C_TriggerTimerStart : public C_BaseMomZoneTrigger
 
     bool GetDrawColor() override;
     int GetDrawMode() override;
+    int GetZoneType() override;
 };
 
 class C_TriggerTimerStop : public C_BaseMomZoneTrigger
@@ -62,6 +65,7 @@ class C_TriggerTimerStop : public C_BaseMomZoneTrigger
 
     bool GetDrawColor() override;
     int GetDrawMode() override;
+    int GetZoneType() override;
 };
 
 class C_TriggerStage : public C_BaseMomZoneTrigger
@@ -72,6 +76,7 @@ public:
 
     bool GetDrawColor() override;
     int GetDrawMode() override;
+    int GetZoneType() override;
 };
 
 class C_TriggerCheckpoint : public C_BaseMomZoneTrigger
@@ -82,6 +87,7 @@ public:
 
     bool GetDrawColor() override;
     int GetDrawMode() override;
+    int GetZoneType() override;
 };
 
 class C_TriggerTrickZone : public C_BaseMomZoneTrigger
@@ -94,6 +100,7 @@ public:
 
     bool GetDrawColor() override;
     int GetDrawMode() override;
+    int GetZoneType() override;
 
     void OnDataChanged(DataUpdateType_t type) override;
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -23,9 +23,11 @@ public:
     virtual bool ShouldDrawOutline() { return false; }
     virtual bool GetOutlineColor() { return false; }
 
-    void DrawOutlineModel(const Color &outlineColor);
+    void DrawOutlineModel();
     bool ShouldDraw() OVERRIDE;
     int DrawModel(int flags) OVERRIDE;
+    bool IsTwoPass() override { return true; }
+    bool IsTransparent() override { return true; }
 
     int m_iTrackNumber;
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -24,11 +24,12 @@ public:
     virtual bool GetOutlineColor() { return false; }
 
     void DrawOutlineModel();
-    bool ShouldDraw() OVERRIDE;
     int DrawModel(int flags) OVERRIDE;
 
+    void DrawSideFacesModelAsBrush();
     void DrawSideFacesModelAsOverlay();
 
+    bool ShouldDraw() override { return true; }
     bool IsTwoPass() override { return true; }
     bool IsTransparent() override { return true; }
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -25,10 +25,9 @@ public:
     virtual bool GetDrawColor() { return false; }
     virtual int GetDrawMode() { return 0; }
 
-    void DrawOutlineModel();
+    void DrawOutlineModel(bool bOverlay);
 
-    void DrawSideFacesModelAsBrush();
-    void DrawSideFacesModelAsOverlay();
+    void DrawSideFacesModel(bool bOverlay);
 
     bool ShouldDraw() override { return true; }
     int DrawModel(int flags) override;

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -5,8 +5,9 @@ class CTriggerOutlineRenderer : public IBrushRenderer
 public:
     CTriggerOutlineRenderer();
     virtual ~CTriggerOutlineRenderer();
-    bool RenderBrushModelSurface(IClientEntity* pBaseEntity, IBrushSurface* pBrushSurface) OVERRIDE;
     Color outlineColor;
+    bool RenderBrushModelSurface(IClientEntity* pBaseEntity, IBrushSurface* pBrushSurface) override;
+    int m_iRenderMode;
 private:
     BrushVertex_t *m_pVertices;
     int m_vertexCount;
@@ -24,12 +25,12 @@ public:
     virtual bool GetOutlineColor() { return false; }
 
     void DrawOutlineModel();
-    int DrawModel(int flags) OVERRIDE;
 
     void DrawSideFacesModelAsBrush();
     void DrawSideFacesModelAsOverlay();
 
     bool ShouldDraw() override { return true; }
+    int DrawModel(int flags) override;
     bool IsTwoPass() override { return true; }
     bool IsTransparent() override { return true; }
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -26,6 +26,9 @@ public:
     void DrawOutlineModel();
     bool ShouldDraw() OVERRIDE;
     int DrawModel(int flags) OVERRIDE;
+
+    void DrawSideFacesModelAsOverlay();
+
     bool IsTwoPass() override { return true; }
     bool IsTransparent() override { return true; }
 

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -25,9 +25,8 @@ public:
     virtual bool GetDrawColor() { return false; }
     virtual int GetDrawMode() { return 0; }
 
-    void DrawOutlineModel(bool bOverlay);
-
-    void DrawSideFacesModel(bool bOverlay);
+    void DrawZoneOutlines(bool bOverlay);
+    void DrawZoneFaces(bool bOverlay);
 
     bool ShouldDraw() override { return true; }
     int DrawModel(int flags) override;

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -3,6 +3,7 @@
 #include "mom_triggers.h"
 #include "in_buttons.h"
 #include "mom_player_shared.h"
+#include "mom_shareddefs.h"
 #include "mom_replay_entity.h"
 #include "mom_system_gamemode.h"
 #include "mom_system_progress.h"
@@ -96,6 +97,19 @@ CBaseMomZoneTrigger::CBaseMomZoneTrigger()
 {
     m_iTrackNumber = TRACK_MAIN; // Default zones to the main map.
     m_vecRestartPos = vec3_invalid;
+}
+
+void CBaseMomZoneTrigger::Spawn()
+{
+    Precache();
+    BaseClass::Spawn();
+}
+
+void CBaseMomZoneTrigger::Precache()
+{
+    BaseClass::Precache();
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL);
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL_OVERLAY);
 }
 
 void CBaseMomZoneTrigger::InitCustomCollision(CPhysCollide* pPhysCollide, const Vector& vecMins, const Vector& vecMaxs)

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -96,6 +96,9 @@ public:
 
     CBaseMomZoneTrigger();
 
+    void Spawn() override;
+    void Precache() override;
+
     // Point-based zones need a custom collision check
     void InitCustomCollision(CPhysCollide *pPhysCollide, const Vector &vecMins, const Vector &vecMaxs);
     virtual bool TestCollision(const Ray_t &ray, unsigned int mask, trace_t &tr) OVERRIDE;

--- a/mp/src/game/shared/momentum/mom_shareddefs.h
+++ b/mp/src/game/shared/momentum/mom_shareddefs.h
@@ -358,4 +358,8 @@ enum WallRunState
 #define LOBBY_DATA_OWNER_MAP "owner_map" // Note: this is used by public and roaming lobbies
 #define LOBBY_DATA_TYPE "type"
 
+// Use this with zone rendering
+#define MOM_ZONE_DRAW_MATERIAL "momentum/zone_material"
+#define MOM_ZONE_DRAW_MATERIAL_OVERLAY "momentum/zone_material_overlay"
+
 static const unsigned long long MOM_STEAM_GROUP_ID64 = 103582791441609755;


### PR DESCRIPTION
Closes #909 

- Drawn very similarly to zone outlines, using `debugoverlay`.
- Only draws side faces as bottom/top faces are complex with `debugoverlay`.
- Only draws outline/faces if the zone if a start zone or on current track.
- Cvars for each zone type a la the outline.

Gross thing is that it draws through walls a bit, and also the duration is arbitrary. 0 duration like the outline causes flickering, so does values larger or smaller than 0.001. Doesn't seem to be framerate dependant. Larger values also work but then lags the game a lot.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
