### PR TITLE
Implement conc repress

### DIFF
--- a/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.cpp
@@ -47,6 +47,7 @@ CMomentumConcGrenade::CMomentumConcGrenade()
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
     m_iPrimaryAmmoType = AMMO_TYPE_GRENADE;
+    m_bRepress = false;
 }
 
 bool CMomentumConcGrenade::Deploy()
@@ -54,6 +55,7 @@ bool CMomentumConcGrenade::Deploy()
     m_bPrimed = false;
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
+    m_bRepress = false;
 
     return BaseClass::Deploy();
 }
@@ -63,13 +65,14 @@ bool CMomentumConcGrenade::Holster(CBaseCombatWeapon *pSwitchingTo)
     m_bPrimed = false;
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
+    m_bRepress = false;
 
     return BaseClass::Holster(pSwitchingTo);
 }
 
 void CMomentumConcGrenade::PrimaryAttack()
 {
-    if (m_bPrimed || m_flThrowTime > 0.0f)
+    if (m_bPrimed || m_flThrowTime > 0.0f || m_bRepress)
         return;
 
     CMomentumPlayer *pPlayer = GetPlayerOwner();
@@ -79,6 +82,7 @@ void CMomentumConcGrenade::PrimaryAttack()
 
     WeaponSound(GetWeaponSound("timer"));
     m_bPrimed = true;
+    m_bRepress = true;
 
     if (m_flTimer <= 0)
     {
@@ -107,6 +111,7 @@ void CMomentumConcGrenade::ItemPostFrame()
     {
         StartGrenadeThrow();
         m_bPrimed = false;
+        m_bRepress = false;
 
         if (m_flTimer > 0.0f && gpGlobals->curtime - m_flTimer > 0.5f) // throw conc with remaining fuse timer
         {
@@ -122,6 +127,8 @@ void CMomentumConcGrenade::ItemPostFrame()
         ThrowGrenade(GetMaxTimer());
         m_bPrimed = false;
     }
+    else if (!(pPlayer->m_nButtons & IN_ATTACK))
+        m_bRepress = false;
     else
     {
         BaseClass::ItemPostFrame();

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.cpp
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.cpp
@@ -47,7 +47,7 @@ CMomentumConcGrenade::CMomentumConcGrenade()
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
     m_iPrimaryAmmoType = AMMO_TYPE_GRENADE;
-    m_bRepress = false;
+    m_bNeedsRepress = false;
 }
 
 bool CMomentumConcGrenade::Deploy()
@@ -55,7 +55,7 @@ bool CMomentumConcGrenade::Deploy()
     m_bPrimed = false;
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
-    m_bRepress = false;
+    m_bNeedsRepress = false;
 
     return BaseClass::Deploy();
 }
@@ -65,14 +65,14 @@ bool CMomentumConcGrenade::Holster(CBaseCombatWeapon *pSwitchingTo)
     m_bPrimed = false;
     m_flThrowTime = 0.0f;
     m_flTimer = 0.0f;
-    m_bRepress = false;
+    m_bNeedsRepress = false;
 
     return BaseClass::Holster(pSwitchingTo);
 }
 
 void CMomentumConcGrenade::PrimaryAttack()
 {
-    if (m_bPrimed || m_flThrowTime > 0.0f || m_bRepress)
+    if (m_bPrimed || m_flThrowTime > 0.0f || m_bNeedsRepress)
         return;
 
     CMomentumPlayer *pPlayer = GetPlayerOwner();
@@ -82,7 +82,7 @@ void CMomentumConcGrenade::PrimaryAttack()
 
     WeaponSound(GetWeaponSound("timer"));
     m_bPrimed = true;
-    m_bRepress = true;
+    m_bNeedsRepress = true;
 
     if (m_flTimer <= 0)
     {
@@ -111,7 +111,7 @@ void CMomentumConcGrenade::ItemPostFrame()
     {
         StartGrenadeThrow();
         m_bPrimed = false;
-        m_bRepress = false;
+        m_bNeedsRepress = false;
 
         if (m_flTimer > 0.0f && gpGlobals->curtime - m_flTimer > 0.5f) // throw conc with remaining fuse timer
         {
@@ -127,8 +127,10 @@ void CMomentumConcGrenade::ItemPostFrame()
         ThrowGrenade(GetMaxTimer());
         m_bPrimed = false;
     }
-    else if (!(pPlayer->m_nButtons & IN_ATTACK))
-        m_bRepress = false;
+    else if (!(pPlayer->m_nButtons & IN_ATTACK)) // Require player to release and repress +attack before another grenade can be thrown
+    {
+        m_bNeedsRepress = false;
+    }
     else
     {
         BaseClass::ItemPostFrame();

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.h
@@ -40,6 +40,7 @@ class CMomentumConcGrenade : public CWeaponBase
 
   protected:
     CNetworkVar(bool, m_bPrimed);      // Set to true when the pin has been pulled but the grenade hasn't been thrown yet.
+    CNetworkVar(bool, m_bRepress);     // Require a release and repress of +attack before a new grenade can be primed
     CNetworkVar(float, m_flThrowTime); // The time at which the grenade will be thrown.  If this value is 0 then the time hasn't been set yet.
     CNetworkVar(float, m_flTimer);     // Once the grenade is cooked, this gets incremented until the grenade is meant to go off.
 };

--- a/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.h
+++ b/mp/src/game/shared/momentum/weapon/weapon_mom_concgrenade.h
@@ -40,7 +40,7 @@ class CMomentumConcGrenade : public CWeaponBase
 
   protected:
     CNetworkVar(bool, m_bPrimed);      // Set to true when the pin has been pulled but the grenade hasn't been thrown yet.
-    CNetworkVar(bool, m_bRepress);     // Require a release and repress of +attack before a new grenade can be primed
+    CNetworkVar(bool, m_bNeedsRepress);     // Require a release and repress of +attack before a new grenade can be primed
     CNetworkVar(float, m_flThrowTime); // The time at which the grenade will be thrown.  If this value is 0 then the time hasn't been set yet.
     CNetworkVar(float, m_flTimer);     // Once the grenade is cooked, this gets incremented until the grenade is meant to go off.
 };


### PR DESCRIPTION
require a repress of +attack after a handheld

Requested in #802

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
