### PR TITLE
Make escape key close leaderboard

### DIFF
--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -163,10 +163,6 @@ int ClientModeMOMNormal::HudElementKeyInput(int down, ButtonCode_t keynum, const
         if (keynum == MOUSE_RIGHT)
         {
             m_pLeaderboards->SetMouseInputEnabled(true);
-            // MOM_TODO: Consider toggling the leaderboards open with this
-            // m_pLeaderboards->SetKeyBoardInputEnabled(!prior);
-            // ButtonCode_t close = gameuifuncs->GetButtonCodeForBind("showtimes");
-            // gViewPortInterface->PostMessageToPanel(PANEL_TIMES, new KeyValues("PollHideCode", "code", close));
             return 0;
         }
     }

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -26,8 +26,6 @@ CClientTimesDisplay::CClientTimesDisplay(IViewPort *pViewPort) : EditablePanel(n
 {
     SetSize(10, 10); // Quiet the "parent not sized yet" spew, actual size in leaderboards.res
 
-    m_nCloseKey = BUTTON_CODE_INVALID;
-
     m_bToggledOpen = false;
     m_flNextUpdateTime = 0.0f;
 
@@ -69,45 +67,6 @@ CClientTimesDisplay::CClientTimesDisplay(IViewPort *pViewPort) : EditablePanel(n
 CClientTimesDisplay::~CClientTimesDisplay()
 {
 }
-
-//-----------------------------------------------------------------------------
-// Call every frame
-//-----------------------------------------------------------------------------
-void CClientTimesDisplay::OnThink()
-{
-    BaseClass::OnThink();
-
-    // NOTE: this is necessary because of the way input works.
-    // If a key down message is sent to vgui, then it will get the key up message
-    // Sometimes the scoreboard is activated by other vgui menus,
-    // sometimes by console commands. In the case where it's activated by
-    // other vgui menus, we lose the key up message because this panel
-    // doesn't accept keyboard input. It *can't* accept keyboard input
-    // because another feature of the dialog is that if it's triggered
-    // from within the game, you should be able to still run around while
-    // the scoreboard is up. That feature is impossible if this panel accepts input.
-    // because if a vgui panel is up that accepts input, it prevents the engine from
-    // receiving that input. So, I'm stuck with a polling solution.
-    //
-    // Close key is set to non-invalid when something other than a keybind
-    // brings the scoreboard up, and it's set to invalid as soon as the
-    // dialog becomes hidden.
-
-    if (m_nCloseKey != BUTTON_CODE_INVALID)
-    {
-        if (!g_pInputSystem->IsButtonDown(m_nCloseKey))
-        {
-            m_nCloseKey = BUTTON_CODE_INVALID;
-            gViewPortInterface->ShowPanel(PANEL_TIMES, false);
-            GetClientVoiceMgr()->StopSquelchMode();
-        }
-    }
-}
-
-//-----------------------------------------------------------------------------
-// Called by vgui panels that activate the client scoreboard
-//-----------------------------------------------------------------------------
-void CClientTimesDisplay::OnPollHideCode(int code) { m_nCloseKey = static_cast<ButtonCode_t>(code); }
 
 //-----------------------------------------------------------------------------
 // Purpose: clears everything in the scoreboard and all it's state
@@ -172,11 +131,6 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
     if (m_pTimes)
         m_pTimes->OnPanelShow(bShow);
 
-    if (!bShow)
-    {
-        m_nCloseKey = BUTTON_CODE_INVALID;
-    }
-
     if (BaseClass::IsVisible() == bShow)
         return;
 
@@ -230,7 +184,7 @@ void CClientTimesDisplay::Close()
 
 void CClientTimesDisplay::OnKeyCodeReleased(KeyCode code)
 {
-    if (code == KEY_ESCAPE)
+    if (code == KEY_ESCAPE || code == KEY_TAB)
     {
         Close();
     }

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -8,6 +8,7 @@
 #include "clientmode.h"
 
 #include "vgui/ISurface.h"
+#include <vgui/IInput.h>
 #include "voice_status.h"
 #include <inputsystem/iinputsystem.h>
 #include "vgui_controls/AnimationController.h"
@@ -102,6 +103,8 @@ void CClientTimesDisplay::OnThink()
             GetClientVoiceMgr()->StopSquelchMode();
         }
     }
+
+    if (input()->IsKeyDown(KEY_ESCAPE)) { Close(); }
 }
 
 //-----------------------------------------------------------------------------
@@ -182,6 +185,7 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
 
     if (bShow)
     {
+        engine->ClientCmd_Unrestricted("gameui_preventescapetoshow\n");
         Reset(true);
         SetVisible(true);
         MoveToFront();
@@ -222,6 +226,7 @@ void CClientTimesDisplay::Close()
     SetMouseInputEnabled(false);
 
     g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(GetParent(), "LeaderboardsBgFocusLost");
+    engine->ClientCmd_Unrestricted("gameui_allowescapetoshow\n");
 }
 
 void CClientTimesDisplay::FireGameEvent(IGameEvent *event)

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -8,6 +8,7 @@
 #include "clientmode.h"
 
 #include "vgui/ISurface.h"
+#include "IGameUIFuncs.h"
 #include "voice_status.h"
 #include <inputsystem/iinputsystem.h>
 #include "vgui_controls/AnimationController.h"
@@ -184,7 +185,7 @@ void CClientTimesDisplay::Close()
 
 void CClientTimesDisplay::OnKeyCodeReleased(KeyCode code)
 {
-    if (code == KEY_ESCAPE || code == KEY_TAB)
+    if (code == KEY_ESCAPE || code == gameuifuncs->GetButtonCodeForBind("showtimes"))
     {
         Close();
     }

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -8,7 +8,6 @@
 #include "clientmode.h"
 
 #include "vgui/ISurface.h"
-#include <vgui/IInput.h>
 #include "voice_status.h"
 #include <inputsystem/iinputsystem.h>
 #include "vgui_controls/AnimationController.h"
@@ -103,8 +102,6 @@ void CClientTimesDisplay::OnThink()
             GetClientVoiceMgr()->StopSquelchMode();
         }
     }
-
-    if (input()->IsKeyDown(KEY_ESCAPE)) { Close(); }
 }
 
 //-----------------------------------------------------------------------------
@@ -185,7 +182,6 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
 
     if (bShow)
     {
-        engine->ClientCmd_Unrestricted("gameui_preventescapetoshow\n");
         Reset(true);
         SetVisible(true);
         MoveToFront();
@@ -209,6 +205,8 @@ void CClientTimesDisplay::SetMouseInputEnabled(bool bState)
     {
         m_bToggledOpen = true;
         g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(GetParent(), "LeaderboardsBgFocusGain");
+        engine->ClientCmd_Unrestricted("gameui_preventescapetoshow\n");
+        SetKeyBoardInputEnabled(true);
     }
 }
 
@@ -222,11 +220,24 @@ void CClientTimesDisplay::SetVisible(bool bState)
 void CClientTimesDisplay::Close()
 {
     m_bToggledOpen = false;
+    engine->ClientCmd_Unrestricted("gameui_allowescapetoshow\n");
     SetVisible(false);
     SetMouseInputEnabled(false);
+    SetKeyBoardInputEnabled(false);
 
     g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(GetParent(), "LeaderboardsBgFocusLost");
-    engine->ClientCmd_Unrestricted("gameui_allowescapetoshow\n");
+}
+
+void CClientTimesDisplay::OnKeyCodeReleased(KeyCode code)
+{
+    if (code == KEY_ESCAPE)
+    {
+        Close();
+    }
+    else
+    {
+        BaseClass::OnKeyCodeReleased(code);
+    }
 }
 
 void CClientTimesDisplay::FireGameEvent(IGameEvent *event)

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.cpp
@@ -122,10 +122,6 @@ void CClientTimesDisplay::ShowPanel(bool bShow)
 {
     if (m_bToggledOpen)
     {
-        if (bShow == false)
-        {
-            m_bToggledOpen = false;
-        }
         return;
     }
 
@@ -185,7 +181,7 @@ void CClientTimesDisplay::Close()
 
 void CClientTimesDisplay::OnKeyCodeReleased(KeyCode code)
 {
-    if (code == KEY_ESCAPE || code == gameuifuncs->GetButtonCodeForBind("showtimes"))
+    if (m_bToggledOpen && (code == KEY_ESCAPE || code == gameuifuncs->GetButtonCodeForBind("showtimes")))
     {
         Close();
     }

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -50,10 +50,7 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
     void SetParent(vgui::VPANEL parent) OVERRIDE { BaseClass::SetParent(parent); }
 
   protected:
-    MESSAGE_FUNC_INT(OnPollHideCode, "PollHideCode", code);
-
     // functions to override
-    void OnThink() OVERRIDE;
     void OnKeyCodeReleased(vgui::KeyCode code) override;
 
     void ApplySchemeSettings(vgui::IScheme *pScheme) OVERRIDE;
@@ -81,7 +78,6 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
     CLeaderboardsTimes *m_pTimes;
 
     IViewPort *m_pViewPort;
-    ButtonCode_t m_nCloseKey;
 
     float m_flNextUpdateTime;
 

--- a/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
+++ b/mp/src/game/client/momentum/ui/leaderboards/ClientTimesDisplay.h
@@ -54,6 +54,7 @@ class CClientTimesDisplay : public vgui::EditablePanel, public IViewPortPanel, p
 
     // functions to override
     void OnThink() OVERRIDE;
+    void OnKeyCodeReleased(vgui::KeyCode code) override;
 
     void ApplySchemeSettings(vgui::IScheme *pScheme) OVERRIDE;
     void PerformLayout() OVERRIDE;


### PR DESCRIPTION
Closes #992

Whenever you open the leaderboard now, you can close it by pressing "Escape" instead of pressing "Tab" again. It also makes it so that the main menu does not open whenever you press "Escape", similar behaviour which is also seen in the chat script.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
