### PR TITLE
Ghost entpanels scale with resolution & are centered

### DIFF
--- a/mp/game/momentum/resource/ui/GhostEntityPanel.res
+++ b/mp/game/momentum/resource/ui/GhostEntityPanel.res
@@ -15,7 +15,6 @@
 		"tabPosition"	"0"
 		"paintborder"	"1"
         "BgColor_override" "BlackHO"
-        "OffsetX" "-74"
         "OffsetY" "-60"
 	}
 
@@ -35,7 +34,7 @@
         "ControlName"       "Label"
         "fieldName"         "GhostEntityPanelName"
         "xpos" "0"
-        "ypos" "2"
+        "ypos" "0"
         "wide" "100"
         "tall" "0"
         "pin_to_sibling" "GhostEntityPanelAvatar"

--- a/mp/game/momentum/resource/ui/GhostEntityPanel.res
+++ b/mp/game/momentum/resource/ui/GhostEntityPanel.res
@@ -7,7 +7,7 @@
 		// "xpos"			"cs-0.5"
 		// "ypos"			"50"
 		"wide"			"80"
-		"tall"			"36"
+		"tall"			"0" // set in code
 		"autoResize"	"0"
 		"pinCorner"		"0"
 		"visible"		"1"

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
@@ -55,7 +55,7 @@ void CGhostEntityPanel::Init(C_MomentumOnlineGhostEntity* pEnt)
 
 void CGhostEntityPanel::OnThink()
 {
-    SetPos(static_cast<int>(m_iPosX + m_OffsetX + 0.5f), static_cast<int>(m_iPosY + m_OffsetY + 0.5f));
+    SetPos(static_cast<int>(m_iPosX - GetWide() / 2), static_cast<int>(m_iPosY + m_iOffsetY));
 
     if (m_pEntity)
     {

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
@@ -38,9 +38,7 @@ CGhostEntityPanel::CGhostEntityPanel() : BaseClass(g_pClientMode->GetViewport(),
     SetPaintBackgroundEnabled(false);
 
     m_pAvatarImage->SetDrawFriend(false);
-    m_pAvatarImage->SetAvatarSize(32, 32);
     m_pAvatarImagePanel->SetImage(m_pAvatarImage);
-    m_pAvatarImagePanel->SetSize(32, 32);
 }
 
 void CGhostEntityPanel::Init(C_MomentumOnlineGhostEntity* pEnt)
@@ -128,11 +126,17 @@ void CGhostEntityPanel::OnTick()
     m_pAvatarImagePanel->SetVisible(mom_entpanels_enable_avatars.GetBool());
 }
 
+void CGhostEntityPanel::PerformLayout()
+{
+    BaseClass::PerformLayout();
+    SetTall(m_pAvatarImagePanel->GetTall() + m_pNameLabel->GetTall() + m_pAvatarImagePanel->GetYPos() + m_pNameLabel->GetYPos());
+    m_pAvatarImage->SetAvatarSize(m_pAvatarImagePanel->GetWide(), m_pAvatarImagePanel->GetTall());
+}
+
 bool CGhostEntityPanel::ShouldDraw()
 {
     return mom_entpanels_enable.GetBool() && (mom_entpanels_enable_avatars.GetBool() || mom_entpanels_enable_names.GetBool());
 }
-
 
 bool CGhostEntityPanel::GetEntityPosition(int& sx, int& sy)
 {

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.cpp
@@ -5,10 +5,8 @@
 #include "view.h"
 #include "mom_shareddefs.h"
 #include "vgui/IVGui.h"
-#include "vgui/ILocalize.h"
 #include "vgui_controls/ImagePanel.h"
 #include <vgui_controls/Label.h>
-#include <vgui/ISurface.h>
 #include "vgui_avatarimage.h"
 #include "c_mom_online_ghost.h"
 
@@ -65,8 +63,6 @@ void CGhostEntityPanel::OnThink()
         {
             m_pAvatarImage->SetAvatarSteamID(CSteamID(m_pEntity->GetSteamID()), k_EAvatarSize64x64);
         }
-
-        // MOM_TODO: Blink the panel if they're typing? Maybe an icon or something? Idk
 
         if (m_bPaintName)
         {

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.h
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.h
@@ -16,6 +16,7 @@ class CGhostEntityPanel : public vgui::EditablePanel
     void Init(C_MomentumOnlineGhostEntity *pEntity);
     void OnThink() override;
     void OnTick() override;
+    void PerformLayout() override;
 
     bool ShouldDraw();
 

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.h
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.h
@@ -7,15 +7,15 @@ class CAvatarImage;
 
 class CGhostEntityPanel : public vgui::EditablePanel
 {
-public:
+  public:
     DECLARE_CLASS_SIMPLE(CGhostEntityPanel, vgui::EditablePanel);
 
     CGhostEntityPanel();
     ~CGhostEntityPanel();
 
     void Init(C_MomentumOnlineGhostEntity *pEntity);
-    void OnThink() OVERRIDE;
-    void OnTick() OVERRIDE;
+    void OnThink() override;
+    void OnTick() override;
 
     bool ShouldDraw();
 
@@ -27,8 +27,8 @@ public:
     CPanelAnimationVar(int, m_OffsetX, "OffsetX", "-74");
     CPanelAnimationVar(int, m_OffsetY, "OffsetY", "-60");
 
-private:
 
+  private:
     bool m_bPaintName;
 
     C_MomentumOnlineGhostEntity *m_pEntity;

--- a/mp/src/game/client/momentum/ui/GhostEntityPanel.h
+++ b/mp/src/game/client/momentum/ui/GhostEntityPanel.h
@@ -23,10 +23,7 @@ class CGhostEntityPanel : public vgui::EditablePanel
 
     bool GetEntityPosition(int& sx, int& sy);
 
-    // Offset from entity that we should draw
-    CPanelAnimationVar(int, m_OffsetX, "OffsetX", "-74");
-    CPanelAnimationVar(int, m_OffsetY, "OffsetY", "-60");
-
+    CPanelAnimationVar(int, m_iOffsetY, "OffsetY", "-60");
 
   private:
     bool m_bPaintName;


### PR DESCRIPTION
Closes #847 

Got the opportunity to quickly solve this.

- Centers entpanels
- Allows their height to properly scale with resolution
- Allows the avatar image size to scale with resolution

640x480:
![image](https://user-images.githubusercontent.com/9014762/99138945-70805b80-25e9-11eb-8b71-58349408be00.png)

1280x720:
![image](https://user-images.githubusercontent.com/9014762/99138971-a6bddb00-25e9-11eb-9030-83285a37c454.png)

1920x1080:
![image](https://user-images.githubusercontent.com/9014762/99138957-8857df80-25e9-11eb-841c-b239e70b6587.png)

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
