### PR TITLE
Hardcode online ghost update rate

### DIFF
--- a/mp/src/game/server/momentum/ghost_client.cpp
+++ b/mp/src/game/server/momentum/ghost_client.cpp
@@ -8,10 +8,6 @@
 
 #include "tier0/memdbgon.h"
 
-ConVar mm_updaterate("mom_ghost_online_updaterate", "40",
-    FCVAR_ARCHIVE | FCVAR_CLIENTCMD_CAN_EXECUTE,
-    "Number of updates per second for online ghosts.\n", true, 1.0f, true, 50.0f);
-
 CON_COMMAND(mom_spectate, "Start spectating if there are ghosts currently being played.")
 {
     if (gpGlobals->eLoadType == MapLoad_Background)

--- a/mp/src/game/server/momentum/mom_lobby_system.cpp
+++ b/mp/src/game/server/momentum/mom_lobby_system.cpp
@@ -707,7 +707,7 @@ void CMomentumLobbySystem::CreateLobbyGhostEntity(const CSteamID &lobbyMember)
         m_mapLobbyGhosts.Insert(lobbyMemberID, pNewPlayer);
 
         if (m_flNextUpdateTime < 0)
-            m_flNextUpdateTime = gpGlobals->curtime + (1.0f / mm_updaterate.GetFloat());
+            m_flNextUpdateTime = gpGlobals->curtime + (1.0f / MOM_ONLINE_GHOST_UPDATERATE);
 
         // "_____ just joined your map."
         WriteLobbyMessage(LOBBY_UPDATE_MEMBER_JOIN_MAP, lobbyMemberID);
@@ -934,7 +934,7 @@ void CMomentumLobbySystem::SendP2PPackets()
         PositionPacket frame;
         if (g_pMomentumGhostClient->CreateNewNetFrame(frame) && SendPacketToEveryone(&frame))
         {
-            m_flNextUpdateTime = gpGlobals->curtime + (1.0f / mm_updaterate.GetFloat());
+            m_flNextUpdateTime = gpGlobals->curtime + (1.0f / MOM_ONLINE_GHOST_UPDATERATE);
         }
     }
 }

--- a/mp/src/game/server/momentum/mom_online_ghost.cpp
+++ b/mp/src/game/server/momentum/mom_online_ghost.cpp
@@ -289,7 +289,7 @@ void CMomentumOnlineGhostEntity::Think()
         HandleGhostFirstPerson();
 
     // Emulate at the update rate (or slightly slower) for the smoothest interpolation
-    SetNextThink(gpGlobals->curtime + 1.0f / mm_updaterate.GetFloat() + (gpGlobals->interval_per_tick * mom_ghost_online_interp_ticks.GetFloat()));
+    SetNextThink(gpGlobals->curtime + 1.0f / MOM_ONLINE_GHOST_UPDATERATE + (gpGlobals->interval_per_tick * mom_ghost_online_interp_ticks.GetFloat()));
 }
 void CMomentumOnlineGhostEntity::HandleGhost()
 {
@@ -299,7 +299,7 @@ void CMomentumOnlineGhostEntity::HandleGhost()
     {
         // Similar fast-forward code to the positions except we aren't jumping here,
         // we want to place these decals ASAP (sound spam incoming) and get them out of the queue.
-        int upperBound = static_cast<int>(ceil(mom_ghost_online_lerp.GetFloat() * mm_updaterate.GetFloat()));
+        int upperBound = static_cast<int>(ceil(mom_ghost_online_lerp.GetFloat() * MOM_ONLINE_GHOST_UPDATERATE));
         while (m_vecDecalPackets.Count() > upperBound)
         {
             ReceivedFrame_t<DecalPacket> *fireMeImmedately = m_vecDecalPackets.RemoveAtHead();
@@ -321,7 +321,7 @@ void CMomentumOnlineGhostEntity::HandleGhost()
         // Realistically, we're going to have a buffer of about MOM_GHOST_LERP * update rate. So for 25 updates
         // in a second, a lerp of 0.1 seconds would make there be about 2.5 packets in the queue at all times.
         // If there's ever any excess, we need to get rid of it, immediately.
-        int upperBound = static_cast<int>(ceil(mom_ghost_online_lerp.GetFloat() * mm_updaterate.GetFloat()));
+        int upperBound = static_cast<int>(ceil(mom_ghost_online_lerp.GetFloat() * MOM_ONLINE_GHOST_UPDATERATE));
         while (m_vecPositionPackets.Count() > upperBound)
         {
             ReceivedFrame_t<PositionPacket> *pTemp = m_vecPositionPackets.RemoveAtHead();

--- a/mp/src/game/shared/momentum/mom_ghostdefs.h
+++ b/mp/src/game/shared/momentum/mom_ghostdefs.h
@@ -12,6 +12,9 @@ enum PacketType
     PACKET_TYPE_COUNT
 };
 
+// Number of updates per second for online ghosts
+#define MOM_ONLINE_GHOST_UPDATERATE 40.0f
+
 #define APPEARANCE_BODYGROUP_MIN 0
 #define APPEARANCE_BODYGROUP_MAX 14
 #define APPEARANCE_TRAIL_LEN_MIN 1
@@ -414,5 +417,3 @@ class SavelocReqPacket : public MomentumPacket
         }
     }
 };
-
-extern ConVar mm_updaterate;


### PR DESCRIPTION
Closes #1095 

This PR hardcodes the mom_ghost_online_updaterate cvar by adding a new macro to ghostsdef.h, and removing said cvar; replacing old usages of the cvar with the macro in the process

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review