### PR TITLE
Store Time in Savelocs

### DIFF
--- a/mp/src/game/client/c_baseviewmodel.cpp
+++ b/mp/src/game/client/c_baseviewmodel.cpp
@@ -25,13 +25,10 @@
 MAKE_TOGGLE_CONVAR_CV(cl_righthand, "1", FCVAR_ARCHIVE, "Use right-handed view models. 1 = ON, 0 = OFF.\n", nullptr, [](IConVar *pVar, const char *pVal)
 {
     const auto pPlayer = C_MomentumPlayer::GetLocalMomPlayer();
-    if (pPlayer)
+    if (pPlayer && pPlayer->m_Data.m_iTimerState == TIMER_STATE_RUNNING)
     {
-        if (pPlayer->m_Data.m_bTimerRunning)
-        {
-            Warning("Cannot change cl_righthand while in a run! Stop the timer to be able to change it.\n");
-            return false;
-        }
+        Warning("Cannot change cl_righthand while in a run! Stop the timer to be able to change it.\n");
+        return false;
     }
 
     return true;

--- a/mp/src/game/client/momentum/c_mom_player.cpp
+++ b/mp/src/game/client/momentum/c_mom_player.cpp
@@ -181,10 +181,14 @@ void C_MomentumPlayer::OnObserverTargetUpdated()
 float C_MomentumPlayer::GetCurrentRunTime()
 {
     int iTotalTicks = 0;
-    if (m_Data.m_bTimerRunning)
-        iTotalTicks = gpGlobals->tickcount - m_Data.m_iStartTick;    
+    if (m_Data.m_iTimerState != TIMER_STATE_NOT_RUNNING)
+    {
+        iTotalTicks = gpGlobals->tickcount - m_Data.m_iStartTick;
+    }
     else if (m_Data.m_bMapFinished)
+    {
         iTotalTicks = m_Data.m_iRunTime;
+    }
 
     return float(iTotalTicks) * m_Data.m_flTickRate;
 }

--- a/mp/src/game/client/momentum/c_mom_replay_entity.cpp
+++ b/mp/src/game/client/momentum/c_mom_replay_entity.cpp
@@ -20,10 +20,14 @@ C_MomentumReplayGhostEntity::C_MomentumReplayGhostEntity()
 float C_MomentumReplayGhostEntity::GetCurrentRunTime()
 {
     int iTotalTicks;
-    if (m_Data.m_bTimerRunning)
+    if (m_Data.m_iTimerState == TIMER_STATE_RUNNING)
+    {
         iTotalTicks = m_iCurrentTick - m_Data.m_iStartTick;
+    }
     else
+    {
         iTotalTicks = m_Data.m_iRunTime;
+    }
 
     return float(iTotalTicks) * m_Data.m_flTickRate;
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_comparisons.cpp
@@ -122,7 +122,9 @@ bool C_RunComparisons::ShouldDraw()
         // MOM_TODO: Should we have a convar against letting a ghost compare?
         const auto pData = pPlayer->GetCurrentUIEntData();
 
-        shouldDrawLocal = pData->m_bTimerRunning && !pData->m_bMapFinished && pPlayer->m_iZoneCount[pData->m_iCurrentTrack] > 1;
+        shouldDrawLocal = pData->m_iTimerState == TIMER_STATE_RUNNING &&
+                          !pData->m_bMapFinished &&
+                          pPlayer->m_iZoneCount[pData->m_iCurrentTrack] > 1;
     }
     return CHudElement::ShouldDraw() && shouldDrawLocal;
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_keypress.cpp
@@ -313,7 +313,7 @@ void CHudKeyPressDisplay::OnThink()
             m_nDisabledButtons = pPlayer->m_afButtonDisabled;
             m_bIsDucked = pPlayer->GetFlags() & FL_DUCKING;
             // we should only draw the strafe/jump counters when the timer is running
-            m_bShouldDrawCounts = pPlayer->m_Data.m_bTimerRunning;
+            m_bShouldDrawCounts = pPlayer->m_Data.m_iTimerState == TIMER_STATE_RUNNING;
             if (m_bShouldDrawCounts)
             {
                 m_nStrafes = pPlayer->m_RunStats.m_iZoneStrafes[0];

--- a/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_speedometer.cpp
@@ -154,7 +154,7 @@ void CHudSpeedMeter::FireGameEvent(IGameEvent *pEvent)
     const auto bLinear = pLocal->m_iLinearTracks.Get(pLocal->m_Data.m_iCurrentTrack);
 
     // return on current or previous zone on a linear map
-    if (!m_pRunEntData->m_bTimerRunning || (iCurrentZone <= m_iLastZone && bLinear))
+    if (m_pRunEntData->m_iTimerState == TIMER_STATE_NOT_RUNNING || (iCurrentZone <= m_iLastZone && bLinear))
         return;
 
     const auto bLinearStartExit = bLinear && bExit && iCurrentZone == 1;

--- a/mp/src/game/client/momentum/ui/HUD/hud_strafesync.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_strafesync.cpp
@@ -39,13 +39,11 @@ inline bool ShouldDrawLocal()
         if (pRunEnt->GetEntType() == RUN_ENT_REPLAY)
         {
             // MOM_TODO: Should we have a convar against this?
-            return pRunEnt->GetRunEntData()->m_bTimerRunning && !pRunEnt->GetRunEntData()->m_bMapFinished;
+            return pRunEnt->GetRunEntData()->m_iTimerState == TIMER_STATE_RUNNING && !pRunEnt->GetRunEntData()->m_bMapFinished;
         }
-        else
-        {
-            return !pPlayer->m_Data.m_bMapFinished &&
-                ((!pPlayer->m_bHasPracticeMode && strafesync_draw.GetInt() == 2) || pPlayer->m_Data.m_bTimerRunning);
-        }
+
+        return !pPlayer->m_Data.m_bMapFinished &&
+                ((!pPlayer->m_bHasPracticeMode && strafesync_draw.GetInt() == 2) || pPlayer->m_Data.m_iTimerState == TIMER_STATE_RUNNING);
     }
     return false;
 }

--- a/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
@@ -227,10 +227,7 @@ void CHudTimer::OnThink()
                     m_pMainStatusLabel->SetText(curTime);
                 }
 
-                if (m_bWasUsingSavelocMenu)
-                    m_pInfoLabel->SetText(CConstructLocalizedString(m_wSavelocStatus, m_iSavelocCurrent, m_iSavelocCount));
-                else
-                    m_pInfoLabel->SetText("");
+                m_pInfoLabel->SetText(m_bWasUsingSavelocMenu ? CConstructLocalizedString(m_wSavelocStatus, m_iSavelocCurrent, m_iSavelocCount) : L"");
 
                 m_pComparisonLabel->SetText("");
                 m_pSplitLabel->SetText("");
@@ -273,6 +270,17 @@ void CHudTimer::OnThink()
                         }
                     }
                 }
+            }
+            else if (m_pRunData->m_iTimerState == TIMER_STATE_PRACTICE)
+            {
+                char curTime[BUFSIZETIME];
+                MomUtil::FormatTime(pEnt->GetCurrentRunTime(), curTime, 2);
+                m_pMainStatusLabel->SetText(curTime);
+
+                m_pInfoLabel->SetText(m_bWasUsingSavelocMenu ? CConstructLocalizedString(m_wSavelocStatus, m_iSavelocCurrent, m_iSavelocCount) : L"");
+
+                m_pComparisonLabel->SetText("");
+                m_pSplitLabel->SetText("");
             }
         }
     }

--- a/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
@@ -207,9 +207,10 @@ void CHudTimer::OnThink()
              * Timer running but spectating while using practice mode => "<Current replay/ghost timer>" and splits etc
              * Timer running => "<Current Time>", "<Last Stage>", "<Last Stage Split>"
              * MOM_TODO: Timer running but using practice mode and savelocs => "Practice Mode" and "Saveloc X/Y"
+             * Timer running and using savelocs (practice timer state)
              */
 
-            if (!m_pRunData->m_bTimerRunning)
+            if (m_pRunData->m_iTimerState == TIMER_STATE_NOT_RUNNING)
             {
                 if (pLocal->m_bHasPracticeMode && pEnt->GetEntType() == RUN_ENT_PLAYER)
                 {
@@ -234,7 +235,7 @@ void CHudTimer::OnThink()
                 m_pComparisonLabel->SetText("");
                 m_pSplitLabel->SetText("");
             }
-            else
+            else if (m_pRunData->m_iTimerState == TIMER_STATE_RUNNING)
             {
                 if (pLocal->m_bHasPracticeMode && pEnt->GetEntType() == RUN_ENT_PLAYER)
                 {

--- a/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
@@ -295,4 +295,5 @@ void CHudTimer::LevelShutdown()
 {
     m_pRunStats = nullptr;
     m_pRunData = nullptr;
+    m_bWasUsingSavelocMenu = false;
 }

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -178,15 +178,13 @@ void CMomentumReplayGhostEntity::Think()
         return;
 
     if (!m_pPlaybackReplay)
-    {
         return;
-    }
 
     if (m_iCurrentTick == m_Data.m_iStartTick)
     {
         m_Data.m_bIsInZone = false;
         m_Data.m_bMapFinished = false;
-        m_Data.m_bTimerRunning = true;
+        m_Data.m_iTimerState = TIMER_STATE_RUNNING;
         StartTimer(gpGlobals->tickcount);
 
         // Needed for hud_comparisons
@@ -409,7 +407,7 @@ void CMomentumReplayGhostEntity::HandleGhostFirstPerson()
         // networked var that allows the replay to control keypress display on the client
         m_nGhostButtons = currentStep->PlayerButtons();
 
-        if (m_Data.m_bTimerRunning)
+        if (m_Data.m_iTimerState == TIMER_STATE_RUNNING)
             UpdateStats(interpolatedVel);
 
         SetViewOffset(Vector(0, 0, currentStep->PlayerViewOffset()));
@@ -620,12 +618,12 @@ void CMomentumReplayGhostEntity::OnZoneEnter(CTriggerZone *pTrigger)
     {
     case ZONE_TYPE_START:
         m_Data.m_iCurrentTrack = pTrigger->GetTrackNumber();
-        m_Data.m_bTimerRunning = false;
+        m_Data.m_iTimerState = TIMER_STATE_NOT_RUNNING;
         break;
     case ZONE_TYPE_STOP:
         {
             m_Data.m_bMapFinished = true;
-            m_Data.m_bTimerRunning = false;
+            m_Data.m_iTimerState = TIMER_STATE_NOT_RUNNING;
 
             FinishTimer();
             // MOM_TODO: Maybe play effects if the player is racing against us and lost?

--- a/mp/src/game/server/momentum/mom_replay_entity.cpp
+++ b/mp/src/game/server/momentum/mom_replay_entity.cpp
@@ -619,6 +619,7 @@ void CMomentumReplayGhostEntity::OnZoneEnter(CTriggerZone *pTrigger)
     case ZONE_TYPE_START:
         m_Data.m_iCurrentTrack = pTrigger->GetTrackNumber();
         m_Data.m_iTimerState = TIMER_STATE_NOT_RUNNING;
+        m_Data.m_bMapFinished = false;
         break;
     case ZONE_TYPE_STOP:
         {
@@ -646,6 +647,7 @@ void CMomentumReplayGhostEntity::OnZoneExit(CTriggerZone *pTrigger)
     switch (pTrigger->GetZoneType())
     {
     case ZONE_TYPE_START:
+        m_Data.m_iTimerState = TIMER_STATE_RUNNING;
         break;
     case ZONE_TYPE_STOP:
         m_Data.m_bMapFinished = false;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -546,8 +546,11 @@ void CSaveLocSystem::CreateAndSaveLocation()
         m_bHintedStartMarkForLevel = true;
     }
 
-    AddSaveloc(CreateSaveloc());
-    ClientPrint(pPlayer, HUD_PRINTTALK, CFmtStr("Saveloc #%i created!", m_rcSavelocs.Count()));
+    AddSaveloc(CreateSaveloc(bCreatedStartMark ? (SAVELOC_POS | SAVELOC_ANG) : SAVELOC_ALL));
+
+    if (!bCreatedStartMark)
+        ClientPrint(pPlayer, HUD_PRINTTALK, CFmtStr("Saveloc #%i created!", m_rcSavelocs.Count()));
+
     UpdateRequesters();
 }
 

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -236,6 +236,7 @@ CSaveLocSystem::CSaveLocSystem(const char* pName): CAutoGameSystem(pName)
     m_iRequesting = 0;
     m_iCurrentSavelocIndx = -1;
     m_bUsingSavelocMenu = false;
+    m_bHintedStartMarkForLevel = false;
 }
 
 CSaveLocSystem::~CSaveLocSystem()
@@ -252,6 +253,8 @@ void CSaveLocSystem::PostInit()
 
 void CSaveLocSystem::LevelInitPreEntity()
 {
+    m_bHintedStartMarkForLevel = false;
+
     // We don't check mom_savelocs_save_between_sessions because we want to be able to load savelocs from friends
     DevLog("Loading savelocs from %s ...\n", SAVELOC_FILE_NAME);
 
@@ -536,10 +539,11 @@ void CSaveLocSystem::CreateAndSaveLocation()
     if (!pPlayer)
         return;
 
-    if (pPlayer->CreateStartMark())
+    const auto bCreatedStartMark = pPlayer->CreateStartMark();
+    if (bCreatedStartMark && !m_bHintedStartMarkForLevel)
     {
         UTIL_HudHintText(pPlayer, "#MOM_Hint_CreateStartMark");
-        return;
+        m_bHintedStartMarkForLevel = true;
     }
 
     AddSaveloc(CreateSaveloc());

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -22,6 +22,7 @@ enum SavedLocationComponent_t
     SAVELOC_TRACK = 1 << 10,
     SAVELOC_ZONE = 1 << 11,
     SAVELOC_TOGGLED_BTNS = 1 << 12,
+    SAVELOC_TIME = 1 << 13,
 
     SAVELOC_ALL = ~SAVELOC_NONE,
 };
@@ -40,6 +41,7 @@ struct SavedLocation_t
     int m_iDisabledButtons;
     int m_iToggledButtons;
     int m_iTrack, m_iZone;
+    int m_iTimerTickOffset; // What to offset from gpGlobals->tickcount
     CEventQueueState entEventsState;
 
     int m_savedComponents;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -137,6 +137,7 @@ private:
     CUtlVector<SavedLocation_t*> m_rcSavelocs;
     int m_iCurrentSavelocIndx;
     bool m_bUsingSavelocMenu;
+    bool m_bHintedStartMarkForLevel;
 };
 
 extern CSaveLocSystem *g_pSavelocSystem;

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -119,10 +119,12 @@ bool CMomentumTimer::Start(CMomentumPlayer *pPlayer)
 
 void CMomentumTimer::Stop(CMomentumPlayer *pPlayer, bool bFinished /* = false */, bool bStopRecording /* = true*/)
 {
-    if (!m_bIsRunning)
-        return;
+    bool bWasRunning = m_bIsRunning;
 
     SetRunning(pPlayer, false);
+
+    if (!bWasRunning)
+        return;
 
     if (pPlayer)
     {
@@ -339,10 +341,10 @@ CON_COMMAND(mom_start_mark_clear, "Clears the saved start location for your curr
     }
 }
 
-CON_COMMAND_F(mom_timer_stop, "Stops the timer if it is currently running.", FCVAR_CLIENTCMD_CAN_EXECUTE)
+CON_COMMAND_F(mom_timer_stop, "Stops the timer if it is currently running.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    if (pPlayer && g_pMomentumTimer->IsRunning())
+    if (pPlayer)
     {
         g_pMomentumTimer->Stop(pPlayer);
     }

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -155,7 +155,7 @@ void CMomentumTimer::Reset(CMomentumPlayer *pPlayer)
     g_pSavelocSystem->SetUsingSavelocMenu(false);
     pPlayer->ResetRunStats();
     pPlayer->m_Data.m_bMapFinished = false;
-    pPlayer->m_Data.m_bTimerRunning = false;
+    pPlayer->m_Data.m_iTimerState = TIMER_STATE_NOT_RUNNING;
 
     if (m_bIsRunning)
     {
@@ -268,7 +268,7 @@ void CMomentumTimer::SetRunning(CMomentumPlayer *pPlayer, bool isRunning)
     m_bIsRunning = isRunning;
 
     if (pPlayer)
-        pPlayer->m_Data.m_bTimerRunning = isRunning;
+        pPlayer->m_Data.m_iTimerState = isRunning ? TIMER_STATE_RUNNING : TIMER_STATE_NOT_RUNNING;
 }
 void CMomentumTimer::CalculateTickIntervalOffset(CMomentumPlayer *pPlayer, const int zoneType, const int zoneNumber)
 {

--- a/mp/src/game/shared/momentum/run/mom_entity_run_data.cpp
+++ b/mp/src/game/shared/momentum/run/mom_entity_run_data.cpp
@@ -8,7 +8,7 @@
 BEGIN_RECV_TABLE_NOBASE(CMomRunEntityData, DT_MomRunEntityData)
 RecvPropBool(RECVINFO(m_bIsInZone)),
 RecvPropBool(RECVINFO(m_bMapFinished)),
-RecvPropBool(RECVINFO(m_bTimerRunning)),
+RecvPropInt(RECVINFO(m_iTimerState)),
 RecvPropFloat(RECVINFO(m_flStrafeSync)),
 RecvPropFloat(RECVINFO(m_flStrafeSync2)),
 RecvPropInt(RECVINFO(m_iRunFlags), SPROP_UNSIGNED),
@@ -25,7 +25,7 @@ END_RECV_TABLE();
 BEGIN_SEND_TABLE_NOBASE(CMomRunEntityData, DT_MomRunEntityData)
 SendPropBool(SENDINFO(m_bIsInZone)),
 SendPropBool(SENDINFO(m_bMapFinished)),
-SendPropBool(SENDINFO(m_bTimerRunning)),
+SendPropInt(SENDINFO(m_iTimerState), 3, SPROP_UNSIGNED),
 SendPropFloat(SENDINFO(m_flStrafeSync)),
 SendPropFloat(SENDINFO(m_flStrafeSync2)),
 SendPropInt(SENDINFO(m_iRunFlags), 8, SPROP_UNSIGNED), // MOM_TODO change the nBits to how many flags we end up supporting!
@@ -45,7 +45,7 @@ CMomRunEntityData::CMomRunEntityData()
 {
     m_bIsInZone = false;
     m_bMapFinished = false;
-    m_bTimerRunning = false;
+    m_iTimerState = TIMER_STATE_NOT_RUNNING;
     m_flStrafeSync = 0.0f;
     m_flStrafeSync2 = 0.0f;
     m_iRunFlags = 0;

--- a/mp/src/game/shared/momentum/run/mom_entity_run_data.h
+++ b/mp/src/game/shared/momentum/run/mom_entity_run_data.h
@@ -11,6 +11,13 @@ EXTERN_RECV_TABLE(DT_MomRunEntityData);
 EXTERN_SEND_TABLE(DT_MomRunEntityData);
 #endif
 
+enum TimerState_t
+{
+    TIMER_STATE_NOT_RUNNING = 0,
+    TIMER_STATE_RUNNING, // Officially running (replay, official run attempt)
+    TIMER_STATE_PRACTICE // Artificially running (loaded saveloc)
+};
+
 class CMomRunEntityData
 {
   public:
@@ -23,7 +30,7 @@ class CMomRunEntityData
 
     CNetworkVar(bool, m_bIsInZone);       // This is true if the player is in a CTriggerTimerStage zone
     CNetworkVar(bool, m_bMapFinished);    // Did the player finish the map?
-    CNetworkVar(bool, m_bTimerRunning);   // Is the timer currently running for this ent?
+    CNetworkVar(int, m_iTimerState);     // Is the timer currently running for this ent? See TimerState_t
     CNetworkVar(float, m_flStrafeSync);   // eyeangle based, perfect strafes / total strafes
     CNetworkVar(float, m_flStrafeSync2);  // acceleration based, strafes speed gained / total strafes
     CNetworkVar(uint32, m_iRunFlags);     // The run flags (W only/HSW/Scroll etc) of the player

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
@@ -84,7 +84,7 @@ bool CRunSafeguard::IsSafeguarded(RunSafeguardMode_t mode)
     if (!pEntData)
         return false;
 
-    if (!pEntData->m_bTimerRunning || pPlayer->IsObserver())
+    if (pEntData->m_iTimerState != TIMER_STATE_RUNNING || pPlayer->IsObserver())
         return false;
 
 #ifdef GAME_DLL


### PR DESCRIPTION
Closes #723

This PR introduces a very nice tool for mappers and players alike: storing the current time in savelocs. This allows players to create savelocs when on a run (or continuing a timed saveloc) to time routes and see if there are potentially better routes to go through.

https://gfycat.com/verifiablesmugelver

Note that if you also hit the end trigger, it will pop open a faux end panel and let you compare against your PB's overall time. It doesn't do this live during the "run" as the stats related to this are more tied to the run replay than the player. But it can be something to expand upon this in the future.

Also note that this is only when a timer was previously running. If players want to time starting from a specific saveloc, they may edit the savedlocs.txt file to have this particular saveloc have a `"time" "0"` (or any tick value instead of 0) to have the timer count up upon loading the saveloc.

This PR also addresses some feedback found on Truktruk's stream / from Facade recently regarding our way we overrode making a saveloc in the start zone. The logic now creates the start mark, only hints at it once, but still creates a saveloc to add to the list as it was otherwise ruining the expected outcome of manually creating a start mark. I feel as though this is the best of both worlds; those not knowing about start marks get their hint (and not too much spam about it), while those that like savelocs and just loading it have the convenience still. It does duplicate data, but eh, they choose this path.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
