### PR TITLE
Fix HUD timer not properly updating when hidden

### DIFF
--- a/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
+++ b/mp/src/game/client/momentum/ui/HUD/hud_timer.cpp
@@ -37,6 +37,7 @@ class CHudTimer : public CHudElement, public EditablePanel
     void Init() OVERRIDE;
     void Reset() OVERRIDE;
     bool ShouldDraw() OVERRIDE;
+    void LevelInit() override;
     void LevelShutdown() OVERRIDE;
     void FireGameEvent(IGameEvent* event) OVERRIDE;
     void ApplySchemeSettings(IScheme* pScheme) OVERRIDE;
@@ -268,6 +269,15 @@ void CHudTimer::OnThink()
                             m_pComparisonLabel->SetFgColor(compareColor);
                             m_pComparisonLabel->SetText(comparisonANSI);
                         }
+                        else
+                        {
+                            m_pComparisonLabel->SetText("");
+                        }
+                    }
+                    else
+                    {
+                        m_pSplitLabel->SetText("");
+                        m_pComparisonLabel->SetText("");
                     }
                 }
             }
@@ -289,6 +299,11 @@ void CHudTimer::OnThink()
 bool CHudTimer::ShouldDraw()
 {
     return mom_hud_timer.GetBool() && CHudElement::ShouldDraw();
+}
+
+void CHudTimer::LevelInit()
+{
+    SetToNoTimer();
 }
 
 void CHudTimer::LevelShutdown()


### PR DESCRIPTION
Closes #1113 

This PR fixes a bug found when hiding the hud timer panel. If the timer is hidden, it doesn't have the OnThink method where it gets all of its data set be called. Thus, you could "store" information about a previous run in the panel by hiding it, doing a run with comparisons, then going to a new map with no comparisons.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
