### PR TITLE
Fix hud chat container not having mouse input

### DIFF
--- a/mp/src/game/client/momentum/ui/chat/ChatPanel.cpp
+++ b/mp/src/game/client/momentum/ui/chat/ChatPanel.cpp
@@ -60,6 +60,7 @@ ChatPanel *g_pChatPanel = nullptr;
 ChatContainer::ChatContainer(Panel *pParent) : BaseClass(pParent, "ChatContainer")
 {
     m_hAutomaticMessageMode = MESSAGE_MODE_NONE;
+    SetMouseInputEnabled(true);
 }
 
 void ChatContainer::Paint()


### PR DESCRIPTION
Closes #1041

The container was only getting mouse input when a lobby is made and the drawer's chat is clicked into. This adds `SetMouseInputEnabled(true)` calls to make the chat container and chat panel have mouse input when hud chat is opened. 

This doesn't happen with the drawers chat. I believe that's because the drawer already has mouse input. Not really sure what code makes mouse input enabled for the hud chat when the drawer's is clicked into though.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
