### PR TITLE
Dont process viewmodel animation when it isn't shown

### DIFF
--- a/mp/src/game/client/c_baseanimating.cpp
+++ b/mp/src/game/client/c_baseanimating.cpp
@@ -3454,6 +3454,9 @@ void C_BaseAnimating::DoAnimationEvents( CStudioHdr *pStudioHdr )
 	if ( bIsInvisible )
 		return;
 
+    if (IsViewModel() && !r_drawviewmodel.GetBool())
+        return;
+
 	// If we don't have any sequences, don't do anything
 	int nStudioNumSeq = pStudioHdr->GetNumSeq();
 	if ( nStudioNumSeq < 1 )


### PR DESCRIPTION
Closes #995

Fixes shotgun playing cocking sound on 8th shot by stopping animations (apart from the muzzle flash) from playing when the viewmodel isn't drawn via `r_drawviewmodels 0`.

This is trivial though I had it assigned to myself as I wanted to see why the cocking sound isn't played when in third person (regardless of `r_drawviewmodels`). Couldn't find the reason after searching for awhile and starting to think it's more trouble than it's worth. 
From what I gather there is something stopping viewmodel animations in third person view but can't find exactly what or if that'd have any weird side effects.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
