### PR TITLE
Use g_pMessageBox to create default binds confirm prompt

### DIFF
--- a/mp/src/game/client/momentum/ui/SettingsPanel/InputSettingsPanel.cpp
+++ b/mp/src/game/client/momentum/ui/SettingsPanel/InputSettingsPanel.cpp
@@ -6,6 +6,7 @@
 #include "filesystem.h"
 #include "inputsystem/iinputsystem.h"
 #include "IGameUIFuncs.h"
+#include "MessageboxPanel.h"
 
 #include "vgui_controls/CvarComboBox.h"
 #include "vgui_controls/CvarToggleCheckButton.h"
@@ -147,10 +148,7 @@ void InputSettingsPanel::OnCommand(const char *command)
     if (FStrEq(command, "Defaults"))
     {
         // open a box asking if we want to restore defaults
-        QueryBox *box = new QueryBox("#GameUI_KeyboardSettings", "#GameUI_KeyboardSettingsText");
-        box->AddActionSignalTarget(this);
-        box->SetCommand(new KeyValues("Command", "command", "DefaultsOK"));
-        box->DoModal();
+        g_pMessageBox->CreateConfirmationBox(this, "#GameUI_KeyboardSettings", "#GameUI_KeyboardSettingsText", new KeyValues("Command", "command", "DefaultsOK"), nullptr);
     }
     else if (FStrEq(command, "DefaultsOK"))
     {

--- a/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
+++ b/mp/src/game/client/momentum/ui/controls/ModelPanel.cpp
@@ -149,8 +149,7 @@ void CRenderPanel::ResetView()
     lightAng = m_angLightDefault;
     m_nFOV = m_nDefaultFOV;
 
-    GetModelCenter(render_offset_modelBase);
-
+    render_offset_modelBase.Init();
     render_offset.Init();
 
     UpdateRenderPosition();


### PR DESCRIPTION
Closes #1019 

The previous way worked because the settings panel it came from wasn't full screen, so the modal popped up correctly.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
