### PR TITLE
Fix slide bugs in explosion gamemodes and non-auto gamemodes

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -2282,6 +2282,9 @@ void CMomentumGameMovement::StuckGround()
                 // If the distance is good, we can start being on the surface and follow it.
                 mv->SetAbsOrigin(tr_Point_C.endpos);
 
+                // Reject velocity normal to the ground
+                mv->m_vecVelocity -= tr_Point_C.plane.normal * mv->m_vecVelocity.Dot(tr_Point_C.plane.normal);
+
                 StayOnGround();
             }
 


### PR DESCRIPTION
Closes #675

Fixes a bug concerning no-gravity stuck-to-ground slides, where the combination of the slide teleporting the player down and the slide disabling gravity meant that the player was both not receiving gravity, and not moving vertically from the slide. This meant that the player could infinitely build vertical speed until the game couldn't handle the player's speed, making it think that the player has left the slide. This is fixed by rejecting any velocity normal to the ground, which still allows sideways propulsion and movement. This also fixes a related bug that allowed the player to jump on a slope, gaining upwards velocity, which then causes an automatic 'jump' when leaving the slide.

Also fixes a bug concerning non-auto gamemodes, where slides that allow jumps do not respond to jump inputs if the gamemode does not have autohop. This is fixed by checking if the player is in one of these slides when pressing jump, which then causes the game to check if the player is on the ground. In effort to not edit the form of 2 frequently used functions (`CheckJumpButton` and `SetGroundEntity`), the slide check is technically done twice, however this CAN be fixed if the other way is thought to be more desirable. As the player's ground entity gets set, the player can now jump, fixing the bug. The ground entity is only set at the moment the player is jumping, and so no friction is applied to the player on the slide.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
