### PR TITLE
Improve Frame top (caption) grip sizing

### DIFF
--- a/mp/src/vgui2/vgui_controls/Frame.cpp
+++ b/mp/src/vgui2/vgui_controls/Frame.cpp
@@ -846,6 +846,7 @@ Frame::Frame(Panel *parent, const char *panelName, bool showTaskbarIcon /*=true*
 	_closeButton = new FrameButton(this, "frame_close", "r");
 	_closeButton->AddActionSignalTarget(this);
 	_closeButton->SetCommand(new KeyValues("CloseFrameButtonPressed"));
+	_closeButton->SetZPos(1);
 	
 	if (!surface()->SupportsFeature(ISurface::FRAME_MINIMIZE_MAXIMIZE))
 	{
@@ -1228,8 +1229,10 @@ void Frame::PerformLayout()
 	_rightGrip->SetBounds(wide - DRAGGER_SIZE, CORNER_SIZE, DRAGGER_SIZE, tall - (CORNER_SIZE + BOTTOMRIGHTSIZE));
 
 	_bottomRightGrip->SetBounds(wide - BOTTOMRIGHTSIZE, tall - BOTTOMRIGHTSIZE, BOTTOMRIGHTSIZE, BOTTOMRIGHTSIZE);
-	
-	_captionGrip->SetSize(wide-10,GetCaptionHeight());
+
+	int clientX, clientY, clientWide, clientTall;
+	GetClientArea(clientX, clientY, clientWide, clientTall);
+	_captionGrip->SetSize(wide - 10, Max(clientY, GetCaptionHeight()));
 	
 	_menuButton->SetBounds(7, 8, GetCaptionHeight()-5, GetCaptionHeight()-5);
 
@@ -1377,6 +1380,7 @@ bool Frame::IsSizeable()
 void Frame::GetClientArea(int &x, int &y, int &wide, int &tall)
 {
 	x = m_iClientInsetX;
+	y = m_bSmallCaption ? 0 : m_iClientInsetY;
 
 	GetSize(wide, tall);
 


### PR DESCRIPTION
Closes #910 

This helps with grabbing the top of the console, for example, as the client area is rather far down compared to some other frames
Fixed an oversight where the Y wasn't initialized to any value in GetClientArea

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
