### PR TITLE
Refactor ILocalize

### DIFF
--- a/mp/src/public/tier1/ilocalize.h
+++ b/mp/src/public/tier1/ilocalize.h
@@ -23,6 +23,7 @@ typedef unsigned short wchar_t;
 #define _WCHAR_T_DEFINED
 #endif
 
+class CLocalizedStringArg;
 
 // direct references to localized strings
 typedef unsigned long StringIndex_t;
@@ -136,6 +137,12 @@ public:
 	}
 
 	template < typename T >
+	static void ConstructStringArgs(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) T *unicodeOuput, int unicodeBufferSizeInBytes, const T *formatString, int numFormatParameters, const CLocalizedStringArg* argList)
+	{
+		ConstructStringArgsInternal( unicodeOuput, unicodeBufferSizeInBytes, formatString, numFormatParameters, argList );
+	}
+
+	template < typename T >
 	static void ConstructString(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) T *unicodeOutput, int unicodeBufferSizeInBytes, const T *formatString, KeyValues *localizationVariables)
 	{
 		ConstructStringKeyValuesInternal( unicodeOutput, unicodeBufferSizeInBytes, formatString, localizationVariables );
@@ -144,7 +151,9 @@ public:
 private:
 	// internal "interface"
 	static void ConstructStringVArgsInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) char *unicodeOutput, int unicodeBufferSizeInBytes, const char *formatString, int numFormatParameters, va_list argList);
+	static void ConstructStringArgsInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) char *unicodeOutput, int unicodeBufferSizeInBytes, const char *formatString, int numFormatParameters, const CLocalizedStringArg *argList);
 	static void ConstructStringVArgsInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) wchar_t *unicodeOutput, int unicodeBufferSizeInBytes, const wchar_t *formatString, int numFormatParameters, va_list argList);
+	static void ConstructStringArgsInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) wchar_t *unicodeOutput, int unicodeBufferSizeInBytes, const wchar_t *formatString, int numFormatParameters, const CLocalizedStringArg *argList);
 
 	static void ConstructStringKeyValuesInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) char *unicodeOutput, int unicodeBufferSizeInBytes, const char *formatString, KeyValues *localizationVariables);
 	static void ConstructStringKeyValuesInternal(OUT_Z_BYTECAP(unicodeBufferSizeInBytes) wchar_t *unicodeOutput, int unicodeBufferSizeInBytes, const wchar_t *formatString, KeyValues *localizationVariables);
@@ -226,99 +235,6 @@ public:
 //			handle weird combinations of const/volatile/whatever automatically.
 // --------------------------------------------------------------------------
 
-// The base implementation doesn't do anything except fail to compile if you
-// use it. Getting an "incomplete type" error here means that you tried to construct
-// a localized string with a type that doesn't have a specialization.
-template < typename T >
-class CLocalizedStringArg;
-
-// --------------------------------------------------------------------------
-
-template < typename T >
-class CLocalizedStringArgStringImpl
-{
-public:
-	enum { kIsValid = true };
-
-	CLocalizedStringArgStringImpl( const locchar_t *pStr ) : m_pStr( pStr ) { }
-
-	const locchar_t *GetLocArg() const { Assert( m_pStr ); return m_pStr; }
-
-private:
-	const locchar_t *m_pStr;
-};
-
-// --------------------------------------------------------------------------
-
-template < typename T >
-class CLocalizedStringArg<T *> : public CLocalizedStringArgStringImpl<T>
-{
-public:
-	CLocalizedStringArg( const locchar_t *pStr ) : CLocalizedStringArgStringImpl<T>( pStr ) { }
-};
-
-// --------------------------------------------------------------------------
-
-template < typename T >
-class CLocalizedStringArgPrintfImpl
-{
-public:
-	enum { kIsValid = true };
-
-	CLocalizedStringArgPrintfImpl( T value, const locchar_t *loc_Format ) { loc_snprintf( m_cBuffer, kBufferSize, loc_Format, value ); }
-
-	const locchar_t *GetLocArg() const { return m_cBuffer; }
-
-private:
-	enum { kBufferSize = 128, };
-	locchar_t m_cBuffer[ kBufferSize ];
-};
-
-// --------------------------------------------------------------------------
-
-template < >
-class CLocalizedStringArg<uint16> : public CLocalizedStringArgPrintfImpl<uint16>
-{
-public:
-	CLocalizedStringArg( uint16 unValue ) : CLocalizedStringArgPrintfImpl<uint16>( unValue, LOCCHAR("%u") ) { }
-};
-
-// --------------------------------------------------------------------------
-
-template < >
-class CLocalizedStringArg<uint32> : public CLocalizedStringArgPrintfImpl<uint32>
-{
-public:
-	CLocalizedStringArg( uint32 unValue ) : CLocalizedStringArgPrintfImpl<uint32>( unValue, LOCCHAR("%u") ) { }
-};
-
-// --------------------------------------------------------------------------
-
-template < >
-class CLocalizedStringArg<int> : public CLocalizedStringArgPrintfImpl<int>
-{
-public:
-    CLocalizedStringArg(int nValue) : CLocalizedStringArgPrintfImpl<int>(nValue, LOCCHAR("%d")) {}
-};
-
-// --------------------------------------------------------------------------
-
-template < >
-class CLocalizedStringArg<uint64> : public CLocalizedStringArgPrintfImpl<uint64>
-{
-public:
-	CLocalizedStringArg( uint64 unValue ) : CLocalizedStringArgPrintfImpl<uint64>( unValue, LOCCHAR("%llu") ) { }
-};
-
-// --------------------------------------------------------------------------
-
-template < >
-class CLocalizedStringArg<float> : public CLocalizedStringArgPrintfImpl<float>
-{
-public:
-    CLocalizedStringArg( float fValue ) : CLocalizedStringArgPrintfImpl<float>( fValue, LOCCHAR("%.2f") ) {}
-};
-
 // --------------------------------------------------------------------------
 
 #ifdef _WIN32
@@ -331,29 +247,37 @@ public:
 #warning "ILocalize needs some string macros defined!"
 #endif
 
-template < >
-class CLocalizedStringArg<locchar_t*> : public CLocalizedStringArgPrintfImpl<locchar_t*>
+class CLocalizedStringArg
 {
 public:
-	CLocalizedStringArg(locchar_t *pwszValue) : CLocalizedStringArgPrintfImpl<locchar_t*>(pwszValue, ___WIDECHAR_PRINT_FORMAT_WIDECHAR) {}
-};
+	template <typename U, std::enable_if_t<std::conjunction_v<std::is_integral<U>, std::is_unsigned<U>, std::bool_constant<sizeof(U) <= 4>>, int> = 0>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(value, LOCCHAR("%u")) {}
+	template <typename U, std::enable_if_t<std::conjunction_v<std::is_integral<U>, std::is_unsigned<U>, std::bool_constant<sizeof(U) == 8>>, int> = 1>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(value, LOCCHAR("%llu")) {}
+	template <typename U, std::enable_if_t<std::conjunction_v<std::is_integral<U>, std::is_signed<U>, std::bool_constant<sizeof(U) <= 4>>, int> = 2>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(value, LOCCHAR("%d")) {}
+	template <typename U, std::enable_if_t<std::conjunction_v<std::is_integral<U>, std::is_signed<U>, std::bool_constant<sizeof(U) == 8>>, int> = 3>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(value, LOCCHAR("%lld")) {}
 
-// --------------------------------------------------------------------------
+	template <typename U, std::enable_if_t<std::is_enum_v<U>, int> = 4>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(static_cast<std::underlying_type_t<U>>(value)) {}
 
-template < >
-class CLocalizedStringArg<char*> : public CLocalizedStringArgPrintfImpl<char*>
-{
+	template <typename U, std::enable_if_t<std::is_floating_point_v<U>, int> = 5>
+	CLocalizedStringArg(U value) : CLocalizedStringArg(value, LOCCHAR("%.2f")) {}
+
+	template <typename U, std::enable_if_t<std::disjunction_v<std::is_same<U, char*>, std::is_same<U, const char*>>, int> = 6>
+	CLocalizedStringArg(U pszValue) : CLocalizedStringArg(pszValue, ___WIDECHAR_PRINT_FORMAT_ANSICHAR) {}
+	template <typename U, std::enable_if_t<std::disjunction_v<std::is_same<U, wchar_t*>, std::is_same<U, const wchar_t*>>, int> = 7>
+	CLocalizedStringArg(U pszValue) : CLocalizedStringArg(pszValue, ___WIDECHAR_PRINT_FORMAT_WIDECHAR) {}
+
 public:
-	CLocalizedStringArg(char *pszValue) : CLocalizedStringArgPrintfImpl<char*>(pszValue, ___WIDECHAR_PRINT_FORMAT_ANSICHAR) {}
-};
+	const locchar_t *GetLocArg() const { return m_cBuffer; }
 
-// --------------------------------------------------------------------------
+private:
+	template <typename T> CLocalizedStringArg(T value, const locchar_t *loc_Format) { loc_snprintf(m_cBuffer, kBufferSize, loc_Format, value); }
 
-template < >
-class CLocalizedStringArg<const char*> : public CLocalizedStringArgPrintfImpl<const char*>
-{
-public:
-	CLocalizedStringArg(const char *pszValue) : CLocalizedStringArgPrintfImpl<const char*>(pszValue, ___WIDECHAR_PRINT_FORMAT_ANSICHAR) {}
+	static constexpr int kBufferSize = 128;
+	locchar_t m_cBuffer[kBufferSize];
 };
 
 // --------------------------------------------------------------------------
@@ -362,130 +286,15 @@ public:
 class CConstructLocalizedString
 {
 public:
-	template < typename T >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0 )
+	template < typename... T, typename = std::enable_if_t<sizeof...(T) != 0> >
+	CConstructLocalizedString( const locchar_t *loc_Format, T... args )
 	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-
 		m_loc_Buffer[0] = '\0';
 
 		if ( loc_Format )
 		{
-			::ILocalize::ConstructString( m_loc_Buffer, sizeof( m_loc_Buffer ), loc_Format, 1, CLocalizedStringArg<T>( arg0 ).GetLocArg() );
-		}
-	}
-
-	template < typename T, typename U >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0, U arg1 )
-	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<U>::kIsValid );
-
-		m_loc_Buffer[0] = '\0';
-
-		if ( loc_Format )
-		{
-			::ILocalize::ConstructString( m_loc_Buffer, sizeof( m_loc_Buffer ), loc_Format, 2, CLocalizedStringArg<T>( arg0 ).GetLocArg(), CLocalizedStringArg<U>( arg1 ).GetLocArg() );
-		}
-	}
-
-	template < typename T, typename U, typename V >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0, U arg1, V arg2 )
-	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<U>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<V>::kIsValid );
-
-		m_loc_Buffer[0] = '\0';
-
-		if ( loc_Format )
-		{
-			::ILocalize::ConstructString( m_loc_Buffer,
-										  sizeof( m_loc_Buffer ),
-										  loc_Format,
-										  3,
-										  CLocalizedStringArg<T>( arg0 ).GetLocArg(),
-										  CLocalizedStringArg<U>( arg1 ).GetLocArg(),
-										  CLocalizedStringArg<V>( arg2 ).GetLocArg() );
-		}
-	}
-
-	template < typename T, typename U, typename V, typename W >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0, U arg1, V arg2, W arg3 )
-	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<U>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<V>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<W>::kIsValid );
-
-		m_loc_Buffer[0] = '\0';
-
-		if ( loc_Format )
-		{
-			::ILocalize::ConstructString( m_loc_Buffer,
-										  sizeof( m_loc_Buffer ),
-										  loc_Format,
-										  4,
-										  CLocalizedStringArg<T>( arg0 ).GetLocArg(),
-										  CLocalizedStringArg<U>( arg1 ).GetLocArg(),
-										  CLocalizedStringArg<V>( arg2 ).GetLocArg(),
-										  CLocalizedStringArg<W>( arg3 ).GetLocArg() );
-		}
-	}
-
-	template < typename T, typename U, typename V, typename W, typename X, typename Y >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5 )
-	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<U>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<V>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<W>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<X>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<Y>::kIsValid );
-
-		m_loc_Buffer[0] = '\0';
-
-		if ( loc_Format )
-		{
-			::ILocalize::ConstructString( m_loc_Buffer,
-										  sizeof( m_loc_Buffer ),
-										  loc_Format,
-										  6,
-										  CLocalizedStringArg<T>( arg0 ).GetLocArg(),
-										  CLocalizedStringArg<U>( arg1 ).GetLocArg(),
-										  CLocalizedStringArg<V>( arg2 ).GetLocArg(),
-										  CLocalizedStringArg<W>( arg3 ).GetLocArg(),
-										  CLocalizedStringArg<X>( arg4 ).GetLocArg(),
-										  CLocalizedStringArg<Y>( arg5 ).GetLocArg() );
-		}
-	}
-
-	template < typename T, typename U, typename V, typename W, typename X, typename Y, typename Z >
-	CConstructLocalizedString( const locchar_t *loc_Format, T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6)
-	{
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<T>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<U>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<V>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<W>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<X>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<Y>::kIsValid );
-		COMPILE_TIME_ASSERT( CLocalizedStringArg<Z>::kIsValid );
-
-		m_loc_Buffer[0] = '\0';
-
-		if ( loc_Format )
-		{
-			::ILocalize::ConstructString( m_loc_Buffer,
-				sizeof( m_loc_Buffer ),
-				loc_Format,
-				7,
-				CLocalizedStringArg<T>( arg0 ).GetLocArg(),
-				CLocalizedStringArg<U>( arg1 ).GetLocArg(),
-				CLocalizedStringArg<V>( arg2 ).GetLocArg(),
-				CLocalizedStringArg<W>( arg3 ).GetLocArg(),
-				CLocalizedStringArg<X>( arg4 ).GetLocArg(),
-				CLocalizedStringArg<Y>( arg5 ).GetLocArg(), 
-				CLocalizedStringArg<Z>( arg6 ).GetLocArg() );
+			const CLocalizedStringArg locArgs[] = { args... };
+			::ILocalize::ConstructStringArgs( m_loc_Buffer, sizeof( m_loc_Buffer ), loc_Format, ARRAYSIZE( locArgs ), locArgs );
 		}
 	}
 


### PR DESCRIPTION
Simplified most of CLocalizedStringArg and CConstructLocalizedString operation, now uses variadic templates, and is future-proof for all standard types

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review