### PR TITLE
Disallow muzzle flash if viewmodel is hidden

### DIFF
--- a/mp/src/game/client/c_baseanimating.cpp
+++ b/mp/src/game/client/c_baseanimating.cpp
@@ -64,6 +64,7 @@
 
 static ConVar cl_SetupAllBones( "cl_SetupAllBones", "0" );
 ConVar r_sequence_debug( "r_sequence_debug", "" );
+extern ConVar r_drawviewmodel;
 
 // If an NPC is moving faster than this, he should play the running footstep sound
 const float RUN_SPEED_ESTIMATE_SQR = 150.0f * 150.0f;
@@ -3610,6 +3611,9 @@ void C_BaseAnimating::DoAnimationEvents( CStudioHdr *pStudioHdr )
 //-----------------------------------------------------------------------------
 bool C_BaseAnimating::DispatchMuzzleEffect( const char *options, bool isFirstPerson )
 {
+	if (isFirstPerson && !r_drawviewmodel.GetBool())
+		return false;
+
 	const char	*p = options;
 	char		token[128];
 	int			weaponType = 0;


### PR DESCRIPTION
Closes #996 

This PR fixes the issue of muzzle flashes showing while the viewmodel is hidden for the pistol

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review