### PR TITLE
Fix for friends times only showing in mapping mode

### DIFF
--- a/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
+++ b/mp/src/game/client/momentum/ui/leaderboards/LeaderboardsTimes.cpp
@@ -73,6 +73,8 @@ CLeaderboardsTimes::CLeaderboardsTimes(CClientTimesDisplay* pParent) : BaseClass
     m_pRunFilterButton->SetCommand("ShowFilter");
     m_pRunFilterButton->AddActionSignalTarget(this);
 
+    m_bUnauthorizedFriendlist = false;
+
     LoadControlSettings("resource/ui/leaderboards/times.res");
 
     // Get rid of the scrollbars for the panels
@@ -390,7 +392,7 @@ void CLeaderboardsTimes::LoadLocalTimes(KeyValues* kv)
 
 void CLeaderboardsTimes::LoadOnlineTimes(TimeType_t type)
 {
-    if (type == TIMES_FRIENDS && !m_bUnauthorizedFriendlist)
+    if (type == TIMES_FRIENDS && m_bUnauthorizedFriendlist)
         return;
 
     if (!m_bTimesLoading[type] && m_bTimesNeedUpdate[type])


### PR DESCRIPTION
Closes #1075 

This is weird:
When not in mapping mode, an early return is hit because `m_bUnauthorizedFriendlist` is `false` on initialization. This caused the friends times API call to never be called. In mapping mode it is initialized to `true`. 
There was no explicit initialization of this `bool`  in the constructor so I added that and it fixed the issue.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
