### PR TITLE
Allow teleport destinations as restart points for start zones

### DIFF
--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -141,6 +141,8 @@
     look_angles(angle) : "Look angles" : "0 0 0" : "Where player will look when teleported to start."
     start_on_jump(integer) : "Start timer on jump" : 1 : "Start the timer when the player jump in the start zone/trigger zone."
     speed_limit_type(integer) : "Limit speed type" : 0 : "0) Limit the speed of the player no matter what. 1) Limit the speed only in air. 2) Limit the speed only on ground. 3) Limit the speed only on landing."
+    teleport_destination(target_destination) : "Remote Destination" : : "The entity specifying the point to which the player should be teleported when restarting a run."
+
     spawnflags(flags) =
     [
         8192: "Limit leave speed" : 1

--- a/mp/game/momentum/momentum.fgd
+++ b/mp/game/momentum/momentum.fgd
@@ -159,7 +159,10 @@
     ]
 ]
 
-@SolidClass base(ZoneTrigger) = trigger_momentum_timer_stage : "Starting trigger for each stage of a map. trigger_momentum_timer_start is automatically stage 1!" []
+@SolidClass base(ZoneTrigger) = trigger_momentum_timer_stage : "Starting trigger for each stage of a map. trigger_momentum_timer_start is automatically stage 1!" 
+[
+    teleport_destination(target_destination) : "Remote Destination" : : "The entity specifying the point to which the player should be teleported when restarting a stage."
+]
 
 @SolidClass base(ZoneTrigger) = trigger_momentum_timer_checkpoint : "Trigger used to denote progress in a linear map. trigger_momentum_timer_start is automatically checkpoint (zone number) 1!" []
 

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1879,9 +1879,12 @@ void CMomentumPlayer::TimerCommand_Restart(int track)
     {
         if (!g_pSavelocSystem->TeleportToStartMark(START_MARK, track))
         {
-            // Don't set angles if still in start zone.
-            QAngle ang = pStart->GetLookAngles();
-            ManualTeleport(&pStart->GetRestartPosition(), (pStart->HasLookAngles() ? &ang : nullptr), &vec3_origin);
+            const auto pZoneTeleDest = pStart->GetTeleDest();
+
+            const Vector *pTargetDest = pZoneTeleDest ? &pZoneTeleDest->GetAbsOrigin() : &pStart->GetRestartPosition();
+            const QAngle *pTargetAng = pZoneTeleDest ? &pZoneTeleDest->GetAbsAngles() : pStart->HasLookAngles() ? &pStart->GetLookAngles() : nullptr;
+
+            ManualTeleport(pTargetDest, pTargetAng, &vec3_origin);
         }
 
         m_Data.m_iCurrentTrack = track;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -1927,8 +1927,12 @@ void CMomentumPlayer::TimerCommand_RestartStage(int stage, int track)
             if (m_Data.m_bIsInZone)
                 return;
 
-            DestroyExplosives();
-            Teleport(&pCurrentZone->GetRestartPosition(), nullptr, &vec3_origin);
+            const auto pZoneTeleDest = pCurrentZone->GetTeleDest();
+
+            const Vector *pTargetDest = pZoneTeleDest ? &pZoneTeleDest->GetAbsOrigin() : &pCurrentZone->GetRestartPosition();
+            const QAngle *pTargetAng = pZoneTeleDest ? &pZoneTeleDest->GetAbsAngles() : nullptr;
+
+            ManualTeleport(pTargetDest, pTargetAng, &vec3_origin, false);
         }
         return;
     }

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -381,7 +381,7 @@ bool CBaseMomZoneTrigger::FindStandableGroundBelow(const Vector& traceStartPos, 
 
 const Vector& CBaseMomZoneTrigger::GetRestartPosition()
 {
-    if(m_vecRestartPos == vec3_invalid)
+    if (m_vecRestartPos == vec3_invalid)
     {
         Vector zoneMaxsRel = CollisionProp()->OBBMaxs();
         Vector zoneMaxs;
@@ -516,6 +516,7 @@ CTriggerTimerStart::CTriggerTimerStart()
 {
     m_iZoneNumber = 1;
 }
+
 bool CTriggerTimerStart::ToKeyValues(KeyValues *pKvInto)
 {
     // Structured like this because properties are another DB table for the site
@@ -536,40 +537,38 @@ bool CTriggerTimerStart::ToKeyValues(KeyValues *pKvInto)
     pKvInto->AddSubKey(pZoneProps);
 
     return BaseClass::ToKeyValues(pKvInto);
-};
+}
 
 bool CTriggerTimerStart::LoadFromKeyValues(KeyValues *zoneKV)
 {
-    if (BaseClass::LoadFromKeyValues(zoneKV))
+    if (!BaseClass::LoadFromKeyValues(zoneKV))
+        return false;
+
+    const auto pZoneProps = zoneKV->FindKey("zoneProps");
+    if (!pZoneProps)
+        return false;
+
+    const auto pActualProps = pZoneProps->FindKey("properties");
+    if (!pActualProps)
+        return false;
+
+    SetSpeedLimit(pActualProps->GetFloat("speed_limit", 350.0f));
+    SetIsLimitingSpeed(pActualProps->GetBool("limiting_speed", true));
+    SetStartOnJump(pActualProps->GetBool("start_on_jump", true));
+    SetLimitSpeedType(pActualProps->GetInt("speed_limit_type", SPEED_NORMAL_LIMIT));
+
+    const float nolook = -190.0f;
+    float yaw = pActualProps->GetFloat("yaw", nolook);
+    if (!CloseEnough(yaw, nolook))
     {
-        const auto pZoneProps = zoneKV->FindKey("zoneProps");
-        if (!pZoneProps)
-            return false;
-
-        const auto pActualProps = pZoneProps->FindKey("properties");
-        if (!pActualProps)
-            return false;
-
-        SetSpeedLimit(pActualProps->GetFloat("speed_limit", 350.0f));
-        SetIsLimitingSpeed(pActualProps->GetBool("limiting_speed", true));
-        SetStartOnJump(pActualProps->GetBool("start_on_jump", true));
-        SetLimitSpeedType(pActualProps->GetInt("speed_limit_type", SPEED_NORMAL_LIMIT));
-
-        const float nolook = -190.0f;
-        float yaw = pActualProps->GetFloat("yaw", nolook);
-        if (!CloseEnough(yaw, nolook))
-        {
-            SetHasLookAngles(true);
-            SetLookAngles(QAngle(0.0f, yaw, 0.0f));
-        }
-        else
-        {
-            SetHasLookAngles(false);
-        }
-        return true;
+        SetHasLookAngles(true);
+        SetLookAngles(QAngle(0.0f, yaw, 0.0f));
     }
-
-    return false;
+    else
+    {
+        SetHasLookAngles(false);
+    }
+    return true;
 }
 
 int CTriggerTimerStart::GetZoneType()
@@ -587,8 +586,7 @@ void CTriggerTimerStart::Spawn()
 
     g_pMomentumTimer->SetStartTrigger(m_iTrackNumber, this);
 }
-void CTriggerTimerStart::SetSpeedLimit(const float fSpeed) { m_fSpeedLimit = fSpeed; }
-void CTriggerTimerStart::SetLookAngles(const QAngle &newang) { m_angLook = newang; }
+
 void CTriggerTimerStart::SetIsLimitingSpeed(const bool bIsLimitSpeed)
 {
     if (bIsLimitSpeed)
@@ -606,6 +604,7 @@ void CTriggerTimerStart::SetIsLimitingSpeed(const bool bIsLimitSpeed)
         }
     }
 }
+
 void CTriggerTimerStart::SetHasLookAngles(const bool bHasLook)
 {
     if (bHasLook)
@@ -623,6 +622,7 @@ void CTriggerTimerStart::SetHasLookAngles(const bool bHasLook)
         }
     }
 }
+
 //----------------------------------------------------------------------------------------------
 
 //----------- CTriggerTimerStop ----------------------------------------------------------------

--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -509,6 +509,10 @@ int CTriggerCheckpoint::GetZoneType() const
 //---------- CTriggerStage -----------------------------------------------------------------
 LINK_ENTITY_TO_CLASS(trigger_momentum_timer_stage, CTriggerStage);
 
+BEGIN_DATADESC(CTriggerStage)
+    DEFINE_KEYFIELD(m_strTeleDestName, FIELD_STRING, "teleport_destination")
+END_DATADESC()
+
 IMPLEMENT_SERVERCLASS_ST(CTriggerStage, DT_TriggerStage)
 END_SEND_TABLE()
 

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -200,7 +200,6 @@ public:
     // Point-based zone editing
     CUtlVector<Vector> m_vecZonePoints;
 
-
 private:
     friend class CMomPointZoneBuilder;
 
@@ -222,7 +221,7 @@ public:
     CTriggerZone();
 
     void SetZoneNumber(int newZone) { m_iZoneNumber = newZone; }
-    int GetZoneNumber() const { return m_iZoneNumber; };
+    int GetZoneNumber() const { return m_iZoneNumber; }
 
     virtual void OnStartTouch(CBaseEntity* pOther) override;
     virtual void OnEndTouch(CBaseEntity* pOther) override;
@@ -293,8 +292,8 @@ class CTriggerTimerStart : public CTriggerZone
     void Spawn() override;
 
     float GetSpeedLimit() const { return m_fSpeedLimit; }
-    void SetSpeedLimit(const float maxLeaveSpeed);
-    void SetLookAngles(const QAngle &newang);
+    void SetSpeedLimit(const float fMaxLeaveSpeed) { m_fSpeedLimit = fMaxLeaveSpeed; }
+    void SetLookAngles(const QAngle &newang) { m_angLook = newang; }
     const QAngle &GetLookAngles() const { return m_angLook; }
 
     // spawnflags

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -188,7 +188,7 @@ public:
     // Return true to signify success
     virtual bool LoadFromKeyValues(KeyValues *pKvFrom);
 
-    virtual int GetZoneType();
+    virtual int GetZoneType() const;
 
     const Vector& GetRestartPosition();
 
@@ -214,7 +214,7 @@ private:
 // to have different zone triggers with either similar or different zone numbers.
 class CTriggerZone : public CBaseMomZoneTrigger
 {
-public:
+  public:
     DECLARE_CLASS(CTriggerZone, CBaseMomZoneTrigger);
     DECLARE_DATADESC();
 
@@ -222,6 +222,11 @@ public:
 
     void SetZoneNumber(int newZone) { m_iZoneNumber = newZone; }
     int GetZoneNumber() const { return m_iZoneNumber; }
+
+    bool IsTeleportableTo() const;
+    const CBaseEntity *GetTeleDest() const { return m_hTeleDest.Get(); }
+
+    void Spawn() override;
 
     virtual void OnStartTouch(CBaseEntity* pOther) override;
     virtual void OnEndTouch(CBaseEntity* pOther) override;
@@ -231,11 +236,15 @@ public:
 
     int DrawDebugTextOverlays() override;
 
-protected:
+  protected:
     // The zone number of this zone. Keep in mind start timer triggers are always zone number 1,
     // while end triggers are typically zone 0. Everything else is meant to be a checkpoint/stage number.
     // See the start trigger for more info. Zone numbers are otherwise 0 by default.
     int m_iZoneNumber;
+    string_t m_strTeleDestName;
+
+  private:
+    EHANDLE m_hTeleDest;
 };
 
 // Checkpoint triggers are the triggers to use for linear maps -- ones that can denote progress on a linear map,
@@ -251,7 +260,7 @@ public:
     // always send to all clients
     int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 
-    virtual int GetZoneType() override;
+    virtual int GetZoneType() const override;
 };
 
 // Stage triggers are used to denote large, strung-together "chunks" of the map, usually 
@@ -270,7 +279,7 @@ public:
     // always send to all clients
     int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 
-    virtual int GetZoneType() override;
+    virtual int GetZoneType() const override;
 };
 
 // The start trigger is the first zone trigger for a track.
@@ -309,7 +318,7 @@ class CTriggerTimerStart : public CTriggerZone
     virtual bool ToKeyValues(KeyValues *pKvInto) override;
     virtual bool LoadFromKeyValues(KeyValues *zoneKV) override;
 
-    int GetZoneType() override;
+    int GetZoneType() const override;
   private:
     QAngle m_angLook;
 
@@ -338,7 +347,7 @@ public:
     // always send to all clients
     virtual int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 
-    int GetZoneType() override;
+    int GetZoneType() const override;
 
     bool GetCancelBool() const { return m_bCancel; }
 
@@ -358,7 +367,7 @@ public:
 
     int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }
 
-    int GetZoneType() override;
+    int GetZoneType() const override;
 
     bool LoadFromKeyValues(KeyValues* pKvFrom) override;
     bool ToKeyValues(KeyValues* pKvInto) override;

--- a/mp/src/game/server/momentum/mom_triggers.h
+++ b/mp/src/game/server/momentum/mom_triggers.h
@@ -272,9 +272,10 @@ public:
 // Another important NOTE: do not mix Checkpoint and Stage triggers for the same Track!
 class CTriggerStage : public CTriggerZone
 {
-public:
+  public:
     DECLARE_CLASS(CTriggerStage, CTriggerZone);
     DECLARE_NETWORKCLASS();
+    DECLARE_DATADESC();
 
     // always send to all clients
     int UpdateTransmitState() override { return SetTransmitState(FL_EDICT_ALWAYS); }

--- a/mp/src/utils/zonmaker/zonmaker.cpp
+++ b/mp/src/utils/zonmaker/zonmaker.cpp
@@ -242,6 +242,15 @@ static KeyValues *ParseZones(CChunk *pRootChunk)
 
         triggerKV->SetInt("type", type);
         triggerKV->SetString("zoneNum", zoneN);
+
+        if (type == ZONE_TYPE_START || type == ZONE_TYPE_STAGE)
+        {
+            if (const auto &key = pChunk->FindKey("teleport_destination"))
+                triggerKV->SetString("teleport_destination", key);
+            else
+                triggerKV->SetString("teleport_destination", "");
+        }
+
         if (type == ZONE_TYPE_START)
         {
             auto propsKV = triggerKV->FindKey("zoneProps", true)->FindKey("properties", true);
@@ -258,7 +267,7 @@ static KeyValues *ParseZones(CChunk *pRootChunk)
             else
                 propsKV->SetBool("start_on_jump", true);
 
-            if ( const auto &key = pChunk->FindKey("speed_limit_type"))
+            if (const auto &key = pChunk->FindKey("speed_limit_type"))
                 propsKV->SetString("speed_limit_type", key);
             else
                 propsKV->SetInt("speed_limit_type", 0);


### PR DESCRIPTION
Closes #313 

- Does a slight refactoring of the start zone trigger code
- Adds a remote destination to the start zone trigger, much like teleport triggers.
  - destination is teleported to if there is no start mark. (start mark > tele dest > middle of zone teleport)
- Updates zonmaker with the change

Opted not to add the base zone trigger as it would show up for end & checkpoint zones.
Would it be a good idea to add this to stage zones as well?

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
