### PR TITLE
Swap default renderer in bug-report template from dx9 to dx11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -40,6 +40,6 @@ body:
     label: Renderer
     options:
       - DX11 (default)
-      - DX9
+      - DX9 (Legacy)
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,7 +39,7 @@ body:
   attributes:
     label: Renderer
     options:
-      - DX9 (default)
-      - DX11
+      - DX11 (default)
+      - DX9
   validations:
     required: true


### PR DESCRIPTION
We recently did this for steam so might as well change it here too.

### Checklist
- [ ] **I have thoroughly tested all of the code I have modified/added/removed to ensure something else did not break**
- [ ] If there is a localization token change, I have updated the `momentum_english_ref.res` file with the changes, ran `tokenizer.py` to generate an up-to-date localization file, and have committed both the `.res` file changes and the new localization `.txt` file
- [ ] If I introduced new h/cpp files, I have added them to the appropriate project's VPC file (`server_momentum.vpc` / `client_momentum.vpc` / etc)
- [ ] If I have added or modified any visual assets (models, materials, panels, effects, etc), I have taken screenshots / videos of them and attached them to this PR directly (screenshots uploaded through github, videos uploaded to youtube and linked)
- [ ] If I have modified any console command, console variable, or momentum entity, I have opened an issue (or a PR) for it in the [Momentum Mod documentation repository](https://github.com/momentum-mod/docs)
- [ ] My commits are relatively small and scoped to the best of my ability
- [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review