### PR TITLE
Fix menu-related safeguards always returning false

### DIFF
--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
@@ -57,7 +57,8 @@ static MAKE_TOGGLE_CONVAR(mom_run_safeguard_change_map, "1", FCVAR_ARCHIVE | FCV
 static MAKE_TOGGLE_CONVAR(mom_run_safeguard_quit_map, "1", FCVAR_ARCHIVE | FCVAR_REPLICATED, "Changes the safeguard setting for preventing quitting/disconnecting while in a run. 0 = OFF, 1 = ON\n");
 static MAKE_TOGGLE_CONVAR(mom_run_safeguard_quit_game, "1", FCVAR_ARCHIVE | FCVAR_REPLICATED, "Changes the safeguard setting for preventing quitting the game while in a run. 0 = OFF, 1 = ON\n");
 
-CRunSafeguard::CRunSafeguard(const char *szAction) : m_flLastTimePressed(0.0f), m_bDoublePressSafeguard(true), m_pRelatedVar(nullptr)
+CRunSafeguard::CRunSafeguard(const char *szAction)
+    : m_flLastTimePressed(0.0f), m_bDoublePressSafeguard(true), m_pRelatedVar(nullptr), m_bIgnoredInMenu(true)
 {
     Q_strncpy(m_szAction, szAction, sizeof(m_szAction));
 }
@@ -82,10 +83,10 @@ bool CRunSafeguard::IsSafeguarded(RunSafeguardMode_t mode)
         return false;
 
 #ifdef GAME_DLL
-    if (g_pRunSafeguards->IsGameUIActive())
+    if (m_bIgnoredInMenu && g_pRunSafeguards->IsGameUIActive())
         return false;
 #else
-    if (g_pBasePanel->GetMainMenu()->IsVisible())
+    if (m_bIgnoredInMenu && g_pBasePanel->GetMainMenu()->IsVisible())
         return false;
 #endif
 
@@ -148,12 +149,15 @@ MomRunSafeguards::MomRunSafeguards()
 
     m_pSafeguards[RUN_SAFEGUARD_MAP_CHANGE] = new CRunSafeguard("changing map");
     m_pSafeguards[RUN_SAFEGUARD_MAP_CHANGE]->SetRelevantCVar(&mom_run_safeguard_change_map);
+    m_pSafeguards[RUN_SAFEGUARD_MAP_CHANGE]->SetIgnoredInMenu(false);
 
     m_pSafeguards[RUN_SAFEGUARD_QUIT_TO_MENU] = new CRunSafeguard("quitting to menu");
     m_pSafeguards[RUN_SAFEGUARD_QUIT_TO_MENU]->SetRelevantCVar(&mom_run_safeguard_quit_map);
+    m_pSafeguards[RUN_SAFEGUARD_QUIT_TO_MENU]->SetIgnoredInMenu(false);
 
     m_pSafeguards[RUN_SAFEGUARD_QUIT_GAME] = new CRunSafeguard("quitting the game");
     m_pSafeguards[RUN_SAFEGUARD_QUIT_GAME]->SetRelevantCVar(&mom_run_safeguard_quit_game);
+    m_pSafeguards[RUN_SAFEGUARD_QUIT_GAME]->SetIgnoredInMenu(false);
 
 #ifdef GAME_DLL
     m_bGameUIActive = false;

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.h
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.h
@@ -36,6 +36,8 @@ class CRunSafeguard
     bool IsSafeguarded(RunSafeguardMode_t mode);
 
     void SetRelevantCVar(ConVar *pVarRef) { m_pRelatedVar = pVarRef; }
+    void SetIgnoredInMenu(bool bIgnoredInMenu) { m_bIgnoredInMenu = bIgnoredInMenu; }
+    bool IsIgnoredInMenu() const { return m_bIgnoredInMenu; }
 
   private:
     bool IsMovementKeysSafeguarded(int nButtons);
@@ -46,6 +48,9 @@ class CRunSafeguard
     float m_flLastTimePressed;
 
     bool m_bDoublePressSafeguard;
+
+    bool m_bIgnoredInMenu;
+
     ConVar *m_pRelatedVar;
 };
 


### PR DESCRIPTION
The menu-related safeguards were never hit since all safeguards were early returned if they were in the main menu.

Introduces a bool field that specifies whether the safeguard should be ignored while in main menu.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
