### PR TITLE
Fix missing subkey for start zone properties

### DIFF
--- a/mp/src/utils/zonmaker/zonmaker.cpp
+++ b/mp/src/utils/zonmaker/zonmaker.cpp
@@ -244,7 +244,7 @@ static KeyValues *ParseZones(CChunk *pRootChunk)
         triggerKV->SetString("zoneNum", zoneN);
         if (type == ZONE_TYPE_START)
         {
-            auto propsKV = triggerKV->FindKey("zoneProps", true);
+            auto propsKV = triggerKV->FindKey("zoneProps", true)->FindKey("properties", true);
 
             const auto spawnFlags = V_atoi(pChunk->FindKey("spawnflags"));
             if (const auto &key = pChunk->FindKey("speed_limit"))


### PR DESCRIPTION
I missed properties subkey in start zone

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
