### PR TITLE
Allow dynamic updating of teleport destinations

### DIFF
--- a/mp/src/game/server/momentum/mom_triggers.cpp
+++ b/mp/src/game/server/momentum/mom_triggers.cpp
@@ -873,17 +873,15 @@ void CTriggerMomentumTeleport::HandleTeleport(CBaseEntity *pOther)
     if (!pOther)
         return;
 
+    if (m_target != NULL_STRING)
+    {
+        m_hDestinationEnt = gEntList.FindEntityByName(nullptr, m_target, nullptr, pOther, pOther);
+    }
+
     if (!m_hDestinationEnt.Get())
     {
-        if (m_target != NULL_STRING)
-        {
-            m_hDestinationEnt = gEntList.FindEntityByName(nullptr, m_target, nullptr, pOther, pOther);
-        }
-        else
-        {
-            DevWarning("trigger_teleport: invalid destination entity!\n");
-            return;
-        }
+        DevWarning("trigger_teleport: invalid destination entity!\n");
+        return;
     }
 
     CBaseEntity *pLandmark = nullptr;


### PR DESCRIPTION
A minor oversight in the trigger_teleport code meant that the destination no longer updates when it's changed with `AddOutput` or `ChangeVariable`, this PR fixes it.

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
