### PR TITLE
Add missing checks for tricksurf gamemode

### DIFF
--- a/mp/src/game/shared/momentum/mom_system_tricks.cpp
+++ b/mp/src/game/shared/momentum/mom_system_tricks.cpp
@@ -615,11 +615,17 @@ void CTrickSystem::OnTrickFailed(CTrickAttempt *pAttempt)
 
 void CTrickSystem::ClearTrickAttempts()
 {
+    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_TRICKSURF))
+        return;
+
     m_vecCurrentTrickAttempts.PurgeAndDeleteElements();
 }
 
 void CTrickSystem::PostPlayerManualTeleport(CMomentumPlayer *pPlayer)
 {
+    if (!g_pGameModeSystem->GameModeIs(GAMEMODE_TRICKSURF))
+        return;
+
     ClearTrickAttempts();
 
     const auto iTracked = m_iTrackedTrick;


### PR DESCRIPTION
Closes https://github.com/momentum-mod/game/issues/1028

Adds some missing checks for whether the gamemode is tricksurf as it caused the related issue.

I searched each function in the trick system to find those used outside of the system and not checked, which turned out to just be the 2 called in `ManualTeleport`.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
