### PR TITLE
Update player's name on user components and lobby members panel

### DIFF
--- a/mp/src/game/client/momentum/ui/controls/UserComponent.cpp
+++ b/mp/src/game/client/momentum/ui/controls/UserComponent.cpp
@@ -32,6 +32,7 @@ UserComponent::UserComponent(Panel* pParent, const char *pName /*= "UserComponen
     m_pUserRank = new Label(this, "UserRank", "...");
     m_pXPProgressBar = new ContinuousProgressBar(this, "XPProgress");
     m_pXPProgressBar->SetProgress(0);
+    m_uSteamID = 0Ull;
 
     LoadControlSettings("resource/ui/UserComponent.res");
 }
@@ -77,6 +78,8 @@ void UserComponent::SetUser(uint64 uID)
     }
 
     InvalidateLayout();
+
+    m_uSteamID = uID;
 }
 
 void UserComponent::OnUserDataUpdate()
@@ -133,5 +136,13 @@ void UserComponent::OnMouseReleased(MouseCode code)
     if (code == MOUSE_LEFT && m_bClickable)
     {
         PostActionSignal(new KeyValues("UserComponentClicked"));
+    }
+}
+
+void UserComponent::OnPersonaStateChange(PersonaStateChange_t *pParams)
+{
+    if (pParams->m_nChangeFlags & k_EPersonaChangeName && m_uSteamID == pParams->m_ulSteamID)
+    {
+        m_pUserName->SetText(SteamFriends()->GetFriendPersonaName(m_uSteamID));
     }
 }

--- a/mp/src/game/client/momentum/ui/controls/UserComponent.h
+++ b/mp/src/game/client/momentum/ui/controls/UserComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "vgui_controls/EditablePanel.h"
+#include <steam/isteamfriends.h>
 
 class CAvatarImagePanel;
 struct UserData;
@@ -25,10 +26,14 @@ protected:
     void ApplySchemeSettings(vgui::IScheme* pScheme) override;
     void OnMouseReleased(vgui::MouseCode code) override;
 
+    STEAM_CALLBACK(UserComponent, OnPersonaStateChange, PersonaStateChange_t);
+
 private:
     CAvatarImagePanel *m_pUserImage;
     vgui::Label *m_pUserName, *m_pUserRank;
     vgui::ProgressBar *m_pXPProgressBar;
 
     bool m_bClickable;
+
+    uint64 m_uSteamID;
 };

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/DrawerPanel_Lobby.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/DrawerPanel_Lobby.cpp
@@ -143,3 +143,12 @@ void DrawerPanel_Lobby::OnReloadControls()
     if (m_bInLobby && bVisible)
         m_pLobbyChat->SetVisible(true);
 }
+
+void DrawerPanel_Lobby::OnPersonaStateChange(PersonaStateChange_t *pParams)
+{
+    if (pParams->m_nChangeFlags & k_EPersonaChangeName)
+    {
+        m_pLobbyInfo->UpdateLobbyName();
+        m_pLobbyMembers->UpdateLobbyMemberName(pParams->m_ulSteamID);
+    }
+}

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/DrawerPanel_Lobby.h
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/DrawerPanel_Lobby.h
@@ -3,6 +3,7 @@
 #include "vgui_controls/PropertyPage.h"
 
 #include "steam/isteammatchmaking.h"
+#include <steam/isteamfriends.h>
 
 class LobbyMembersPanel;
 class LobbyInfoPanel;
@@ -19,6 +20,8 @@ public:
     STEAM_CALLBACK(DrawerPanel_Lobby, OnLobbyEnter, LobbyEnter_t); // When we enter a lobby
     STEAM_CALLBACK(DrawerPanel_Lobby, OnLobbyDataUpdate, LobbyDataUpdate_t); // People/lobby updates status
     STEAM_CALLBACK(DrawerPanel_Lobby, OnLobbyChatUpdate, LobbyChatUpdate_t); // People join/leave
+    STEAM_CALLBACK(DrawerPanel_Lobby, OnPersonaStateChange, PersonaStateChange_t); // People change name
+
     void OnLobbyLeave(); // No dedicated steam callback, thanks valve
 
 protected:

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyInfoPanel.h
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyInfoPanel.h
@@ -20,6 +20,8 @@ public:
 
     void OnLobbyDataUpdate(LobbyDataUpdate_t *pData);
 
+    void UpdateLobbyName();
+
 protected:
     void OnCommand(const char* command) override;
     void OnMousePressed(vgui::MouseCode code) override;
@@ -32,7 +34,6 @@ protected:
 private:
     void LobbyEnterSuccess();
     void SetLobbyTypeImage() const;
-    void UpdateLobbyName();
     void IncrementLobbyType() const;
     void SetLobbyType(int type) const;
     void OnChangeLobbyLimit();

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyMembersPanel.cpp
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyMembersPanel.cpp
@@ -165,6 +165,15 @@ void LobbyMembersPanel::UpdateLobbyMemberData(const CSteamID& memberID)
     m_pMemberList->ApplyItemChanges(itemID);
 }
 
+void LobbyMembersPanel::UpdateLobbyMemberName(const CSteamID &memberID)
+{
+    const auto pData = m_pMemberList->GetItem(FindItemIDForLobbyMember(memberID));
+    if (!pData)
+        return;
+
+    pData->SetString("personaname", SteamFriends()->GetFriendPersonaName(memberID));
+}
+
 int LobbyMembersPanel::StaticLobbyMemberSortFunc(ListPanel* list, const ListPanelItem &item1, const ListPanelItem &item2)
 {
     KeyValues *it1 = item1.kv;

--- a/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyMembersPanel.h
+++ b/mp/src/game/client/momentum/ui/gameui/mainmenu/drawer/lobby/LobbyMembersPanel.h
@@ -29,6 +29,7 @@ public:
 
     void AddLobbyMember(const CSteamID &steamID); // Adds a lobby member to the panel
     void UpdateLobbyMemberData(const CSteamID &memberID); // Updates the lobby member's status data on the panel
+    void UpdateLobbyMemberName(const CSteamID &memberID); // Updates just the lobby member's name
 
     static int StaticLobbyMemberSortFunc(vgui::ListPanel *list, const vgui::ListPanelItem &item1, const vgui::ListPanelItem &item2);
 


### PR DESCRIPTION
Closes #1162 

Unfortunately there's no steam callback for changing names (at least from what I read of the steamworks API), so I took the approach of just updating it more often.

- Main menu user component updates when drawer is closed. Not on open as you can't see it with the drawer open anyhow.
- Profile page's user component updates when the tab is clicked on. For some reason `OnPageShow` isn't being called when opening the drawer though. Intentional?
- Lobby name & avatar now update with any lobby change.
- Fixed steam name being always being overwritten by user data in user component (`SetUser` sets the steam name then calls `FillControlsWithUserData` that overwrites it with the one in user data). Result though is us not using the locally stored username.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
