### PR TITLE
Fix ModelPanel cubemap override logic

### DIFF
--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -424,6 +424,7 @@ void CRenderPanel::Paint()
     MaterialFogMode_t oldFog = pRenderContext->GetFogMode();
     pRenderContext->FogMode(MATERIAL_FOG_NONE);
 
+    const auto pCubemapTex = pRenderContext->GetLocalCubemap();
     pRenderContext->BindLocalCubemap(m_hDefaultCubemap);
 
     DrawModel();
@@ -434,6 +435,7 @@ void CRenderPanel::Paint()
 
     modelrender->SuppressEngineLighting(false);
 
+    pRenderContext->BindLocalCubemap(pCubemapTex);
     pRenderContext->Flush();
 }
 


### PR DESCRIPTION
As reported by @bltech, the ModelPanel cubemap logic was incorrectly overriding the cubemap and causing things in game to have the main menu cubemap applied to them.

![image](https://user-images.githubusercontent.com/5162166/95699916-ad84b700-0c13-11eb-8e0d-4695243af2b5.png)

The correct logic to use here is to cache off the previous cubemap before setting the override, then to set it back to the cached cubemap after rendering.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
