### PR TITLE
Better trigger jump fix

### DIFF
--- a/mp/src/game/server/player_command.cpp
+++ b/mp/src/game/server/player_command.cpp
@@ -367,6 +367,13 @@ void CPlayerMove::PreventJumpBug(CBasePlayer *player, IMoveHelper *moveHelper)
                 
         // Restore normal bounds
         player->SetCollisionBounds(mins, maxs);
+
+        // ProcessImpacts causes trigger Touch() functions to fire no matter what.
+        // We still need to call ProcessImpacts() at the end of this tick, which means some Touch() functions may fire twice in one tick.
+        // The basevelocity system assumes sources of basevelocity -- like trigger_push Touch() functions -- are accumulated only once per tick.
+        // Removing this flag before we run ProcessImpacts() again will keep from double counting sources of basevelocity this tick.
+        // Without doing this, the player would usually just get a double boost for 1 tick, but if timed very precisely it can produce a permanent double boost.
+        player->RemoveFlag(FL_BASEVELOCITY);
     }
 }
 

--- a/mp/src/game/server/player_command.h
+++ b/mp/src/game/server/player_command.h
@@ -53,7 +53,7 @@ protected:
 	void			RunThink (CBasePlayer *ent, double frametime );
 	void			RunPostThink( CBasePlayer *player );
 
-	void			PreventBounce(CBasePlayer *player, IMoveHelper *moveHelper, bool jumpbug);
+	void			PreventJumpBug(CBasePlayer *player, IMoveHelper *moveHelper);
 };
 
 

--- a/mp/src/game/shared/igamemovement.h
+++ b/mp/src/game/shared/igamemovement.h
@@ -77,7 +77,8 @@ public:
 
     //no longer private so we can have late reflect :)
 	Vector			m_vecAbsOrigin;		// edict::origin 
-    
+
+	Vector			m_vecGroundPosition;
 };
 
 inline const Vector &CMoveData::GetAbsOrigin() const

--- a/mp/src/game/shared/momentum/mom_gamemovement.cpp
+++ b/mp/src/game/shared/momentum/mom_gamemovement.cpp
@@ -3059,6 +3059,11 @@ void CMomentumGameMovement::SetGroundEntity(const trace_t *pm)
 
     BaseClass::SetGroundEntity(pm);
 
+    if (pm && pm->m_pEnt)
+    {
+         VectorCopy(pm->endpos, mv->m_vecGroundPosition);
+    }
+
     // Doing this after the BaseClass call in case OnLand wants to use the new ground stuffs
     if (bLanded)
     {


### PR DESCRIPTION
I tested `sv_ground_trigger_fix` and noticed it wasn't catching all cases of the bug so I made some changes to make it more accurate.

The "jumpbug" fix wasn't always correctly determining if the player would unduck, and I figured out that splitting the trace it was doing into two (one for unducking, one for landing) fixed this, though I'm not entirely sure why (trace shenanigans?). It also uses the exact same logic as `CanUnduck()` now, which should make it even more accurate.

The other part of the fix is the trigger jumping bug where you can land at the end of one tick and jump the next without activating triggers due to `sv_considered_on_ground` keeping you above them. This fix needs to know where the ground actually is below you, which depends on the logic in `CategorizePosition()`, some of which was not already accounted for in Momentum's fix. Rather than re-implement more of that function, I just saved off the known ground position when `SetGroundEntity()` is called and used that value to do the fix, which means that fix should have less (if any) false negatives now while also being cleaner.

I also noticed that the jumpbug fix calls `ProcessImpacts()` directly, which means it can be called twice in one tick. Unfortunately this means that some trigger `Touch()` functions may be called twice in a tick, and in the case of `trigger_push` entities, it can result in double boosts as they are designed to only be called once per tick. I considered making touch system changes to keep `Touch()` functions from being called twice in a tick, but that would be somewhat tricky and I am not sure if that would have side effects. `trigger_push` entities are the only thing I personally know of that depends on one `Touch()` call per tick, so instead I added a very simple fix specifically targeting them.


### Checklist
- [x] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [x] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [x] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [x] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [x] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [x] My commits are relatively small and scoped to the best of my ability
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

<!-- If any of these items are giving you doubts, please ask about it in the Discord! -->
