### PR TITLE
Fix certain commands going through mapfinished panel

### DIFF
--- a/mp/src/game/client/momentum/clientmode_mom_normal.cpp
+++ b/mp/src/game/client/momentum/clientmode_mom_normal.cpp
@@ -48,6 +48,8 @@ CON_COMMAND(hud_reloadcontrols, "Reloads the control res files for hud elements.
 extern ConVar cl_forwardspeed;
 extern ConVar cl_sidespeed;
 
+extern ConVar mom_mapfinished_movement_enable;
+
 HScheme g_hVGuiCombineScheme = 0;
 
 // Instance the singleton and expose the interface to it.
@@ -193,6 +195,9 @@ int ClientModeMOMNormal::HudElementKeyInput(int down, ButtonCode_t keynum, const
                 m_pSpectatorGUI->SetMouseInputEnabled(true);
             return 0;
         }
+
+        if (!mom_mapfinished_movement_enable.GetBool())
+            return 0;
     }
 
     if (g_pZoneMenu && g_pZoneMenu->IsVisible())

--- a/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_mapfinished.cpp
@@ -22,7 +22,7 @@
 
 using namespace vgui;
 
-static MAKE_TOGGLE_CONVAR(mom_mapfinished_movement_enable, "0", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
+MAKE_TOGGLE_CONVAR(mom_mapfinished_movement_enable, "0", FCVAR_CLIENTDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE,
                           "Toggles being able to move after completing a run. 0 = OFF, 1 = ON\n");
 
 DECLARE_HUDELEMENT_DEPTH(CHudMapFinishedDialog, 70);


### PR DESCRIPTION
Closes #1091 

This PR fixes specific commands going through the mapfinished panel even when `mom_mapfinished_movement_enable` is false.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
