### PR TITLE
Remove Renderer option from bug-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -43,12 +43,4 @@ body:
     description: Windows version, Linux distro, etc.
   validations:
     required: true
-
-- type: dropdown
-  attributes:
-    label: Renderer
-    options:
-      - DX11 (default)
-      - DX9 (Legacy)
-  validations:
-    required: true
+    


### PR DESCRIPTION
Don't need this if there is only DX11 now!