### PR TITLE
Settings panel remembers last opened tab

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/MomentumSettingsDialog.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/MomentumSettingsDialog.cpp
@@ -19,6 +19,7 @@
 
 #include "clientmode.h"
 #include "ienginevgui.h"
+#include "mom_shareddefs.h"
 
 #include "tier0/memdbgon.h"
 
@@ -71,7 +72,7 @@ private:
     int m_iSpacingX;
 };
 
-
+static MAKE_TOGGLE_CONVAR(mom_settings_remember_tab, "1", FCVAR_ARCHIVE, "Toggles remembering the last opened tab in settings. 0 = OFF, 1 = ON.\n");
 static CMomentumSettingsDialog *g_pSettingsDialog = nullptr;
 
 CMomentumSettingsDialog::CMomentumSettingsDialog() : BaseClass(nullptr, "SettingsDialog")
@@ -175,7 +176,7 @@ void CMomentumSettingsDialog::Activate()
 {
     BaseClass::Activate();
 
-    SetActivePanel(m_pInputPage);
+    SetActivePanel(mom_settings_remember_tab.GetBool() ? m_pCurrentSettingsPage : m_pInputPage);
 }
 
 void CMomentumSettingsDialog::OnThink()


### PR DESCRIPTION
Closes #937

This PR makes it so that the Settings panel will remember the last selected tab, automatically opening to it when the player opens the settings, as well as a ConVar deciding whether or not it will engage in said behavior

Docs PR can be found [here](https://github.com/momentum-mod/docs/pull/106)

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review