### PR TITLE
Temporary, per-run stage start marks

### DIFF
--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -480,14 +480,6 @@ void CMomentumPlayer::Spawn()
         m_iLandTick = 0;
         ResetRunStats();
 
-        g_pSavelocSystem->ClearAllStartMarks(START_MARK);
-
-        // Load startmarks after player spawn
-        if (g_pSavelocSystem->LoadStartMarks())
-            DevLog("Loaded startmarks from the savedlocs file!\n");
-        else
-            DevWarning("ERROR: Failed loading startmarks from the savedlocs file.\n");
-
         g_MapZoneSystem.DispatchMapInfo(this);
 
         // Reset current checkpoint trigger upon spawn

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -4,7 +4,6 @@
 #include "GameEventListener.h"
 #include "run/mom_run_entity.h"
 
-struct SavedLocation_t;
 class CBaseMomentumTrigger;
 class CTriggerOnehop;
 class CTriggerProgress;
@@ -201,7 +200,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     void SetAccelTicks(int ticks) { m_nAccelTicks = ticks; }
 
     bool CanTeleport();
-    void ManualTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity);
+    void ManualTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity, bool bStopTimer = true);
 
     // Trail Methods
     void Teleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity) OVERRIDE;

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "mom_ghostdefs.h"
-#include "mom_shareddefs.h"
 #include "GameEventListener.h"
 #include "run/mom_run_entity.h"
 
@@ -225,11 +224,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     void SetCurrentZoneTrigger(CTriggerZone *pZone) { return m_CurrentZoneTrigger.Set(pZone); }
     CTriggerZone *GetCurrentZoneTrigger() const { return m_CurrentZoneTrigger.Get(); }
-
-    bool CreateStartMark();
-    bool SetStartMark(int track, SavedLocation_t *saveloc);
-    SavedLocation_t *GetStartMark(int track) const { return (track >= 0 && track < MAX_TRACKS) ? m_pStartZoneMarks[track] : nullptr; }
-    bool ClearStartMark(int track, bool bPrintMsg = true);
+    bool IsInZone(MomZoneType_t eZoneType);
 
     void PreThink() override;
     void PostThink() OVERRIDE;
@@ -377,8 +372,6 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     CUtlVector<CTriggerOnehop*> m_vecOnehops;
     CHandle<CBaseMomentumTrigger> m_CurrentProgress;
     CHandle<CTriggerZone> m_CurrentZoneTrigger;
-
-    SavedLocation_t *m_pStartZoneMarks[MAX_TRACKS];
 
     // for detecting bhop
     friend class CMomentumGameMovement;

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -265,6 +265,7 @@ void CSaveLocSystem::PostInit()
 void CSaveLocSystem::LevelInitPreEntity()
 {
     m_bHintedStartMarkForLevel = false;
+    ClearAllStartMarks(START_MARK);
 
     // Note: We are not only loading in PostInit because if players edit their savelocs file (add
     // savelocs from a friend or something), then we want to reload on map load again,
@@ -273,12 +274,16 @@ void CSaveLocSystem::LevelInitPreEntity()
         return;
 
     KeyValues *kvMapSavelocs = m_pSavedLocsKV->FindKey(gpGlobals->mapname.ToCStr());
-    if (kvMapSavelocs && !kvMapSavelocs->IsEmpty())
-    {
-        m_iCurrentSavelocIndx = kvMapSavelocs->GetInt(SAVELOC_KV_KEY_CURRENTINDEX);
+    if (!kvMapSavelocs || kvMapSavelocs->IsEmpty())
+        return;
 
-        AddSavelocsFromKV(kvMapSavelocs->FindKey(SAVELOC_KV_KEY_SAVELOCS));
-    }
+    m_iCurrentSavelocIndx = kvMapSavelocs->GetInt(SAVELOC_KV_KEY_CURRENTINDEX);
+    AddSavelocsFromKV(kvMapSavelocs->FindKey(SAVELOC_KV_KEY_SAVELOCS));
+
+    if (LoadStartMarks())
+        DevLog("Loaded startmarks from the savedlocs KV!\n");
+    else
+        DevWarning("Failed loading startmarks from the savedlocs file.\n");
 }
 
 bool CSaveLocSystem::LoadStartMarks()

--- a/mp/src/game/server/momentum/mom_system_saveloc.cpp
+++ b/mp/src/game/server/momentum/mom_system_saveloc.cpp
@@ -600,6 +600,12 @@ bool CSaveLocSystem::CreateStartMark()
     if (!pPlayer)
         return false;
 
+    if (!pPlayer->GetGroundEntity())
+    {
+        Warning("Must be on ground to create a start mark!\n");
+        return false;
+    }
+
     StartMarkType_t type;
     int iMarkIndex;
     SavedLocation_t **pSaveLocAtIndex;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -27,6 +27,12 @@ enum SavedLocationComponent_t
     SAVELOC_ALL = ~SAVELOC_NONE,
 };
 
+enum StartMarkType_t
+{
+    START_MARK = 0,
+    START_MARK_STAGE
+};
+
 // Saved Location used in the "Saveloc menu"
 struct SavedLocation_t
 {
@@ -57,7 +63,7 @@ struct SavedLocation_t
     void Load(KeyValues* kvCP);
 
     // Called when the player wants to teleport to this checkpoint 
-    void Teleport(CMomentumPlayer* pPlayer);
+    void Teleport(CMomentumPlayer* pPlayer, bool bStopTimer = true);
 
     bool Read(CUtlBuffer &mem);
     bool Write(CUtlBuffer &mem);
@@ -129,10 +135,10 @@ public:
     void SetUsingSavelocMenu(bool bIsUsingSLMenu);
 
     bool CreateStartMark();
-    void ClearStartMark(int track, bool bPrintMsg = true);
-    void ClearCurrentStartMark(bool bPrintMsg = true);
-    void ClearAllStartMarks();
-    bool TeleportToStartMark(int track);
+    void ClearStartMark(StartMarkType_t eMarktype, int iMarkIndex, bool bPrintMsg = true);
+    void ClearCurrentStartMark(StartMarkType_t eMarktype, bool bPrintMsg = true);
+    void ClearAllStartMarks(StartMarkType_t eMarktype);
+    bool TeleportToStartMark(StartMarkType_t eMarktype, int iMarkIndex);
 
     KeyValues *GetSavelocKV() const { return m_pSavedLocsKV; }
     void ImportMapSavelocs(const char *pImportMapName);
@@ -154,6 +160,7 @@ private:
     bool m_bHintedStartMarkForLevel;
 
     CUtlVector<SavedLocation_t*> m_vecStartMarks;
+    CUtlVector<SavedLocation_t*> m_vecStageMarks;
 };
 
 extern CSaveLocSystem *g_pSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -128,6 +128,12 @@ public:
     // WARNING! No verification is done. It is up to the caller to don't give false information
     void SetUsingSavelocMenu(bool bIsUsingSLMenu);
 
+    bool CreateStartMark();
+    void ClearStartMark(int track, bool bPrintMsg = true);
+    void ClearCurrentStartMark(bool bPrintMsg = true);
+    void ClearAllStartMarks();
+    bool TeleportToStartMark(int track);
+
     KeyValues *GetSavelocKV() const { return m_pSavedLocsKV; }
     void ImportMapSavelocs(const char *pImportMapName);
 
@@ -146,6 +152,8 @@ private:
     int m_iCurrentSavelocIndx;
     bool m_bUsingSavelocMenu;
     bool m_bHintedStartMarkForLevel;
+
+    CUtlVector<SavedLocation_t*> m_vecStartMarks;
 };
 
 extern CSaveLocSystem *g_pSavelocSystem;

--- a/mp/src/game/server/momentum/mom_system_saveloc.h
+++ b/mp/src/game/server/momentum/mom_system_saveloc.h
@@ -74,9 +74,9 @@ class CSaveLocSystem : public CAutoGameSystem
 public:
     CSaveLocSystem(const char* pName);
     ~CSaveLocSystem();
-    void PostInit() OVERRIDE;
-    void LevelInitPreEntity() OVERRIDE;
-    void LevelShutdownPreEntity() OVERRIDE;
+    void PostInit() override;
+    void LevelInitPreEntity() override;
+    void LevelShutdownPreEntity() override;
 
     // Online
     // Called when the UI wants to request savelocs

--- a/mp/src/game/server/momentum/mom_timer.cpp
+++ b/mp/src/game/server/momentum/mom_timer.cpp
@@ -327,32 +327,6 @@ void CMomentumTimer::DisablePractice(CMomentumPlayer *pPlayer)
 
 //--------- Commands --------------------------------
 
-CON_COMMAND(mom_start_mark_create, "Marks a starting point inside the start trigger for a more customized starting location.\n")
-{
-    const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    if (pPlayer)
-    {
-        pPlayer->CreateStartMark();
-    }
-}
-
-CON_COMMAND(mom_start_mark_clear, "Clears the saved start location for your current track, if there is one.\n"
-                                  "You may also specify the track number to clear as the parameter; "
-                                  "\"mom_start_mark_clear 2\" clears track 2's start mark.")
-{
-    const auto pPlayer = CMomentumPlayer::GetLocalPlayer();
-    if (pPlayer)
-    {
-        int track = pPlayer->m_Data.m_iCurrentTrack;
-        if (args.ArgC() > 1)
-        {
-            track = Q_atoi(args[1]);
-        }
-
-        pPlayer->ClearStartMark(track);
-    }
-}
-
 CON_COMMAND_F(mom_timer_stop, "Stops the timer if it is currently running.\n", FCVAR_CLIENTCMD_CAN_EXECUTE)
 {
     const auto pPlayer = CMomentumPlayer::GetLocalPlayer();


### PR DESCRIPTION
Closes #221 

Adds start marks for stages that are reset on new runs. Also moves start mark code to the saveloc system.

- Since it stops the timer, I had to circumvent `ManualTeleport` in a way I'm not happy with but don't see a better option.
- Made it so players can `mom_restart_stage` to them while in the zone since that can't be abused (need to be there already before teleporting to it).
- Minor refactor of the start mark code when moving it over to the saveloc system. Might've identified a memory leak [here](https://github.com/momentum-mod/game/blob/ac0416a947feb5b14dd00629abcfd4e08223b8cd/mp/src/game/server/momentum/mom_player.cpp#L255)? Anyway should now properly be deleted.
- Don't like how similar the start mark vs stage mark code is. On hindsight should've probably just "overloaded" `mom_start_mark_create` to make stage zones too.

Draft PR for now as this conflicts with https://github.com/momentum-mod/game/pull/1134.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
