### PR TITLE
Replace current KZ mode with SimpleKZ

### DIFF
--- a/mp/src/game/client/momentum/c_mom_player.cpp
+++ b/mp/src/game/client/momentum/c_mom_player.cpp
@@ -54,7 +54,7 @@ C_MomentumPlayer::C_MomentumPlayer(): m_pSpecTarget(nullptr)
     m_afButtonDisabled = 0;
     m_flStartSpeed = 0.0f;
     m_flEndSpeed = 0.0f;
-    m_flStamina = 0.0f;
+    // m_flStamina = 0.0f;
     m_flGrabbableLadderTime = 0.0f;
 
     m_iLandTick = 0;
@@ -69,6 +69,16 @@ C_MomentumPlayer::C_MomentumPlayer(): m_pSpecTarget(nullptr)
     m_bIsPowerSliding = false;
     m_nWallRunState = WALLRUN_NOT;
     m_bWasSprinting = false;
+
+
+    m_bPSTurningLeft = false;
+    m_flPSBonusSpeed = 0.0f;
+    m_flPSTurnRate = 0.0f;
+    m_flPSVelMod = 1.0f;
+    m_flPSVelModLanding = 1.0f;
+    m_vecOldVelocity.Init();
+    m_iTicksSinceIncrement = 0;
+    m_vecLandingVelocity.Init();
 
     m_nButtonsToggled = 0;
 }

--- a/mp/src/game/client/momentum/c_mom_player.cpp
+++ b/mp/src/game/client/momentum/c_mom_player.cpp
@@ -79,6 +79,7 @@ C_MomentumPlayer::C_MomentumPlayer(): m_pSpecTarget(nullptr)
     m_vecOldVelocity.Init();
     m_iTicksSinceIncrement = 0;
     m_vecLandingVelocity.Init();
+    m_iLastJumpButtonTick = 0;
 
     m_nButtonsToggled = 0;
 }

--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -107,7 +107,22 @@ public:
     Vector GetEscapeVel() const { return m_vecCornerEscapeVel; }
     void SetEscapeVel(const Vector &vecNewYaw) { m_vecCornerEscapeVel = vecNewYaw; }
 
+    void SetOldEyeAngles(const QAngle &ang) { m_qangOldEyeAngles = ang; }
+    const QAngle &OldEyeAngles() const { return m_qangOldEyeAngles; }
+
 private:
+
+    // KZ stuff (SKZ)
+    bool m_bPSTurningLeft;
+    float m_flPSBonusSpeed;
+    float m_flPSTurnRate;
+    float m_flPSVelMod;
+    float m_flPSVelModLanding;
+    Vector m_vecOldVelocity;
+    int m_iTicksSinceIncrement;
+    QAngle m_qangOldEyeAngles;    
+    Vector m_vecLandingVelocity;
+        
     // Mobility mod (parkour)
     bool m_bWasSprinting;
     bool m_bIsPowerSliding;
@@ -144,7 +159,7 @@ private:
     SurfInt m_surfIntList[SurfInt::TYPE_COUNT]; // Stores interactions by type
     SurfInt::Type m_surfIntHistory[SurfInt::TYPE_COUNT]; // Keeps track of the history of interactions
 
-    float m_flStamina;
+    // float m_flStamina;
 
     CMomRunEntity *m_pSpecTarget;
 

--- a/mp/src/game/client/momentum/c_mom_player.h
+++ b/mp/src/game/client/momentum/c_mom_player.h
@@ -122,7 +122,8 @@ private:
     int m_iTicksSinceIncrement;
     QAngle m_qangOldEyeAngles;    
     Vector m_vecLandingVelocity;
-        
+    int m_iLastJumpButtonTick;
+    
     // Mobility mod (parkour)
     bool m_bWasSprinting;
     bool m_bIsPowerSliding;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -213,8 +213,7 @@ static MAKE_TOGGLE_CONVAR_C(mom_trail_enable, "0", FCVAR_CLIENTCMD_CAN_EXECUTE |
 static CMomentumPlayer *s_pPlayer = nullptr;
 
 CMomentumPlayer::CMomentumPlayer()
-    : m_flStamina(0.0f),
-      m_flLastVelocity(0.0f), m_nPerfectSyncTicks(0), m_nStrafeTicks(0), m_nAccelTicks(0),
+    : m_flLastVelocity(0.0f), m_nPerfectSyncTicks(0), m_nStrafeTicks(0), m_nAccelTicks(0),
       m_nPrevButtons(0), m_flTweenVelValue(1.0f), m_bInAirDueToJump(false), m_iProgressNumber(-1), 
       m_cvarMapFinMoveEnable("mom_mapfinished_movement_enable")
 {
@@ -254,6 +253,15 @@ CMomentumPlayer::CMomentumPlayer()
 
     m_bIsWalking = false;
     m_bIsSprinting = false;
+
+    m_bPSTurningLeft = false;
+    m_flPSBonusSpeed = 0.0f;
+    m_flPSTurnRate = 0.0f;
+    m_flPSVelMod = 1.0f;
+    m_flPSVelModLanding = 1.0f;
+    m_vecOldVelocity.Init();
+    m_iTicksSinceIncrement = 0;
+    m_vecLandingVelocity.Init();
 
     m_bIsPowerSliding = false;
     m_nWallRunState = WALLRUN_NOT;

--- a/mp/src/game/server/momentum/mom_player.cpp
+++ b/mp/src/game/server/momentum/mom_player.cpp
@@ -262,7 +262,8 @@ CMomentumPlayer::CMomentumPlayer()
     m_vecOldVelocity.Init();
     m_iTicksSinceIncrement = 0;
     m_vecLandingVelocity.Init();
-
+    m_iLastJumpButtonTick = 0;
+    
     m_bIsPowerSliding = false;
     m_nWallRunState = WALLRUN_NOT;
 

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -275,6 +275,21 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
 
     SavedState_t *GetSavedRunState() { return &m_SavedRunState; }
 
+    // KZ stuff
+
+    QAngle m_qangOldEyeAngles;
+    bool m_bPSTurningLeft;
+    float m_flPSBonusSpeed;
+    float m_flPSTurnRate;
+    float m_flPSVelMod;
+    float m_flPSVelModLanding;
+    Vector m_vecOldVelocity;
+    int m_iTicksSinceIncrement;
+    Vector m_vecLandingVelocity;
+
+    void SetOldEyeAngles(const QAngle &ang) { m_qangOldEyeAngles = ang; }
+    const QAngle &OldEyeAngles() const { return m_qangOldEyeAngles; }
+
     // Ahop stuff
     CNetworkVar(bool, m_bIsSprinting);
     CNetworkVar(bool, m_bIsWalking);
@@ -384,7 +399,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     QAngle m_qangLastAngle;
 
     // used by CMomentumGameMovement
-    float m_flStamina;
+    // float m_flStamina;
 
     bool m_bAllowUserTeleports;
 

--- a/mp/src/game/server/momentum/mom_player.h
+++ b/mp/src/game/server/momentum/mom_player.h
@@ -286,6 +286,7 @@ class CMomentumPlayer : public CBasePlayer, public CGameEventListener, public CM
     Vector m_vecOldVelocity;
     int m_iTicksSinceIncrement;
     Vector m_vecLandingVelocity;
+    int m_iLastJumpButtonTick;
 
     void SetOldEyeAngles(const QAngle &ang) { m_qangOldEyeAngles = ang; }
     const QAngle &OldEyeAngles() const { return m_qangOldEyeAngles; }

--- a/mp/src/game/shared/gamemovement.cpp
+++ b/mp/src/game/shared/gamemovement.cpp
@@ -1133,14 +1133,19 @@ void CGameMovement::ProcessMovement( CBasePlayer *pPlayer, CMoveData *pMove )
 
 	mv = pMove;
 	mv->m_flMaxSpeed = pPlayer->GetPlayerMaxSpeed();
+	// CSGO (and therefore SKZ) caps ground speed at CS_PLAYER_SPEED_RUN (250.0f) as well
+	if (g_pGameModeSystem->GameModeIs(GAMEMODE_KZ))
+	{
+		mv->m_flMaxSpeed = MIN(250.0f, mv->m_flMaxSpeed);
+	}
 
 	// CheckV( player->CurrentCommandNumber(), "StartPos", mv->GetAbsOrigin() );
 
 	DiffPrint( "start %f %f %f", mv->GetAbsOrigin().x, mv->GetAbsOrigin().y, mv->GetAbsOrigin().z );
-
-	// Run the command.
+	
+    // Run the command.
 	PlayerMove();
-
+	    
 	FinishMove();
 
 	DiffPrint( "end %f %f %f", mv->GetAbsOrigin().x, mv->GetAbsOrigin().y, mv->GetAbsOrigin().z );
@@ -1849,10 +1854,17 @@ void CGameMovement::Accelerate( Vector& wishdir, float wishspeed, float accel )
 	// If not going to add any speed, done.
 	if (addspeed <= 0)
 		return;
-
 	// Determine amount of acceleration.
-	accelspeed = accel * gpGlobals->frametime * wishspeed * player->m_surfaceFriction;
-
+	if (g_pGameModeSystem->GameModeIs(GAMEMODE_KZ))
+	{
+		// Change acceleration based on movement modifiers (KZ)
+		const float kAccelerationScale = MAX(250.0f, wishspeed);
+		accelspeed = accel * gpGlobals->frametime * kAccelerationScale * player->m_surfaceFriction;
+	}
+	else
+	{
+		accelspeed = accel * gpGlobals->frametime * wishspeed * player->m_surfaceFriction;
+	}
 	// Cap at addspeed
 	if (accelspeed > addspeed)
 		accelspeed = addspeed;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -279,12 +279,13 @@ void CMomentumGameMovement::WalkMove()
             else if (dtAngle < -180.f)
                 dtAngle += 360.f;
             // If player is turning at the required speed, and has the correct button inputs, reward it
-            bool bValidPrestrafeButtons = (mv->m_nButtons & (IN_FORWARD | IN_BACK) && !(mv->m_nButtons & IN_FORWARD && mv->m_nButtons & IN_BACK))
-                || mv->m_nButtons & (IN_MOVELEFT | IN_MOVERIGHT) && !(mv->m_nButtons & IN_MOVELEFT && mv->m_nButtons & IN_MOVERIGHT);
+            // Basically overlapping will result in false here
+            bool bValidPrestrafeButtons = (((mv->m_nButtons & (IN_FORWARD | IN_BACK)) && !(mv->m_nButtons & IN_FORWARD && mv->m_nButtons & IN_BACK))
+                || ((mv->m_nButtons & (IN_MOVELEFT | IN_MOVERIGHT)) && !(mv->m_nButtons & IN_MOVELEFT && mv->m_nButtons & IN_MOVERIGHT)));
             if (dtAngle != 0 && bValidPrestrafeButtons) // player turned left
             {
                 // If player changes their prestrafe direction, reset it
-                if (dtAngle > 0 && !m_pPlayer->m_bPSTurningLeft || dtAngle < 0 && m_pPlayer->m_bPSTurningLeft)
+                if ((dtAngle > 0 && !m_pPlayer->m_bPSTurningLeft) || (dtAngle < 0 && m_pPlayer->m_bPSTurningLeft))
                 {
                     m_pPlayer->m_flPSBonusSpeed = 0.0f;
                     m_pPlayer->m_flPSVelMod = 1.0f;

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -1337,14 +1337,15 @@ void CMomentumGameMovement::PlayerMove()
 void CMomentumGameMovement::PreventBunnyHopping()
 {
     float fraction = 1.0f;
-    float speed = mv->m_vecVelocity.Length();;
-
+    float speed = mv->m_vecVelocity.Length();
     if (g_pGameModeSystem->GameModeIs(GAMEMODE_KZ))
     {
         // SKZ formula
         float landingspeed = m_pPlayer->m_vecLandingVelocity.Length2D();
         int cmdsSinceLanding = (gpGlobals->tickcount - m_pPlayer->m_iLandTick);
-        if (cmdsSinceLanding <= PERF_TICKS)
+        // Original formula uses cmdnum instead of tickcount. They should both behave similarly to each other in Momentum.
+        bool hitTweakedPerf = ((cmdsSinceLanding == 1) || (cmdsSinceLanding <= 3 && gpGlobals->tickcount - m_pPlayer->m_iLastJumpButtonTick <= 3));
+        if (hitTweakedPerf)
         {
             if (cmdsSinceLanding > 1)
             {
@@ -1427,6 +1428,9 @@ bool CMomentumGameMovement::CheckJumpButton()
     // Avoid nullptr access, return false if somehow we don't have a player
     if (!player)
         return false;
+    
+    // SimpleKZ stuff. Track the last jump input from the player.
+    m_pPlayer->m_iLastJumpButtonTick = gpGlobals->tickcount;
 
     if (player->pl.deadflag)
     {

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -138,6 +138,7 @@ void CGameMode_KZ::SetGameModeVars()
     sv_friction.SetValue(5.2f);
     sv_maxspeed.SetValue(320);
     sv_maxvelocity.SetValue(3500);
+    sv_stopspeed.SetValue(80);
 }
 
 bool CGameMode_KZ::WeaponIsAllowed(WeaponID_t weapon)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -138,7 +138,9 @@ void CGameMode_KZ::SetGameModeVars()
     sv_friction.SetValue(5.2f);
     sv_maxspeed.SetValue(320);
     sv_maxvelocity.SetValue(3500);
-    sv_stopspeed.SetValue(80);
+    sv_stopspeed.SetValue(80);    
+    
+    sv_considered_on_ground.SetValue(2);
 }
 
 bool CGameMode_KZ::WeaponIsAllowed(WeaponID_t weapon)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.cpp
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.cpp
@@ -145,10 +145,19 @@ void CGameMode_KZ::SetGameModeVars()
 
 bool CGameMode_KZ::WeaponIsAllowed(WeaponID_t weapon)
 {
-    // KZ only blacklists weapons
     return weapon != WEAPON_ROCKETLAUNCHER &&
            weapon != WEAPON_STICKYLAUNCHER &&
            weapon != WEAPON_CONCGRENADE;
+}
+
+void CGameMode_KZ::OnPlayerSpawn(CMomentumPlayer *pPlayer)
+{
+    CGameModeBase::OnPlayerSpawn(pPlayer);
+
+#ifdef GAME_DLL
+    pPlayer->GiveWeapon(WEAPON_PISTOL);
+    pPlayer->GiveWeapon(WEAPON_KNIFE);
+#endif
 }
 
 bool CGameMode_KZ::HasCapability(GameModeHUDCapability_t capability)

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -100,7 +100,7 @@ public:
     const char* GetDiscordIcon() override { return "mom_icon_kz"; }
     const char* GetMapPrefix() override { return "kz_"; }
     const char* GetGameModeCfg() override { return "kz.cfg"; }
-    float GetIntervalPerTick() override { return 0.01f; }
+    float GetIntervalPerTick() override { return 0.0078125f; }
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
     bool WeaponIsAllowed(WeaponID_t weapon) override;

--- a/mp/src/game/shared/momentum/mom_system_gamemode.h
+++ b/mp/src/game/shared/momentum/mom_system_gamemode.h
@@ -103,6 +103,7 @@ public:
     float GetIntervalPerTick() override { return 0.0078125f; }
     void SetGameModeVars() override;
     bool PlayerHasAutoBhop() override { return false; }
+    void OnPlayerSpawn(CMomentumPlayer *pPlayer) override;
     bool WeaponIsAllowed(WeaponID_t weapon) override;
     bool HasCapability(GameModeHUDCapability_t capability) override;
 };

--- a/mp/src/tier1/convar.cpp
+++ b/mp/src/tier1/convar.cpp
@@ -954,7 +954,7 @@ void ConVar::SetValue( float value )
 		return;
 
 	char temp[32];
-	Q_snprintf(temp, sizeof(temp), "%f", value);
+	Q_snprintf(temp, sizeof(temp), "%.8f", value);
 	m_pParent->SetValue( temp );
 }
 


### PR DESCRIPTION
Changes:
- Remove stamina from current KZ gamemode.
- Add CSGO's SimpleKZ movement tweaks (prestrafe and bhop).
- Remove sliding at speed over 250 and move KZ tickrate to 128 in order for SKZ to be functional
- Re-add ledgegrabbing (sv_considered_on_ground 2.0)
- Modify "Last Jump Modifier" to SKZ takeoff velocity... this is a bit scuffed.
- Give knife and pistol to KZ players.

Difference:
- Player jump height is always 57.0 instead of 55.8 and only 57.0 when crouch jumped in CSGO.
- However, player crouch height boost is 8.5 instead of 9.0 in CSGO, making 66s impossible in this game.
- This ultimately adds one tick of air time compared to CSGO, increase your jump distance by 2.5 to 3 units.
- Landing while ducked does not immediately clamp player speed like CSGO.
- CSGO's bhop takeoff speed is delayed by one tick, this is not the case here.

Bugs:
- Saveloc doesn't save prestrafe variables.
- Tickrate can't be correctly set to 128, only possible through console. (fixed)

### Checklist
- [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [ ] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [ ] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [ ] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [ ] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [ ] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review


