### PR TITLE
Properly reset run safeguards

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1251,6 +1251,8 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
             LimitSpeed(pStart->GetSpeedLimit(), true);
         }
         m_bShouldLimitPlayerSpeed = false;
+
+        g_pRunSafeguards->ResetAllSafeguards();
         // No break here, we want to fall through; this handles both the start and stage triggers
     case ZONE_TYPE_STAGE:
         {
@@ -1264,6 +1266,8 @@ void CMomentumPlayer::OnZoneExit(CTriggerZone *pTrigger)
                 if (zoneNum == 1)
                     m_RunStats.SetZoneEnterSpeed(0, enterVel3D, enterVel2D);
             }
+
+            g_pRunSafeguards->ResetSafeguard(RUN_SAFEGUARD_RESTART_STAGE);
         }
     default:
         break;

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
@@ -63,6 +63,11 @@ CRunSafeguard::CRunSafeguard(const char *szAction)
     Q_strncpy(m_szAction, szAction, sizeof(m_szAction));
 }
 
+void CRunSafeguard::Reset()
+{
+    m_flLastTimePressed = 0.0f - mom_run_safeguard_doublepress_maxtime.GetFloat();
+}
+
 bool CRunSafeguard::IsSafeguarded(RunSafeguardMode_t mode)
 {
     CMomentumPlayer *pPlayer;
@@ -163,6 +168,27 @@ MomRunSafeguards::MomRunSafeguards()
     m_bGameUIActive = false;
     g_pModuleComms->ListenForEvent("gameui_toggle", UtlMakeDelegate(this, &MomRunSafeguards::OnGameUIToggled));
 #endif
+}
+
+void MomRunSafeguards::ResetAllSafeguards()
+{
+    for (int i = 0; i < RUN_SAFEGUARD_COUNT; i++)
+    {
+        m_pSafeguards[i]->Reset();
+    }
+}
+
+void MomRunSafeguards::ResetSafeguard(int type)
+{
+    if (type <= RUN_SAFEGUARD_INVALID || type >= RUN_SAFEGUARD_COUNT)
+        return;
+
+    ResetSafeguard(RunSafeguardType_t(type));
+}
+
+void MomRunSafeguards::ResetSafeguard(RunSafeguardType_t type)
+{
+    m_pSafeguards[type]->Reset();
 }
 
 #ifdef GAME_DLL

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.cpp
@@ -58,7 +58,7 @@ static MAKE_TOGGLE_CONVAR(mom_run_safeguard_quit_map, "1", FCVAR_ARCHIVE | FCVAR
 static MAKE_TOGGLE_CONVAR(mom_run_safeguard_quit_game, "1", FCVAR_ARCHIVE | FCVAR_REPLICATED, "Changes the safeguard setting for preventing quitting the game while in a run. 0 = OFF, 1 = ON\n");
 
 CRunSafeguard::CRunSafeguard(const char *szAction)
-    : m_flLastTimePressed(0.0f), m_bDoublePressSafeguard(true), m_pRelatedVar(nullptr), m_bIgnoredInMenu(true)
+    : m_flLastTimePressed(0.0f), m_pRelatedVar(nullptr), m_bIgnoredInMenu(true)
 {
     Q_strncpy(m_szAction, szAction, sizeof(m_szAction));
 }
@@ -130,17 +130,13 @@ bool CRunSafeguard::IsDoublePressSafeguarded()
 {
     if (gpGlobals->curtime > m_flLastTimePressed + mom_run_safeguard_doublepress_maxtime.GetFloat())
     {
-        m_bDoublePressSafeguard = true;
-    }
-    m_flLastTimePressed = gpGlobals->curtime;
-    if (m_bDoublePressSafeguard)
-    {
         Warning("You must double press the key to %s while the timer is running!\n"
                 "You can turn this safeguard off in the Gameplay Settings!\n", m_szAction);
-        m_bDoublePressSafeguard = false;
+        m_flLastTimePressed = gpGlobals->curtime;
         return true;
     }
 
+    Reset();
     return false;
 }
 

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.h
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.h
@@ -33,6 +33,8 @@ class CRunSafeguard
   public:
     CRunSafeguard(const char *szAction);
 
+    void Reset();
+
     bool IsSafeguarded(RunSafeguardMode_t mode);
 
     void SetRelevantCVar(ConVar *pVarRef) { m_pRelatedVar = pVarRef; }
@@ -58,6 +60,10 @@ class MomRunSafeguards
 {
   public:
     MomRunSafeguards();
+
+    void ResetAllSafeguards();
+    void ResetSafeguard(int type);
+    void ResetSafeguard(RunSafeguardType_t type);
 
     bool IsSafeguarded(RunSafeguardType_t type);
     bool IsSafeguarded(RunSafeguardType_t type, RunSafeguardMode_t mode);

--- a/mp/src/game/shared/momentum/run/mom_run_safeguards.h
+++ b/mp/src/game/shared/momentum/run/mom_run_safeguards.h
@@ -49,8 +49,6 @@ class CRunSafeguard
 
     float m_flLastTimePressed;
 
-    bool m_bDoublePressSafeguard;
-
     bool m_bIgnoredInMenu;
 
     ConVar *m_pRelatedVar;


### PR DESCRIPTION
Closes #1068 

- Resets all run safeguards when entering start zone
- Resets the `mom_restart_stage` safeguard when entering a stage/checkpoint zone
- Resets the double press safeguard when it is not safeguarded (when it returns false)
  - Actions could happen with no safeguard after they have been safeguarded once as this was not being reset (IE opening chat should always be safeguarded, not failing to be when spammed)

For now, "reset" refers to the double press safeguard's `m_flLastTimePressed`.

Zone entering resets can't happen in their respective `TimerCommand_*` methods because the player can hit those without explicitly restarting. 
Stops the case where: press once, get safeguarded > restart by failing > exit zone > do command again & not get safeguarded.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
