### PR TITLE
Save startmarks to file

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -491,10 +491,10 @@ void CMomentumPlayer::Spawn()
         }
 
         // Load startmarks after player spawn
-        if(g_pSavelocSystem->LoadStartMarks())
-            DevLog("Loaded startmarks from %s!\n", SAVELOC_FILE_NAME);
+        if (g_pSavelocSystem->LoadStartMarks())
+            DevLog("Loaded startmarks from the savedlocs file!\n");
         else
-            DevWarning("ERROR: Failed loading startmarks from %s.\n", SAVELOC_FILE_NAME);
+            DevWarning("ERROR: Failed loading startmarks from the savedlocs file.\n");
 
         g_MapZoneSystem.DispatchMapInfo(this);
 
@@ -794,13 +794,18 @@ bool CMomentumPlayer::CreateStartMark()
 
 bool CMomentumPlayer::SetStartMark(int track, SavedLocation_t *saveloc)
 {
-    if (track >= 0 && track < MAX_TRACKS && saveloc->m_savedComponents == (SAVELOC_POS | SAVELOC_ANG))
-    {
-        m_pStartZoneMarks[track] = saveloc;
+    if (!saveloc)
+        return false;
 
-        return true;
-    }
-    return false;
+    if (track < 0 || track >= MAX_TRACKS)
+        return false;
+
+    if (saveloc->m_savedComponents != (SAVELOC_POS | SAVELOC_ANG))
+        return false;
+
+    m_pStartZoneMarks[track] = saveloc;
+
+    return true;
 }
 
 bool CMomentumPlayer::ClearStartMark(int track, bool bPrintMsg)

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -491,8 +491,10 @@ void CMomentumPlayer::Spawn()
         }
 
         // Load startmarks after player spawn
-        if (this == GetLocalPlayer())
-            g_pSavelocSystem->LoadStartMarks();
+        if(g_pSavelocSystem->LoadStartMarks())
+            DevLog("Loaded startmarks from %s!\n", SAVELOC_FILE_NAME);
+        else
+            DevWarning("ERROR: Failed loading startmarks from %s.\n", SAVELOC_FILE_NAME);
 
         g_MapZoneSystem.DispatchMapInfo(this);
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -490,6 +490,10 @@ void CMomentumPlayer::Spawn()
             ClearStartMark(i, false);
         }
 
+        // Load startmarks after player spawn
+        if (this == GetLocalPlayer())
+            g_pSavelocSystem->LoadStartMarks();
+
         g_MapZoneSystem.DispatchMapInfo(this);
 
         // Reset current checkpoint trigger upon spawn
@@ -782,6 +786,17 @@ bool CMomentumPlayer::CreateStartMark()
         {
             Warning("Could not create the start mark for some reason!\n");
         }
+    }
+    return false;
+}
+
+bool CMomentumPlayer::SetStartMark(int track, SavedLocation_t *saveloc)
+{
+    if (track >= 0 && track < MAX_TRACKS && saveloc->m_savedComponents == (SAVELOC_POS | SAVELOC_ANG))
+    {
+        m_pStartZoneMarks[track] = saveloc;
+
+        return true;
     }
     return false;
 }

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -227,6 +227,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     CTriggerZone *GetCurrentZoneTrigger() const { return m_CurrentZoneTrigger.Get(); }
 
     bool CreateStartMark();
+    bool SetStartMark(int track, SavedLocation_t *saveloc);
     SavedLocation_t *GetStartMark(int track) const { return (track >= 0 && track < MAX_TRACKS) ? m_pStartZoneMarks[track] : nullptr; }
     bool ClearStartMark(int track, bool bPrintMsg = true);
 

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -13,6 +13,8 @@
 
 #include "tier0/memdbgon.h"
 
+#define SAVELOC_FILE_NAME "savedlocs.txt"
+
 MAKE_TOGGLE_CONVAR(mom_saveloc_save_between_sessions, "1", FCVAR_ARCHIVE, "Defines if savelocs should be saved between sessions of the same map.\n");
 
 SavedLocation_t::SavedLocation_t() : m_bCrouched(false), m_vecPos(vec3_origin), m_vecVel(vec3_origin), m_qaAng(vec3_angle),
@@ -283,7 +285,10 @@ bool CSaveLocSystem::LoadStartMarks()
         pStartmark->Load(kvStartMark);
 
         if (!pPlayer->SetStartMark(track, pStartmark))
+        {
+            delete pStartmark;
             return false;
+        }
     }
 
     return true;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -260,11 +260,49 @@ void CSaveLocSystem::LevelInitPreEntity()
     }
 }
 
+bool CSaveLocSystem::LoadStartMarks()
+{
+    if (m_pSavedLocsKV)
+    {
+        DevLog("Loaded startmarks from %s!\n", SAVELOC_FILE_NAME);
+
+        if (!m_pSavedLocsKV->IsEmpty())
+        {
+            KeyValues *kvMapSavelocs = m_pSavedLocsKV->FindKey(gpGlobals->mapname.ToCStr());
+            if (kvMapSavelocs && !kvMapSavelocs->IsEmpty())
+            {
+                KeyValues *kvStartMarks = kvMapSavelocs->FindKey("startmarks");
+                if (!kvStartMarks)
+                    return false;
+
+                CMomentumPlayer *pPlayer = CMomentumPlayer::GetLocalPlayer();
+
+                if (!pPlayer)
+                    return false;
+
+                FOR_EACH_SUBKEY(kvStartMarks, kvStartMark)
+                {
+                    int track = atoi(kvStartMark->GetName());
+
+                    auto c = new SavedLocation_t;
+                    c->Load(kvStartMark);
+
+                    pPlayer->SetStartMark(track, c);
+                }
+
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void CSaveLocSystem::LevelShutdownPreEntity()
 {
-    if (CMomentumPlayer::GetLocalPlayer() && m_pSavedLocsKV && mom_saveloc_save_between_sessions.GetBool())
+    CMomentumPlayer *pPlayer = CMomentumPlayer::GetLocalPlayer();
+    if (pPlayer && m_pSavedLocsKV && mom_saveloc_save_between_sessions.GetBool())
     {
-        DevLog("Saving map %s savelocs to %s ...\n", gpGlobals->mapname.ToCStr(), SAVELOC_FILE_NAME);
+        DevLog("Saving map %s savelocs and startmarks to %s ...\n", gpGlobals->mapname.ToCStr(), SAVELOC_FILE_NAME);
         // Make the KV to save into and save into it
         KeyValues *pKvMapSavelocs = new KeyValues(gpGlobals->mapname.ToCStr());
         // Set the current index
@@ -281,8 +319,24 @@ void CSaveLocSystem::LevelShutdownPreEntity()
             kvCPs->AddSubKey(kvCP);
         }
 
+        // Add startmarks
+        KeyValues *kvStartMarks = new KeyValues("startmarks");
+        for (int track = 0; track < MAX_TRACKS; track++)
+        {
+            char szTrackNum[10];
+            Q_snprintf(szTrackNum, sizeof(szTrackNum), "%09i", track);
+            KeyValues *kvStartMark = new KeyValues(szTrackNum);
+
+            // Save location of valid startmarks only
+            if (SavedLocation_t *startMark = pPlayer->GetStartMark(track))
+                startMark->Save(kvStartMark);
+
+            kvStartMarks->AddSubKey(kvStartMark);
+        }
+
         // Save them into the keyvalues
         pKvMapSavelocs->AddSubKey(kvCPs);
+        pKvMapSavelocs->AddSubKey(kvStartMarks);
        
         // Remove the map if it already exists in there
         KeyValues *pExisting = m_pSavedLocsKV->FindKey(gpGlobals->mapname.ToCStr());
@@ -297,7 +351,7 @@ void CSaveLocSystem::LevelShutdownPreEntity()
 
         // Save everything to file
         if (m_pSavedLocsKV->SaveToFile(filesystem, SAVELOC_FILE_NAME, "MOD", true))
-            DevLog("Saved map %s savelocs to %s!\n", gpGlobals->mapname.ToCStr(), SAVELOC_FILE_NAME);
+            DevLog("Saved map %s savelocs and startmarks to %s!\n", gpGlobals->mapname.ToCStr(), SAVELOC_FILE_NAME);
     }
 
     // Remove all requesters if we had any

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -5,6 +5,8 @@
 class CMomentumPlayer;
 class SavelocReqPacket;
 
+#define SAVELOC_FILE_NAME "savedlocs.txt"
+
 enum SavedLocationComponent_t
 {
     SAVELOC_NONE = 0,

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -85,6 +85,8 @@ public:
     bool ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender);
 
     // Local
+    // Loads start marks from saveloc file
+    bool LoadStartMarks();
     // Gets the current menu Saveloc index
     uint32 GetCurrentSavelocMenuIndex() const { return m_iCurrentSavelocIndx; }
     // Is the player currently using the saveloc menu?

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -5,8 +5,6 @@
 class CMomentumPlayer;
 class SavelocReqPacket;
 
-#define SAVELOC_FILE_NAME "savedlocs.txt"
-
 enum SavedLocationComponent_t
 {
     SAVELOC_NONE = 0,


### PR DESCRIPTION
Closes #906

Saves startmarks into savedlocs.txt given that the player is in a local session. The startmarks are saved in the form:
```
"MOMSavelocSystem"
{
    ...
    "[mapname]"
    {
        ...
        "startmarks"
        {
            "[track number]"
            {
                [saveloc data]
            }
            etc.
        }
        ... 
    }
    ...
}
```

This is implemented using a very similar system to the existing savelocs system, except that the loading must be done AFTER the player has joined, and so this is called by the actual player rather than the game system as none of the overridable functions act in this timeframe.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
