### PR TITLE
Ability to draw info_teleport_destinations in game

### DIFF
--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -526,3 +526,11 @@ RecvPropBool(RECVINFO(m_bStuckOnGround)),
 RecvPropBool(RECVINFO(m_bAllowingJump)),
 RecvPropBool(RECVINFO(m_bDisableGravity)),
 END_RECV_TABLE();
+
+// ======================================
+
+LINK_ENTITY_TO_CLASS(info_teleport_destination, C_TeleportDestination);
+
+IMPLEMENT_CLIENTCLASS_DT(C_TeleportDestination, DT_TeleportDestination, CTeleportDestination)
+END_RECV_TABLE();
+

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -589,3 +589,11 @@ void C_TeleportDestination::Precache()
     BaseClass::Precache();
     PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL);
 }
+
+void C_TeleportDestination::GetRenderBounds(Vector &mins, Vector &maxs) 
+{
+    // force render bounds as this was drawing only when the origin was in view
+    float dim = mom_teledests_dimensions.GetFloat() / 2.0f;
+    mins.Init(-dim, -dim, 0);
+    maxs.Init(dim, dim, 0);
+}

--- a/mp/src/game/client/momentum/c_mom_triggers.cpp
+++ b/mp/src/game/client/momentum/c_mom_triggers.cpp
@@ -42,6 +42,10 @@ static ConVar mom_zone_checkpoint_draw_color("mom_zone_checkpoint_draw_color", "
 static MAKE_TOGGLE_CONVAR(mom_zone_draw_alpha_override_toggle, "1", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Toggles the alpha override for drawing zone faces.\n");
 static MAKE_CONVAR(mom_zone_draw_faces_alpha_override, "160", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Alpha override for drawing zone faces.\n", 0, 255);
 
+static MAKE_TOGGLE_CONVAR(mom_teledests_draw, "0", FCVAR_CLIENTCMD_CAN_EXECUTE, "Toggles drawing teleport destination markings\n");
+static MAKE_CONVAR(mom_teledests_dimensions, "32", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Changes the dimensions of drawn teleport destination markings\n", 1, 128);
+static ConVar mom_teledests_color("mom_teledests_color", "FFFFFFFF", FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_ARCHIVE, "Color of the teleport destination markings.\n");
+
 CTriggerOutlineRenderer::CTriggerOutlineRenderer()
 {
     m_pVertices = nullptr;
@@ -534,3 +538,54 @@ LINK_ENTITY_TO_CLASS(info_teleport_destination, C_TeleportDestination);
 IMPLEMENT_CLIENTCLASS_DT(C_TeleportDestination, DT_TeleportDestination, CTeleportDestination)
 END_RECV_TABLE();
 
+int C_TeleportDestination::DrawModel(int flags)
+{
+    if (!mom_teledests_draw.GetBool())
+        return 1;
+
+    Color color;
+    if (!MomUtil::GetColorFromHex(mom_teledests_color.GetString(), color))
+        return 1;
+
+    const auto origin = GetAbsOrigin();
+    float dim = mom_teledests_dimensions.GetFloat() / 2.0f;
+
+    CMatRenderContextPtr pRenderContext(materials);
+    const auto pMaterial = materials->FindMaterial(MOM_ZONE_DRAW_MATERIAL, TEXTURE_GROUP_OTHER);
+    IMesh *pMesh = pRenderContext->GetDynamicMesh(true, nullptr, nullptr, pMaterial);
+    CMeshBuilder builder;
+
+    builder.Begin(pMesh, MATERIAL_QUADS, 4);
+
+    builder.Position3f(origin.x + dim, origin.y + dim, origin.z);
+    builder.Color4ub(color.r(), color.g(), color.b(), color.a());
+    builder.AdvanceVertex();
+
+    builder.Position3f(origin.x + dim, origin.y - dim, origin.z);
+    builder.Color4ub(color.r(), color.g(), color.b(), color.a());
+    builder.AdvanceVertex();
+
+    builder.Position3f(origin.x - dim, origin.y - dim, origin.z);
+    builder.Color4ub(color.r(), color.g(), color.b(), color.a());
+    builder.AdvanceVertex();
+
+    builder.Position3f(origin.x - dim, origin.y + dim, origin.z);
+    builder.Color4ub(color.r(), color.g(), color.b(), color.a());
+    builder.AdvanceVertex();
+
+    builder.End(false, true);
+
+    return 1;
+}
+
+void C_TeleportDestination::Spawn()
+{
+    Precache();
+    BaseClass::Spawn();
+}
+
+void C_TeleportDestination::Precache()
+{
+    BaseClass::Precache();
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL);
+}

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -127,4 +127,9 @@ class C_TeleportDestination : public C_BaseEntity
 
   public:
     C_TeleportDestination() = default;
+
+    bool ShouldDraw() override { return true; }
+    int DrawModel(int flags) override;
+    void Spawn() override;
+    void Precache() override;
 };

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -132,4 +132,5 @@ class C_TeleportDestination : public C_BaseEntity
     int DrawModel(int flags) override;
     void Spawn() override;
     void Precache() override;
+    void GetRenderBounds(Vector &mins, Vector &maxs) override;
 };

--- a/mp/src/game/client/momentum/c_mom_triggers.h
+++ b/mp/src/game/client/momentum/c_mom_triggers.h
@@ -119,3 +119,12 @@ class C_TriggerSlide : public C_BaseMomZoneTrigger
     CNetworkVar(bool, m_bAllowingJump);
     CNetworkVar(bool, m_bDisableGravity);
 };
+
+class C_TeleportDestination : public C_BaseEntity
+{
+    DECLARE_CLASS(C_TeleportDestination, C_BaseEntity);
+    DECLARE_CLIENTCLASS();
+
+  public:
+    C_TeleportDestination() = default;
+};

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -2558,3 +2558,5 @@ int CTriggerMomentumCatapult::DrawDebugTextOverlays()
 }
 
 //-----------------------------------------------------------------------------------------------
+
+LINK_ENTITY_TO_CLASS(info_teleport_destination, CTeleportDestination);

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -2560,3 +2560,7 @@ int CTriggerMomentumCatapult::DrawDebugTextOverlays()
 //-----------------------------------------------------------------------------------------------
 
 LINK_ENTITY_TO_CLASS(info_teleport_destination, CTeleportDestination);
+
+IMPLEMENT_SERVERCLASS_ST(CTeleportDestination, DT_TeleportDestination)
+END_SEND_TABLE();
+

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -2564,3 +2564,14 @@ LINK_ENTITY_TO_CLASS(info_teleport_destination, CTeleportDestination);
 IMPLEMENT_SERVERCLASS_ST(CTeleportDestination, DT_TeleportDestination)
 END_SEND_TABLE();
 
+void CTeleportDestination::Spawn()
+{
+    Precache();
+    BaseClass::Spawn();
+}
+
+void CTeleportDestination::Precache()
+{
+    BaseClass::Precache();
+    PrecacheMaterial(MOM_ZONE_DRAW_MATERIAL);
+}

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -936,7 +936,11 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
 class CTeleportDestination : public CPointEntity
 {
     DECLARE_CLASS(CTeleportDestination, CPointEntity);
+    DECLARE_NETWORKCLASS();
 
 public:
     CTeleportDestination() = default;
+
+    // always send to all clients
+    int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -941,6 +941,9 @@ class CTeleportDestination : public CPointEntity
 public:
     CTeleportDestination() = default;
 
+    void Spawn() override;
+    void Precache() override;
+
     // always send to all clients
     int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 };

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -932,3 +932,11 @@ class CTriggerMomentumCatapult : public CBaseMomentumTrigger
     bool m_bEveryTick;
     float m_flHeightOffset;
 };
+
+class CTeleportDestination : public CPointEntity
+{
+    DECLARE_CLASS(CTeleportDestination, CPointEntity);
+
+public:
+    CTeleportDestination() = default;
+};

--- a/mp/src/game/server/triggers.cpp
+++ b/mp/src/game/server/triggers.cpp
@@ -2274,7 +2274,6 @@ void CTriggerPush::Touch( CBaseEntity *pOther )
 	}
 }
 
-LINK_ENTITY_TO_CLASS( info_teleport_destination, CPointEntity );
 
 //-----------------------------------------------------------------------------
 // Teleport Relative trigger


### PR DESCRIPTION
Closes #341 

Adds the ability to draw teleport destinations, like showtriggers. A square is drawn at the base of them, using the zone drawing material for now.

cvars:
- `mom_teledests_draw` - toggles showing them. Not archived, defaulted to off
- `mom_teledests_color` - default white
- `mom_teledests_dimensions` - controls the dimension of the square

![image](https://user-images.githubusercontent.com/9014762/99217701-93e40b80-278d-11eb-8af5-4704707d1379.png)

There is one issue however: tele dests stop drawing when the center of them is not in view. I'm guessing because this a technically just a point? 
https://www.youtube.com/watch?v=j8M1SCq-_L4

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
