### PR TITLE
Fix using arrow keys resetting selection to first item after selecting from dropdown

### DIFF
--- a/mp/src/vgui2/vgui_controls/ComboBox.cpp
+++ b/mp/src/vgui2/vgui_controls/ComboBox.cpp
@@ -729,13 +729,7 @@ void ComboBox::OnMenuItemSelected()
 	//if ( m_bAllowEdit )
 	{
 		int idx = GetActiveItem();
-		if ( idx >= 0 )
-		{
-			wchar_t name[ 256 ];
-			GetItemText( idx, name, sizeof( name ) );
-
-			OnSetText( name );
-		}
+		SelectMenuItem(idx);
 	}
 
 	Repaint();

--- a/mp/src/vgui2/vgui_controls/Menu.cpp
+++ b/mp/src/vgui2/vgui_controls/Menu.cpp
@@ -1970,6 +1970,7 @@ void Menu::OnMenuItemSelected(Panel *panel)
 		{
 			activeItemSet = true;
 			m_iActivatedItem = i;
+			m_iCurrentlySelectedItemID = i;
 			break;
 		}
 	}


### PR DESCRIPTION
Closes #1083

<!-- Describe what your pull request is doing here -->

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
