### PR TITLE
Noclip/practice mode duck speed multiplier

### DIFF
--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -2199,10 +2199,10 @@ void CGameMovement::FullObserverMove( void )
 
 	float factor = sv_specspeed.GetFloat();
 
-	if ( mv->m_nButtons & IN_SPEED )
-	{
-		factor /= 2.0f;
-	}
+    if (mv->m_nButtons & IN_SPEED)
+    {
+        factor *= sv_noclipspeed_sprint_multiplier.GetFloat();
+    }
     if (mv->m_nButtons & IN_DUCK)
     {
         factor *= sv_noclipspeed_duck_multiplier.GetFloat();
@@ -2279,10 +2279,10 @@ void CGameMovement::FullNoClipMove( float factor, float maxacceleration )
 
 	AngleVectors (mv->m_vecViewAngles, &forward, &right, &up);  // Determine movement angles
 
-	if ( mv->m_nButtons & IN_SPEED )
-	{
-		factor /= 2.0f;
-	}
+    if ( mv->m_nButtons & IN_SPEED )
+    {
+        factor *= sv_noclipspeed_sprint_multiplier.GetFloat();
+    }
     if (mv->m_nButtons & IN_DUCK)
     {
         factor *= sv_noclipspeed_duck_multiplier.GetFloat();

--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -2203,6 +2203,10 @@ void CGameMovement::FullObserverMove( void )
 	{
 		factor /= 2.0f;
 	}
+    if (mv->m_nButtons & IN_DUCK)
+    {
+        factor *= sv_noclipspeed_duck_multiplier.GetFloat();
+    }
 
 	float fmove = mv->m_flForwardMove * factor;
 	float smove = mv->m_flSideMove * factor;
@@ -2279,6 +2283,10 @@ void CGameMovement::FullNoClipMove( float factor, float maxacceleration )
 	{
 		factor /= 2.0f;
 	}
+    if (mv->m_nButtons & IN_DUCK)
+    {
+        factor *= sv_noclipspeed_duck_multiplier.GetFloat();
+    }
 	
 	// Copy movement amounts
 	float fmove = mv->m_flForwardMove * factor;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -819,6 +819,9 @@ void CMomentumGameMovement::CalculateWaterWishVelocityZ(Vector &wishVel, const V
 
 void CMomentumGameMovement::Duck()
 {
+    if (player->GetMoveType() == MOVETYPE_NOCLIP)
+        return;
+
     if (g_pGameModeSystem->GameModeIs(GAMEMODE_AHOP))
     {
         BaseClass::Duck();

--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -77,6 +77,7 @@ ConVar	sv_noclipaccelerate( "sv_noclipaccelerate", "5", FCVAR_NOTIFY | FCVAR_ARC
 ConVar	sv_noclipspeed	( "sv_noclipspeed", "14", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);
 ConVar sv_noclipspeed_vertical("sv_noclipspeed_vertical", "7", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar sv_noclipspeed_duck_multiplier("sv_noclipspeed_duck_multiplier", "0.3", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
+ConVar sv_noclipspeed_sprint_multiplier("sv_noclipspeed_sprint_multiplier", "0.5", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar	sv_specaccelerate( "sv_specaccelerate", "5", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar	sv_specspeed	( "sv_specspeed", "3", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);
 ConVar	sv_specnoclip	( "sv_specnoclip", "1", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);

--- a/mp/src/game/shared/movevars_shared.cpp
+++ b/mp/src/game/shared/movevars_shared.cpp
@@ -76,6 +76,7 @@ ConVar	sv_stopspeed	( "sv_stopspeed","75", FCVAR_NOTIFY | FCVAR_REPLICATED | FCV
 ConVar	sv_noclipaccelerate( "sv_noclipaccelerate", "5", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar	sv_noclipspeed	( "sv_noclipspeed", "14", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);
 ConVar sv_noclipspeed_vertical("sv_noclipspeed_vertical", "7", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
+ConVar sv_noclipspeed_duck_multiplier("sv_noclipspeed_duck_multiplier", "0.3", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar	sv_specaccelerate( "sv_specaccelerate", "5", FCVAR_NOTIFY | FCVAR_ARCHIVE | FCVAR_REPLICATED);
 ConVar	sv_specspeed	( "sv_specspeed", "3", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);
 ConVar	sv_specnoclip	( "sv_specnoclip", "1", FCVAR_ARCHIVE | FCVAR_NOTIFY | FCVAR_REPLICATED);

--- a/mp/src/game/shared/movevars_shared.h
+++ b/mp/src/game/shared/movevars_shared.h
@@ -19,6 +19,7 @@ extern ConVar sv_stopspeed;
 extern ConVar sv_noclipaccelerate;
 extern ConVar sv_noclipspeed;
 extern ConVar sv_noclipspeed_vertical;
+extern ConVar sv_noclipspeed_duck_multiplier;
 extern ConVar sv_maxspeed;
 extern ConVar sv_accelerate;
 extern ConVar sv_airaccelerate;

--- a/mp/src/game/shared/movevars_shared.h
+++ b/mp/src/game/shared/movevars_shared.h
@@ -20,6 +20,7 @@ extern ConVar sv_noclipaccelerate;
 extern ConVar sv_noclipspeed;
 extern ConVar sv_noclipspeed_vertical;
 extern ConVar sv_noclipspeed_duck_multiplier;
+extern ConVar sv_noclipspeed_sprint_multiplier;
 extern ConVar sv_maxspeed;
 extern ConVar sv_accelerate;
 extern ConVar sv_airaccelerate;


### PR DESCRIPTION
Closes #1114 

- Stops ducking in noclip (no view offset / speed decrease).
- Introduces cvar `sv_noclipspeed_duck_multiplier` which multiplies the noclip speed factor if duck is pressed.
- Also replaced the hardcoded one from sprint with a cvar, `sv_noclipspeed_sprint_multiplier`.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
