### PR TITLE
Move RNGFix code under a convar

### DIFF
--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -51,6 +51,8 @@ ConVar sv_ladder_angle("sv_ladder_angle", "-0.707", FCVAR_REPLICATED,
                        "Cos of angle of incidence to ladder perpendicular for applying ladder_dampen", true, -1.0f,
                        true, 1.0f);
 
+ConVar sv_rngfix_enable("sv_rngfix_enable", "0", FCVAR_MAPPING);
+
 #ifndef CLIENT_DLL
 #include "env_player_surface_trigger.h"
 static ConVar dispcoll_drawplane("dispcoll_drawplane", "0");
@@ -381,9 +383,7 @@ void CMomentumGameMovement::WalkMove()
 
 void CMomentumGameMovement::StepMove(Vector &vecDestination, trace_t &trace)
 {
-#ifdef USE_NEW_RNGFIX
-    if (g_pGameModeSystem->GameModeIs(GAMEMODE_AHOP))
-#endif
+    if (!sv_rngfix_enable.GetBool() || g_pGameModeSystem->GameModeIs(GAMEMODE_AHOP))
     {
         BaseClass::StepMove(vecDestination, trace);
         return;
@@ -1809,56 +1809,59 @@ void CMomentumGameMovement::CategorizePosition()
                     }
                 }
 
-#ifdef USE_NEW_RNGFIX
-                if (bGrounded)
+                if (sv_rngfix_enable.GetBool())
                 {
-                    if (sv_slope_fix.GetBool())
+                    if (bGrounded)
                     {
-                        ClipVelocity(vecNextVelocity, pm.plane.normal, vecNextVelocity, 1.0f);
-
-                        // What constitutes a favorable landing depends on if the player is allowed to bhop.
-
-                        // It also depends on if ground speed is capped *and* if the player actually bhops
-                        // on the next tick, but if we assume ground speed is capped only when bhopping isn't
-                        // allowed, all that matters is if bhopping is allowed.
-
-                        // On modes that can't bhop, colliding before landing is better if it means they start sliding.
-                        // If this check fails, we want to pretend they collided first and couldn't land,
-                        // so we don't set the ground entity.
-                        if (g_pGameModeSystem->GetGameMode()->CanBhop() || vecNextVelocity.z <= NON_JUMP_VELOCITY)
+                        if (sv_slope_fix.GetBool())
                         {
-                            // Only update velocity as if we collided if it results in horizontal speed gain.
-                            // Otherwise, we are probably going uphill and are actually trying to avoid this collision.
-                            if (vecNextVelocity.Length2DSqr() > mv->m_vecVelocity.Length2DSqr())
-                            {
-                                VectorCopy(vecNextVelocity, mv->m_vecVelocity);
-                            }
+                            ClipVelocity(vecNextVelocity, pm.plane.normal, vecNextVelocity, 1.0f);
 
+                            // What constitutes a favorable landing depends on if the player is allowed to bhop.
+
+                            // It also depends on if ground speed is capped *and* if the player actually bhops
+                            // on the next tick, but if we assume ground speed is capped only when bhopping isn't
+                            // allowed, all that matters is if bhopping is allowed.
+
+                            // On modes that can't bhop, colliding before landing is better if it means they start sliding.
+                            // If this check fails, we want to pretend they collided first and couldn't land,
+                            // so we don't set the ground entity.
+                            if (g_pGameModeSystem->GetGameMode()->CanBhop() || vecNextVelocity.z <= NON_JUMP_VELOCITY)
+                            {
+                                // Only update velocity as if we collided if it results in horizontal speed gain.
+                                // Otherwise, we are probably going uphill and are actually trying to avoid this collision.
+                                if (vecNextVelocity.Length2DSqr() > mv->m_vecVelocity.Length2DSqr())
+                                {
+                                    VectorCopy(vecNextVelocity, mv->m_vecVelocity);
+                                }
+
+                                SetGroundEntity(&pm);
+                            }
+                        }
+                        else
+                        {
                             SetGroundEntity(&pm);
                         }
                     }
-                    else
+                }
+                else
+                {
+                    ClipVelocity(vecNextVelocity, pm.plane.normal, vecNextVelocity, 1.0f);
+
+                    // Set ground entity if the player is not going to slide on a ramp next tick and if they will be
+                    // grounded (exception if the player wants to bhop)
+                    if (vecNextVelocity.z <= NON_JUMP_VELOCITY && bGrounded)
                     {
+                        // Make sure we check clip velocity on slopes/surfs before setting the ground entity and nulling out
+                        // velocity.z
+                        if (sv_slope_fix.GetBool() && vecNextVelocity.Length2DSqr() > mv->m_vecVelocity.Length2DSqr())
+                        {
+                            VectorCopy(vecNextVelocity, mv->m_vecVelocity);
+                        }
+
                         SetGroundEntity(&pm);
                     }
                 }
-#else
-                ClipVelocity(vecNextVelocity, pm.plane.normal, vecNextVelocity, 1.0f);
-
-                // Set ground entity if the player is not going to slide on a ramp next tick and if they will be
-                // grounded (exception if the player wants to bhop)
-                if (vecNextVelocity.z <= NON_JUMP_VELOCITY && bGrounded)
-                {
-                    // Make sure we check clip velocity on slopes/surfs before setting the ground entity and nulling out
-                    // velocity.z
-                    if (sv_slope_fix.GetBool() && vecNextVelocity.Length2DSqr() > mv->m_vecVelocity.Length2DSqr())
-                    {
-                        VectorCopy(vecNextVelocity, mv->m_vecVelocity);
-                    }
-
-                    SetGroundEntity(&pm);
-                }
-#endif
             }
             else
             {
@@ -2572,8 +2575,7 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
             {
                 TracePlayerBBox(mv->GetAbsOrigin(), end, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, pm);
 
-#ifdef USE_NEW_RNGFIX
-                if (sv_slope_fix.GetBool() && player->GetMoveType() == MOVETYPE_WALK &&
+                if (sv_rngfix_enable.GetBool() && sv_slope_fix.GetBool() && player->GetMoveType() == MOVETYPE_WALK &&
                     player->GetGroundEntity() == nullptr && player->GetWaterLevel() < WL_Waist &&
                     g_pGameModeSystem->GetGameMode()->CanBhop() && !g_pGameModeSystem->GameModeIs(GAMEMODE_AHOP))
                 {
@@ -2606,7 +2608,6 @@ int CMomentumGameMovement::TryPlayerMove(Vector *pFirstDest, trace_t *pFirstTrac
                         }
                     }
                 }
-#endif
             }
         }
 
@@ -3133,10 +3134,12 @@ void CMomentumGameMovement::ReduceTimers()
     BaseClass::ReduceTimers();
 }
 
-#ifndef USE_NEW_RNGFIX
 int CMomentumGameMovement::ClipVelocity(Vector in, Vector &normal, Vector &out, float overbounce)
 {
     const int blocked = BaseClass::ClipVelocity(in, normal, out, overbounce);
+
+    if (sv_rngfix_enable.GetBool())
+        return blocked;
 
     // Check if the jump button is held to predict if the player wants to jump up an incline. Not checking for jumping
     // could allow players that hit the slope almost perpendicularly and still surf up the slope because they would
@@ -3160,7 +3163,6 @@ int CMomentumGameMovement::ClipVelocity(Vector in, Vector &normal, Vector &out, 
     // Return blocking flags.
     return blocked;
 }
-#endif
 
 inline float VectorYaw(const Vector &v)
 {

--- a/mp/src/game/shared/momentum/mom_gamemovement.h
+++ b/mp/src/game/shared/momentum/mom_gamemovement.h
@@ -8,8 +8,6 @@
 
 class CMomentumPlayer;
 
-// #define USE_NEW_RNGFIX
-
 class CMomentumGameMovement : public CGameMovement
 {
     typedef CGameMovement BaseClass;
@@ -25,9 +23,7 @@ public:
     void AirMove() override;
     void WalkMove() override;
 
-#ifndef USE_NEW_RNGFIX
     int ClipVelocity(Vector in, Vector &normal, Vector &out, float overbounce) override;
-#endif
 
     // Ladder
     float LadderDistance() const override;


### PR DESCRIPTION
Previously the RNGFix code was ifdef'd out because it caused issues. This PR moves the code under `sv_rngfix_enable`.

Closes one of the cards for 0.8.7

### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
