### PR TITLE
Linux now needs amd64 chroot

### DIFF
--- a/mp/src/devtools/makefile_base_posix.mak
+++ b/mp/src/devtools/makefile_base_posix.mak
@@ -81,17 +81,19 @@ COPY_DLL_TO_SRV = 0
 LDFLAGS += -Wl,--build-id
 
 # Building the game on Linux requires a CHROOT environment, please read https://github.com/momentum-mod/game/wiki/Building-The-Game/#linux for more info!
-CHROOT_NAME=steamrt_scout_i386
+CHROOT_NAME=steamrt_scout_amd64
 
 #
 # If we should be running in a chroot, check to see if we are. If not, then prefix everything with the 
 # required chroot
 #
 export STEAM_RUNTIME_PATH := /opt/gcc-9.2
-ifndef USING_DOCKER
-    ifneq ("$(SCHROOT_CHROOT_NAME)", "$(CHROOT_NAME)")
-        $(info '$(SCHROOT_CHROOT_NAME)' is not '$(CHROOT_NAME)')
-        $(error This makefile should be run from within a chroot. 'schroot --chroot $(CHROOT_NAME) -- $(MAKE) $(MAKEFLAGS)')  
+ifeq ("$(wildcard /run/systemd/container)","")
+    ifndef USING_DOCKER
+        ifneq ("$(SCHROOT_CHROOT_NAME)", "$(CHROOT_NAME)")
+            $(info '$(SCHROOT_CHROOT_NAME)' is not '$(CHROOT_NAME)')
+            $(error This makefile should be run from within a chroot. 'schroot --chroot $(CHROOT_NAME) -- $(MAKE) $(MAKEFLAGS)')  
+        endif
     endif
 endif
 GCC_VER = -9.2

--- a/mp/src/nbproject_default/configurations.xml
+++ b/mp/src/nbproject_default/configurations.xml
@@ -17,8 +17,8 @@
       <makefileType>
         <makeTool>
           <buildCommandWorkingDir>.</buildCommandWorkingDir>
-          <buildCommand>schroot --chroot steamrt_scout_i386 -- make -f games.mak</buildCommand>
-          <cleanCommand>schroot --chroot steamrt_scout_i386 -- make clean -f games.mak</cleanCommand>
+          <buildCommand>schroot --chroot steamrt_scout_amd64 -- make -f games.mak</buildCommand>
+          <cleanCommand>schroot --chroot steamrt_scout_amd64 -- make clean -f games.mak</cleanCommand>
           <executablePath></executablePath>
           <ccTool>
             <incDir>
@@ -92,8 +92,8 @@
       <makefileType>
         <makeTool>
           <buildCommandWorkingDir>.</buildCommandWorkingDir>
-          <buildCommand>schroot --chroot steamrt_scout_i386 -- make -f games.mak</buildCommand>
-          <cleanCommand>schroot --chroot steamrt_scout_i386 -- make clean -f games.mak</cleanCommand>
+          <buildCommand>schroot --chroot steamrt_scout_amd64 -- make -f games.mak</buildCommand>
+          <cleanCommand>schroot --chroot steamrt_scout_amd64 -- make clean -f games.mak</cleanCommand>
           <executablePath></executablePath>
           <ccTool>
             <incDir>


### PR DESCRIPTION
Docs PR momentum-mod/docs#149
New compiler needs amd64 chroot to function properly

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review