### PR TITLE
Changes `mom_restart_stage` to not restart the whole map if the map is only one stage. (#1116)

### DIFF
--- a/mp/src/game/server/momentum/mapzones.cpp
+++ b/mp/src/game/server/momentum/mapzones.cpp
@@ -203,6 +203,9 @@ bool CMapZoneSystem::LoadZonesFromKeyValues(KeyValues *pKvTracks, bool bFromSite
         const auto trackNum = bFromSite ? trackKV->GetInt("trackNum") : Q_atoi(trackKV->GetName());
         if (trackNum >= -1 && trackNum < MAX_TRACKS)
         {
+            // Assume track is linear until a stage zone is found
+            m_iLinearTracks |= 1ULL << trackNum;
+
             KeyValues *toItr = bFromSite ? trackKV->FindKey("zones") : trackKV;
             if (!toItr)
                 return false;
@@ -234,8 +237,8 @@ bool CMapZoneSystem::LoadZonesFromKeyValues(KeyValues *pKvTracks, bool bFromSite
                                 if (zoneNum > m_iZoneCount[trackNum])
                                     m_iZoneCount[trackNum] = zoneNum;
 
-                                if (zoneType == ZONE_TYPE_CHECKPOINT)
-                                    m_iLinearTracks |= (1ULL << trackNum);
+                                if (zoneType == ZONE_TYPE_STAGE)
+                                    m_iLinearTracks &= ~(1ULL << trackNum);
                             }
                             else if (trackNum == -1)
                                 globalZones++;

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -398,25 +398,7 @@ CON_COMMAND_F(mom_restart_stage,
         track = pPlayer->m_Data.m_iCurrentTrack;
     }
 
-    if (track > sizeof(pPlayer->m_iZoneCount) || track < 0)
-    {
-        Warning("No such track\n");
-        return;
-    }
-
-    if (stage > pPlayer->m_iZoneCount[track] || track < 1)
-    {
-        Warning("No such stage\n");
-        return;
-    }
-
-    if (stage == 0)
-    {
-        Warning("No stage to restart!\n");
-        return;
-    }
-
-    if (pPlayer->m_iZoneCount[track] <= 1)
+    if (pPlayer->m_iZoneCount[track] == 1)
     {
         Warning("Track only has one zone! Use mom_restart instead.\n");
         return;

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -400,7 +400,7 @@ CON_COMMAND_F(mom_restart_stage,
 
     if (pPlayer->m_iLinearTracks.Get(track) == true)
     {
-        Warning("Track only has one zone! Use mom_restart instead.\n");
+        Warning("Not on a staged map! Use mom_restart instead.\n");
         return;
     }
 

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -398,7 +398,7 @@ CON_COMMAND_F(mom_restart_stage,
         track = pPlayer->m_Data.m_iCurrentTrack;
     }
 
-    if (pPlayer->m_iZoneCount[track] == 1)
+    if (pPlayer->m_iLinearTracks.Get(track) == true)
     {
         Warning("Track only has one zone! Use mom_restart instead.\n");
         return;

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -383,9 +383,6 @@ CON_COMMAND_F(mom_restart_stage,
     if (!pPlayer)
         return;
 
-    if (g_pRunSafeguards->IsSafeguarded(RUN_SAFEGUARD_RESTART_STAGE))
-        return;
-
     int stage = 0, track = 0;
     if (args.ArgC() > 1)
     {
@@ -404,6 +401,8 @@ CON_COMMAND_F(mom_restart_stage,
         return;
     }
 
+    if (g_pRunSafeguards->IsSafeguarded(RUN_SAFEGUARD_RESTART_STAGE))
+        return;
 
     pPlayer->TimerCommand_RestartStage(stage, track);
 }

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -398,6 +398,31 @@ CON_COMMAND_F(mom_restart_stage,
         track = pPlayer->m_Data.m_iCurrentTrack;
     }
 
+    if (track > sizeof(pPlayer->m_iZoneCount) || track < 0)
+    {
+        Warning("No such track\n");
+        return;
+    }
+
+    if (stage > pPlayer->m_iZoneCount[track] || track < 1)
+    {
+        Warning("No such stage\n");
+        return;
+    }
+
+    if (stage == 0)
+    {
+        Warning("No stage to restart!\n");
+        return;
+    }
+
+    if (pPlayer->m_iZoneCount[track] <= 1)
+    {
+        Warning("Track only has one zone! Use mom_restart instead.\n");
+        return;
+    }
+
+
     pPlayer->TimerCommand_RestartStage(stage, track);
 }
 

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -383,9 +383,6 @@ CON_COMMAND_F(mom_restart_stage,
     if (!pPlayer)
         return;
 
-    if (g_pRunSafeguards->IsSafeguarded(RUN_SAFEGUARD_RESTART_STAGE))
-        return;
-
     int stage = 0, track = 0;
     if (args.ArgC() > 1)
     {
@@ -403,6 +400,9 @@ CON_COMMAND_F(mom_restart_stage,
         Warning("You are not currently on a staged track! Use mom_restart instead.\n");
         return;
     }
+
+    if (g_pRunSafeguards->IsSafeguarded(RUN_SAFEGUARD_RESTART_STAGE))
+        return;
 
     pPlayer->TimerCommand_RestartStage(stage, track);
 }


### PR DESCRIPTION
Closes #1116 

Changes `mom_restart_stage` to not restart the whole map if the map is only one stage.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
