### PR TITLE
Add Saveloc Importing ConCommand

### DIFF
--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -14,6 +14,9 @@
 #include "tier0/memdbgon.h"
 
 #define SAVELOC_FILE_NAME "savedlocs.txt"
+#define SAVELOC_KV_KEY_SAVELOCS "cps"
+#define SAVELOC_KV_KEY_CURRENTINDEX "cur"
+#define SAVELOC_KV_KEY_STARTMARKS "startmarks"
 
 MAKE_TOGGLE_CONVAR(mom_saveloc_save_between_sessions, "1", FCVAR_ARCHIVE, "Defines if savelocs should be saved between sessions of the same map.\n");
 

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -125,6 +125,8 @@ public:
     // WARNING! No verification is done. It is up to the caller to don't give false information
     void SetUsingSavelocMenu(bool bIsUsingSLMenu);
 
+    void AddSavelocsFromKV(KeyValues *pSavelocData);
+
 private:
     void CheckTimer(); // Check the timer to see if we should stop it
     void FireUpdateEvent() const; // Fire tan event to the UI when we change our saveloc vector in any way, or stop using the saveloc menu

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -128,6 +128,9 @@ public:
     // WARNING! No verification is done. It is up to the caller to don't give false information
     void SetUsingSavelocMenu(bool bIsUsingSLMenu);
 
+    KeyValues *GetSavelocKV() const { return m_pSavedLocsKV; }
+    void ImportMapSavelocs(const char *pImportMapName);
+
     void AddSavelocsFromKV(KeyValues *pSavelocData);
 
 private:

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -87,7 +87,8 @@ public:
     bool ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender);
 
     // Local
-    // Loads start marks from saveloc file
+    bool SaveSavelocsToKV();
+    // Loads start marks from savelocs keyvalues
     bool LoadStartMarks();
     // Gets the current menu Saveloc index
     uint32 GetCurrentSavelocMenuIndex() const { return m_iCurrentSavelocIndx; }

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -87,6 +87,8 @@ public:
     bool ReadReceivedSavelocs(SavelocReqPacket *input, const uint64 &sender);
 
     // Local
+    // Loads savelocs from file
+    bool LoadSavelocsIntoKV();
     bool SaveSavelocsToKV();
     // Loads start marks from savelocs keyvalues
     bool LoadStartMarks();


### PR DESCRIPTION
Closes #1104 

Mappers can now import a previous map's savelocs easily with the `mom_saveloc_import` command, which auto-completes to maps with savelocs, and appends them to the end of your current saveloc list.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
