### PR TITLE
Fix crash when closing the map info panel too quickly

### DIFF
--- a/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
+++ b/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
@@ -278,10 +278,10 @@ void CDialogMapInfo::FillMapInfo()
     }
 }
 
-void CDialogMapInfo::GetMapTimes(TimeType_t type)
+bool CDialogMapInfo::GetMapTimes(TimeType_t type)
 {
     if (gpGlobals->curtime - UPDATE_INTERVAL < m_fRequestDelays[type])
-        return;
+        return false;
 
     bool bSent = false;
 
@@ -309,6 +309,7 @@ void CDialogMapInfo::GetMapTimes(TimeType_t type)
         ClearPlayerList();
 
     m_fRequestDelays[type] = gpGlobals->curtime + UPDATE_INTERVAL;
+    return bSent;
 }
 
 void CDialogMapInfo::OnTop10TimesCallback(KeyValues *pKvResponse)

--- a/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
+++ b/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
@@ -305,7 +305,7 @@ void CDialogMapInfo::FillMapInfo()
 
 bool CDialogMapInfo::GetMapTimes(TimeType_t type)
 {
-    if (gpGlobals->curtime - UPDATE_INTERVAL < m_fRequestDelays[type])
+    if (gpGlobals->curtime < m_fRequestDelays[type])
         return false;
 
     bool bSent = false;

--- a/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
+++ b/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.cpp
@@ -122,21 +122,39 @@ void CDialogMapInfo::OnCommand(const char* command)
 {
     if (FStrEq(command, "Top10"))
     {
-        GetMapTimes(TIMES_TOP10);
-        m_pAroundButton->SetSelected(false);
-        m_pFriendsButton->SetSelected(false);
+        if (GetMapTimes(TIMES_TOP10))
+        {
+            m_pAroundButton->SetSelected(false);
+            m_pFriendsButton->SetSelected(false);
+        }
+        else if (m_pAroundButton->IsSelected() || m_pFriendsButton->IsSelected())
+        {
+            m_pTop10Button->SetSelected(false);
+        }
     }
     else if (FStrEq(command, "Around"))
     {
-        GetMapTimes(TIMES_AROUND);
-        m_pTop10Button->SetSelected(false);
-        m_pFriendsButton->SetSelected(false);
+        if (GetMapTimes(TIMES_AROUND))
+        {
+            m_pTop10Button->SetSelected(false);
+            m_pFriendsButton->SetSelected(false);
+        }
+        else if(m_pTop10Button->IsSelected() || m_pFriendsButton->IsSelected())
+        {
+            m_pAroundButton->SetSelected(false);
+        }
     }
     else if (FStrEq(command, "Friends"))
     {
-        GetMapTimes(TIMES_FRIENDS);
-        m_pAroundButton->SetSelected(false);
-        m_pTop10Button->SetSelected(false);
+        if (GetMapTimes(TIMES_FRIENDS))
+        {
+            m_pAroundButton->SetSelected(false);
+            m_pTop10Button->SetSelected(false);
+        }
+        else if (m_pAroundButton->IsSelected() || m_pTop10Button->IsSelected())
+        {
+            m_pFriendsButton->SetSelected(false);
+        }
     }
     else BaseClass::OnCommand(command);
 }

--- a/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.h
+++ b/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.h
@@ -35,8 +35,9 @@ class CDialogMapInfo : public vgui::Frame
 
 protected:
     // vgui overrides
-    void PerformLayout() OVERRIDE;
-    void OnCommand(const char* command) OVERRIDE;
+    void PerformLayout() override;
+    void OnCommand(const char* command) override;
+    void OnClose() override;
 
     // API
     void GetMapInfo();
@@ -53,6 +54,7 @@ private:
     void RequestInfo();
 
     float m_fRequestDelays[TIMES_COUNT];
+    bool m_bTimesLoading[TIMES_COUNT];
 
     vgui::Button *m_pMapActionButton, *m_pTop10Button, *m_pAroundButton, *m_pFriendsButton;
     vgui::ListPanel *m_pTimesList;

--- a/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.h
+++ b/mp/src/game/client/momentum/ui/MapSelection/MapInfoDialog.h
@@ -42,7 +42,7 @@ protected:
     void GetMapInfo();
     void FillMapInfo();
 
-    void GetMapTimes(TimeType_t type);
+    bool GetMapTimes(TimeType_t type);
     void OnTop10TimesCallback(KeyValues *pKvResponse);
     void OnAroundTimesCallback(KeyValues *pKvResponse);
     void OnFriendsTimesCallback(KeyValues *pKvResponse);


### PR DESCRIPTION
Closes #987 

The crash happens when opening the map info dialog then closing it before times are loaded. The panel is set to auto delete on close and the API calls execute code that references the panel's fields after the panel is closed (and deleted), causing an access violation.

This change simply stops the panel from closing until the API calls for times are completed. This is the only solution that I see other than making this a singleton, which seems unfitting.

Also:
- Fixes the times buttons being able to be pressed when their API call cannot be sent because of the `UPDATE_INTERVAL`.
- Fixes the `UPDATE_INTERVAL` from being effectively doubled. It is now 5 seconds.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
