### PR TITLE
Use official distributed version of gcc-9 from steam runtime

### DIFF
--- a/mp/src/devtools/makefile_base_posix.mak
+++ b/mp/src/devtools/makefile_base_posix.mak
@@ -81,13 +81,13 @@ COPY_DLL_TO_SRV = 0
 LDFLAGS += -Wl,--build-id
 
 # Building the game on Linux requires a CHROOT environment, please read https://github.com/momentum-mod/game/wiki/Building-The-Game/#linux for more info!
-CHROOT_NAME=steamrt_scout_amd64
+CHROOT_NAME=steamrt_scout_i386
 
 #
 # If we should be running in a chroot, check to see if we are. If not, then prefix everything with the 
 # required chroot
 #
-export STEAM_RUNTIME_PATH := /opt/gcc-9.2
+export STEAM_RUNTIME_PATH := /usr
 ifeq ("$(wildcard /run/systemd/container)","")
     ifndef USING_DOCKER
         ifneq ("$(SCHROOT_CHROOT_NAME)", "$(CHROOT_NAME)")
@@ -96,7 +96,7 @@ ifeq ("$(wildcard /run/systemd/container)","")
         endif
     endif
 endif
-GCC_VER = -9.2
+GCC_VER = -9
 P4BIN = p4
 CRYPTOPPDIR=ubuntu12_32
 
@@ -126,7 +126,7 @@ endif
 CCACHE := $(SRCROOT)/devtools/bin/linux/ccache
 
 ifeq ($(origin AR), default)
-	AR = /usr/bin/ar crs
+	AR = $(STEAM_RUNTIME_PATH)/bin/ar crs
 endif
 ifeq ($(origin CC), default)
 	CC = $(CCACHE) $(STEAM_RUNTIME_PATH)/bin/gcc$(GCC_VER)	
@@ -155,7 +155,7 @@ endif
 
 ifeq ($(CLANG_BUILD),1)
 	# Clang specific flags
-else ifeq ($(GCC_VER),-9.2)
+else ifeq ($(GCC_VER),-9)
 	WARN_FLAGS += -Wno-unused-local-typedefs
 	WARN_FLAGS += -Wno-unused-result
 	WARN_FLAGS += -Wno-narrowing
@@ -180,8 +180,8 @@ else
 	# pentium4 = MMX, SSE, SSE2 - no SSE3 (added in prescott) # -msse3 -mfpmath=sse
 	ARCH_FLAGS += -m32 -fabi-compat-version=2 -march=$(MARCH_TARGET) -mtune=core2 $(SSE_GEN_FLAGS)
 	LD_SO = ld-linux.so.2
-	LIBSTDCXX := $(shell $(CXX) $(ARCH_FLAGS) -print-file-name=libstdc++.so)
-	LIBSTDCXXPIC := $(shell $(CXX) $(ARCH_FLAGS) -print-file-name=libstdc++.so)
+	LIBSTDCXX := $(shell $(CXX) $(ARCH_FLAGS) -print-file-name=libstdc++.a)
+	LIBSTDCXXPIC := $(shell $(CXX) $(ARCH_FLAGS) -print-file-name=libstdc++.a)
 	LDFLAGS += -m32
 endif
 

--- a/mp/src/nbproject_default/configurations.xml
+++ b/mp/src/nbproject_default/configurations.xml
@@ -17,8 +17,8 @@
       <makefileType>
         <makeTool>
           <buildCommandWorkingDir>.</buildCommandWorkingDir>
-          <buildCommand>schroot --chroot steamrt_scout_amd64 -- make -f games.mak</buildCommand>
-          <cleanCommand>schroot --chroot steamrt_scout_amd64 -- make clean -f games.mak</cleanCommand>
+          <buildCommand>schroot --chroot steamrt_scout_i386 -- make -f games.mak</buildCommand>
+          <cleanCommand>schroot --chroot steamrt_scout_i386 -- make clean -f games.mak</cleanCommand>
           <executablePath></executablePath>
           <ccTool>
             <incDir>
@@ -92,8 +92,8 @@
       <makefileType>
         <makeTool>
           <buildCommandWorkingDir>.</buildCommandWorkingDir>
-          <buildCommand>schroot --chroot steamrt_scout_amd64 -- make -f games.mak</buildCommand>
-          <cleanCommand>schroot --chroot steamrt_scout_amd64 -- make clean -f games.mak</cleanCommand>
+          <buildCommand>schroot --chroot steamrt_scout_i386 -- make -f games.mak</buildCommand>
+          <cleanCommand>schroot --chroot steamrt_scout_i386 -- make clean -f games.mak</cleanCommand>
           <executablePath></executablePath>
           <ccTool>
             <incDir>


### PR DESCRIPTION
When I first built the GCC-9 steam runtime environment (mid June), I wasn't able to get it to build game with GCC distributed in runtime (gcc-9-monolithic). Now that I managed to build and run game with that version, I'm switching to it. Current runtime also has this newer GCC version, so CI should pass for now. I'll update the docker after this gets merged.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review