### PR TITLE
Replace Version Number with "Development Build" when game is built in Debug mode

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_versioninfo.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_versioninfo.cpp
@@ -47,7 +47,13 @@ void CHudVersionInfo::VidInit()
 {
     KeyValuesAD loc("Version");
     loc->SetWString("verLabel", g_pVGuiLocalize->FindSafe("#MOM_StartupMsg_Alpha_Title"));
+
+#ifdef DEBUG
+    loc->SetString("verNum", "[Development Build]");
+#else
     loc->SetString("verNum", MOM_CURRENT_VERSION);
+#endif
+
     loc->SetString("mappingMode", CommandLine()->CheckParm("-mapping") ? "- Mapping Mode Active" : "");
     SetText(CConstructLocalizedString(L"%verLabel% %verNum% %mappingMode%", (KeyValues*)loc));
     InvalidateLayout();

--- a/mp/src/game/client/momentum/ui/HUD/hud_versioninfo.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_versioninfo.cpp
@@ -48,11 +48,11 @@ void CHudVersionInfo::VidInit()
     KeyValuesAD loc("Version");
     loc->SetWString("verLabel", g_pVGuiLocalize->FindSafe("#MOM_StartupMsg_Alpha_Title"));
 
+    loc->SetString("verNum", 
 #ifdef DEBUG
-    loc->SetString("verNum", "[Development Build]");
-#else
-    loc->SetString("verNum", MOM_CURRENT_VERSION);
+    "[Development Build] "
 #endif
+    MOM_CURRENT_VERSION);
 
     loc->SetString("mappingMode", CommandLine()->CheckParm("-mapping") ? "- Mapping Mode Active" : "");
     SetText(CConstructLocalizedString(L"%verLabel% %verNum% %mappingMode%", (KeyValues*)loc));


### PR DESCRIPTION
When building Develop, the last version number of the Steam version is shown which can be misleading, so I had an idea to see if it could be replaced with generic text instead whenever the game is built in Debug. The version number appears as normal when the game is built in Release.
Just a quick idea, might be useful to see if someone's on a development build.

![](https://i.imgur.com/DVo7qcg.png)

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
