### PR TITLE
Fix Menu Drawer Lobby Name Corruption Bug

### DIFF
--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbySearchPanel.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbySearchPanel.cpp
@@ -55,7 +55,7 @@ public:
             pLobbyData->SetInt("avatar", m_pPanel->TryAddAvatar(hAvatarID));
         }
 
-        pLobbyData->SetString("name", GetLobbyName(hLobbyID, hAvatarID));
+        GetLobbyName(hLobbyID, hAvatarID, pLobbyData);
 
         pLobbyData->SetString("map", GetLobbyMap(hLobbyID));
 
@@ -75,7 +75,7 @@ public:
         return true;
     }
 
-    virtual const char *GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID) = 0;
+    virtual void GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID, KeyValues *pOut) = 0;
 
     virtual const char *GetLobbyMap(const CSteamID &hLobbyID)
     {
@@ -119,14 +119,14 @@ public:
         m_flLastRequestTime = gpGlobals->curtime;
     }
 
-    const char *GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID) override
+    void GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID, KeyValues *pOut) override
     {
         const char *pOwnerName = "";
 
         if (hAvatarID)
             pOwnerName = SteamFriends()->GetFriendPersonaName(hAvatarID);
-        
-        return pOwnerName[0] ? CFmtStr("%s's Lobby", pOwnerName).Get() : "#MOM_Drawer_Lobby_Public_Fallback";
+
+        pOut->SetString("name", pOwnerName[0] ? CFmtStr("%s's Lobby", pOwnerName).Get() : "#MOM_Drawer_Lobby_Public_Fallback");
     }
 
 protected:
@@ -255,7 +255,7 @@ public:
         return LobbyListProvider::GetLobbyMap(hLobbyID);
     }
 
-    const char *GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID) override
+    void GetLobbyName(const CSteamID &hLobbyID, uint64 hAvatarID, KeyValues *pOut) override
     {
         const char *pToReturn = "#MOM_Drawer_Lobby_Friend_Fallback";
 
@@ -286,7 +286,7 @@ public:
             }
         }
 
-        return pToReturn;
+        pOut->SetString("name", pToReturn);
     }
 
     void OnLobbyRemoved(const CSteamID &hLobbyID) override


### PR DESCRIPTION
This PR fixes a small and rare bug with lobby names being corrupted by improving the logic used to get the lobby name, passing the KeyValues directly in as opposed to returning and using a stack-temporary return value.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
