### PR TITLE
Default the RJ viewmodel to the centered version

### DIFF
--- a/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_stock.txt
+++ b/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_stock.txt
@@ -31,6 +31,7 @@ WeaponData
         "single_shot"       "Weapon_RL.Single"
         "explosion"         "Weapon_RL.Explosion"
         "RocketTrail"       "Rocket.Trail"
+        "RocketFizzle"      "Rocket.Fizzle"
     }
 
     // Weapon particles

--- a/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_stock.txt
+++ b/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_stock.txt
@@ -18,7 +18,7 @@ WeaponData
 
     "ModelData"
     {
-        "view"  "models/weapons/mom_rocketlauncher/v_mom_rocketlauncher_c.mdl"
+        "view"  "models/weapons/mom_rocketlauncher/v_mom_rocketlauncher.mdl"
         "world" "models/weapons/mom_rocketlauncher/w_mom_rocketlauncher.mdl"
 
         "rocket"    "models/weapons/mom_rocketlauncher/w_missile.mdl"

--- a/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_tf2_original.txt
+++ b/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_tf2_original.txt
@@ -30,7 +30,8 @@ WeaponData
     {
         "single_shot"       "Weapon_QuakeRPG.Single"
         "explosion"         "Weapon_QuakeRPG.Explode"
-        "RocketTrail"       "Rocket.Trail"
+        // "RocketTrail"       "Rocket.Trail"
+        // "RocketFizzle"      "Rocket.Fizzle"
     }
 
     // Weapon particles

--- a/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_tf2_stock.txt
+++ b/mp/game/momentum/custom/overrides/scripts/weapon_momentum_rocketlauncher_tf2_stock.txt
@@ -28,7 +28,8 @@ WeaponData
     {
         "single_shot"   "Weapon_RPG.Single"
         "explosion"     "BaseExplosionEffect.SoundTF2"
-        "RocketTrail"   "Rocket.Trail"
+        // "RocketTrail"   "Rocket.Trail"
+        // "RocketFizzle"      "Rocket.Fizzle"
     }
 
     // Weapon particles

--- a/mp/game/momentum/custom/overrides/scripts/weapon_momentum_stickylauncher_tf2.txt
+++ b/mp/game/momentum/custom/overrides/scripts/weapon_momentum_stickylauncher_tf2.txt
@@ -26,11 +26,14 @@ WeaponData
     // Sounds for the weapon.
     SoundData
     {
-        "single_shot"       "StickybombLauncher.Single"
+        "single_shot"       "Weapon_StickyBombLauncher.Single"
+        "charged_shot"      "Weapon_StickyBombLauncher.Single"
         "explosion"         "BaseExplosionEffect.SoundTF2"
-        "detonate"          "StickybombLauncher.Detonate"
-        "deny"              "StickybombLauncher.Deny"
-        "charge"            "StickybombLauncher.Charge"
+        "detonate"          "Weapon_StickyBombLauncher.ModeSwitch"
+        "deny"              "HL2Player.UseDeny"
+        "charge"            "Weapon_StickyBombLauncher.ChargeUp"
+        // "chargestop"        "StickybombLauncher.ChargeStop"
+        // "StickyFizzle"      "Stickybomb.Fizzle"
     }
     
     // Weapon particles

--- a/mp/game/momentum/scripts/game_sounds_weapons_tf.txt
+++ b/mp/game/momentum/scripts/game_sounds_weapons_tf.txt
@@ -1557,7 +1557,7 @@
 
 "Weapon_StickyBombLauncher.ModeSwitch"
 {
-	"channel"	"CHAN_WEAPON"
+	"channel"	"CHAN_AUTO"
 	"soundlevel"	"SNDLVL_NORM"
 	"volume"	"1.0"
 	"wave"		")weapons/stickybomblauncher_det.wav"
@@ -1589,7 +1589,7 @@
 
 "Weapon_StickyBombLauncher.ChargeUp"
 {
-	"channel"		"CHAN_WEAPON"
+	"channel"		"CHAN_STATIC"
 	"soundlevel"	"SNDLVL_NORM"
 	"volume"		"1"
 	"wave"		"weapons/stickybomblauncher_charge_up.wav"

--- a/mp/game/momentum/scripts/weapon_momentum_rocketlauncher.txt
+++ b/mp/game/momentum/scripts/weapon_momentum_rocketlauncher.txt
@@ -18,7 +18,7 @@ WeaponData
 
     "ModelData"
     {
-        "view"  "models/weapons/mom_rocketlauncher/v_mom_rocketlauncher.mdl"
+        "view"  "models/weapons/mom_rocketlauncher/v_mom_rocketlauncher_c.mdl"
         "world" "models/weapons/mom_rocketlauncher/w_mom_rocketlauncher.mdl"
 
         "rocket"    "models/weapons/mom_rocketlauncher/w_missile.mdl"


### PR DESCRIPTION
To match the default firing position cvar value.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
