### PR TITLE
Update trigger_momentum_timer_stop to have "Cancel" property

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -114,7 +114,14 @@
     ]
 ]
 
-@SolidClass base(ZoneTrigger) = trigger_momentum_timer_stop : "Trigger that stops the timer." []
+@SolidClass base(ZoneTrigger) = trigger_momentum_timer_stop : "Trigger that stops the timer."
+[
+    cancel(choices) : "Cancel Timer" : 0 : "If true, the run will not be submitted." =
+    [
+        0 : "False"
+        1 : "True"
+    ]
+]
 
 @SolidClass base(ZoneTrigger) = trigger_momentum_timer_stage : "Starting trigger for each stage of a map. trigger_momentum_timer_start is automatically stage 1!" []
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1118,12 +1118,18 @@ void CMomentumPlayer::OnZoneEnter(CTriggerZone *pTrigger)
     case ZONE_TYPE_STOP:
         {
             // We've reached end zone, stop here
-            //auto pStopTrigger = static_cast<CTriggerTimerStop *>(pTrigger);
+            const auto pStopTrigger = static_cast<CTriggerTimerStop *>(pTrigger);
             m_iOldTrack = m_Data.m_iCurrentTrack;
             m_iOldZone = m_Data.m_iCurrentZone;
 
             if (g_pMomentumTimer->IsRunning())
             {
+                if (pStopTrigger->GetCancelBool())
+                {
+                    g_pMomentumTimer->Stop(this);
+                    return;
+                }
+
                 const int zoneNum = m_Data.m_iCurrentZone;
 
                 // This is needed so we have an ending velocity.

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -420,8 +420,17 @@ void CTriggerTimerStart::SetHasLookAngles(const bool bHasLook)
 //----------- CTriggerTimerStop ----------------------------------------------------------------
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_stop, CTriggerTimerStop);
 
+BEGIN_DATADESC(CTriggerTimerStop)
+    DEFINE_KEYFIELD(m_bCancel, FIELD_BOOLEAN, "cancel")
+END_DATADESC();
+
 IMPLEMENT_SERVERCLASS_ST(CTriggerTimerStop, DT_TriggerTimerStop)
 END_SEND_TABLE()
+
+CTriggerTimerStop::CTriggerTimerStop()
+{
+    m_bCancel = false;
+}
 
 void CTriggerTimerStop::Spawn()
 {
@@ -437,6 +446,7 @@ int CTriggerTimerStop::GetZoneType()
 
 //----------------------------------------------------------------------------------------------
 
+//----------- CTriggerTrickZone ----------------------------------------------------------------
 LINK_ENTITY_TO_CLASS(trigger_momentum_trick, CTriggerTrickZone);
 
 IMPLEMENT_SERVERCLASS_ST(CTriggerTrickZone, DT_TriggerTrickZone)

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -246,6 +246,9 @@ class CTriggerTimerStop : public CTriggerZone
 public:
     DECLARE_CLASS(CTriggerTimerStop, CTriggerZone);
     DECLARE_NETWORKCLASS();
+    DECLARE_DATADESC();
+
+    CTriggerTimerStop();
 
     virtual void Spawn() OVERRIDE;
 
@@ -253,6 +256,11 @@ public:
     virtual int UpdateTransmitState() OVERRIDE { return SetTransmitState(FL_EDICT_ALWAYS); }
 
     int GetZoneType() OVERRIDE;
+
+    bool GetCancelBool() const { return m_bCancel; }
+
+private:
+    bool m_bCancel;
 };
 
 class CTriggerTrickZone : public CBaseMomZoneTrigger


### PR DESCRIPTION
Closes #763 

This PR adds a new zone type, `trigger_momentum_timer_cancel`, which allows mappers to stop the timer without submitting the run.
The main reason for this would perhaps be for invalidating runs if a player takes an unintended shortcut, or maybe for some kind of "non-gameplay" area which could be found after start.

Related docs PR is opened at [#117](https://github.com/momentum-mod/docs/pull/117)

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review