### PR TITLE
Use $color2 for PBR materials on models

### DIFF
--- a/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
+++ b/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
@@ -97,11 +97,11 @@ BEGIN_VS_SHADER(PBR, "PBR shader")
     END_SHADER_PARAMS;
 
     // Setting up variables for this shader
-    void SetupVars(PBR_Vars_t &info)
+    void SetupVars(IMaterialVar **params, PBR_Vars_t &info)
     {
         info.baseTexture = BASETEXTURE;
         info.baseTexture2 = BASETEXTURE2;
-        info.baseColor = COLOR;
+        info.baseColor = IS_FLAG_SET(MATERIAL_VAR_MODEL) ? COLOR2 : COLOR;
         info.normalTexture = NORMALTEXTURE;
         info.bumpMap = BUMPMAP;
         info.bumpMap2 = BUMPMAP2;
@@ -170,7 +170,7 @@ BEGIN_VS_SHADER(PBR, "PBR shader")
     SHADER_INIT
     {
         PBR_Vars_t info;
-        SetupVars(info);
+        SetupVars(params, info);
 
         Assert(info.flashlightTexture >= 0);
         LoadTexture(info.flashlightTexture, TEXTUREFLAGS_SRGB);
@@ -231,7 +231,7 @@ BEGIN_VS_SHADER(PBR, "PBR shader")
     SHADER_DRAW
     {
         PBR_Vars_t info;
-        SetupVars(info);
+        SetupVars(params, info);
 
         // Setting up booleans
         bool bHasBaseTexture = (info.baseTexture != -1) && params[info.baseTexture]->IsTexture();


### PR DESCRIPTION
Closes #1012 

For those looking to use a color value on models, it turns out `$color` was cursed from the start and the solution is `$color2`.

According to Sears, `$color` is used in lightmapped calculations and likely overwritten, so `$color2` was invented to allow models (on VertexLitGeneric) to be able to still have a color input.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
