### PR TITLE
Allow opening console from everywhere

### DIFF
--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.cpp
@@ -11,6 +11,8 @@
 #include "tier0/icommandline.h"
 #include "ienginevgui.h"
 #include "vgui_controls/AnimationController.h"
+#include "vgui/IInput.h"
+#include "IGameUIFuncs.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -66,6 +68,8 @@ CBaseMenuPanel::CBaseMenuPanel() : BaseClass(nullptr, "BaseGameUIPanel")
     m_pMainMenu = new MainMenu(this);
 
     m_pLoadingScreen = new CLoadingScreen(this);
+
+    input()->RegisterKeyCodeUnhandledListener(GetVPanel());
 
     OnGameUIActivated(); // Done here because normally it was done earlier than construction of this panel
 }
@@ -450,4 +454,15 @@ void CBaseMenuPanel::SetBackgroundRenderState(EBackgroundState state)
     }
 
     m_eBackgroundState = state;
+}
+
+void CBaseMenuPanel::OnKeyCodeUnhandled(int code)
+{
+    const char *binding = gameuifuncs->GetBindingForButtonCode(static_cast<ButtonCode_t>(code));
+
+    if (binding && (FStrEq(binding, "toggleconsole") || FStrEq(binding, "showconsole")))
+    {
+        engine->ClientCmd_Unrestricted(binding);
+    }
+
 }

--- a/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
+++ b/mp/src/game/client/momentum/ui/gameui/BaseMenuPanel.h
@@ -40,7 +40,9 @@ class CBaseMenuPanel : public vgui::EditablePanel
 
     MESSAGE_FUNC_PARAMS(OnLevelLoadingStarted, "LevelLoadStarted", pKvData);
     MESSAGE_FUNC_PARAMS(OnLevelLoadingFinished, "LevelLoadFinished", pKvData);
-    
+
+    MESSAGE_FUNC_INT(OnKeyCodeUnhandled, "KeyCodeUnhandled", code);
+
     EBackgroundState GetMenuBackgroundState() const { return m_eBackgroundState; }
 
 protected:


### PR DESCRIPTION
Closes #885

VGUI Input provides a hook to distribute KeyEvents that weren't handled at all to interested parties. Using this, we can check these events for toggleconsole and showconsole and in that case toggle the console manually. I chose BaseMenuPanel arbitrarily for this, it could be any other panel really.

This works with any keybind (sadly not mousebinds) and on any panel (main menu drawer!), even engine panels (e.g. mat_texture_list) apart from full-screen stuff like the settings and the leaderboards if you right-click.

This seems like the cleanest way I could find.

### Checklist
- [X] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [X] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [X] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [X] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [X] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [X] My commits are relatively small and scoped to the best of my ability
- [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
